### PR TITLE
Use async loading of components

### DIFF
--- a/src/components/EditorWrapper.vue
+++ b/src/components/EditorWrapper.vue
@@ -62,37 +62,26 @@ import { EditorContent } from 'tiptap'
 import { Collaboration } from 'tiptap-extensions'
 import { Keymap } from './../extensions'
 
-import Avatar from 'nextcloud-vue/dist/Components/Avatar'
 import Tooltip from 'nextcloud-vue/dist/Directives/Tooltip'
-
-import ReadOnlyEditor from './ReadOnlyEditor'
-import GuestNameDialog from './GuestNameDialog'
-import CollisionResolveDialog from './CollisionResolveDialog'
-import { iconBar } from './../mixins/menubar'
-import MenuBar from './MenuBar'
-import MenuBubble from './MenuBubble'
 
 const COLLABORATOR_IDLE_TIME = 5
 const COLLABORATOR_DISCONNECT_TIME = 20
 const EDITOR_PUSH_DEBOUNCE = 200
 
 export default {
-	name: 'Editor',
+	name: 'EditorWrapper',
 	components: {
-		MenuBar,
-		MenuBubble,
-		CollisionResolveDialog,
-		Avatar,
-		ReadOnlyEditor,
 		EditorContent,
-		GuestNameDialog
+		Avatar: () => import('nextcloud-vue/dist/Components/Avatar'),
+		MenuBar: () => import('./MenuBar'),
+		MenuBubble: () => import('./MenuBubble'),
+		ReadOnlyEditor: () => import('./ReadOnlyEditor'),
+		CollisionResolveDialog: () => import('./CollisionResolveDialog'),
+		GuestNameDialog: () => import('./GuestNameDialog')
 	},
 	directives: {
 		Tooltip
 	},
-	mixins: [
-		iconBar
-	],
 	props: {
 		relativePath: {
 			type: String,
@@ -208,7 +197,7 @@ export default {
 		},
 		initSession() {
 			if (!this.hasDocumentParameters) {
-				this.$emit('error', 'No valid file provided')
+				this.$parent.$emit('error', 'No valid file provided')
 				return
 			}
 			const guestName = localStorage.getItem('text-guestName') ? localStorage.getItem('text-guestName') : getRandomGuestName()
@@ -268,7 +257,7 @@ export default {
 						]
 					})
 					this.syncService.state = this.tiptap.state
-					this.$emit('update:loaded', true)
+					this.$parent.$emit('update:loaded', true)
 				})
 				.on('sync', ({ steps, document }) => {
 					try {

--- a/src/components/FilesEditor.vue
+++ b/src/components/FilesEditor.vue
@@ -1,0 +1,53 @@
+<!--
+  - @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+  -
+  - @author Julius Härtl <jus@bitgrid.net>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<editor-wrapper :file-id="fileId" :relative-path="relativePath" :active="active"
+		:share-token="shareToken" />
+</template>
+
+<script>
+export default {
+	name: 'FilesEditor',
+	components: {
+		EditorWrapper: () => import('./EditorWrapper')
+	},
+	props: {
+		relativePath: {
+			type: String,
+			default: null
+		},
+		fileId: {
+			type: String,
+			default: null
+		},
+		active: {
+			type: Boolean,
+			default: false
+		},
+		shareToken: {
+			type: String,
+			default: null
+		}
+	}
+}
+</script>

--- a/src/files.js
+++ b/src/files.js
@@ -20,8 +20,11 @@
  *
  */
 
-import Editor from './components/EditorWrapper'
+import FilesEditor from './components/FilesEditor'
 import { documentReady } from './helpers'
+
+__webpack_nonce__ = btoa(OC.requestToken) // eslint-disable-line
+__webpack_public_path__ = OC.linkTo('text', 'js/') // eslint-disable-line
 
 const openFileExtensions = [
 	'md', 'markdown'
@@ -74,11 +77,11 @@ documentReady(() => {
 	OCA.Viewer.registerHandler({
 		id: 'text',
 		mimes: ['text/markdown'],
-		component: Editor,
+		component: FilesEditor,
 		group: null
 	})
 })
 
 OCA.Text = {
-	Editor
+	Editor: FilesEditor
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,23 +1,29 @@
-import Vue from 'vue'
-import Editor from './components/EditorWrapper'
+import FilesEditor from './components/FilesEditor'
 
 __webpack_nonce__ = btoa(OC.requestToken) // eslint-disable-line
 __webpack_public_path__ = OC.linkTo('text', 'js/') // eslint-disable-line
 
-Vue.prototype.t = t
-Vue.prototype.OCA = OCA
-
 if (document.getElementById('maineditor')) {
-	new Vue({
-		render: h => h(Editor, {
-			props: {
-				relativePath: '/welcome.md',
-				active: true
-			}
+	Promise.all([
+		import('vue'),
+		import('./components/EditorWrapper')
+	]).then((imports) => {
+		const Vue = imports[0].default
+		Vue.prototype.t = window.t
+		Vue.prototype.OCA = window.OCA
+		const Editor = imports[1].default
+		const vm = new Vue({
+			render: h => h(Editor, {
+				props: {
+					relativePath: '/welcome.md',
+					active: true
+				}
+			})
 		})
-	}).$mount('#maineditor')
+		vm.$mount(document.getElementById('preview'))
+	})
 }
 
 OCA.Text = {
-	Editor
+	Editor: FilesEditor
 }

--- a/src/public.js
+++ b/src/public.js
@@ -1,12 +1,7 @@
-import Vue from 'vue'
-import Editor from './components/EditorWrapper'
 import { documentReady } from './helpers'
 
 __webpack_nonce__ = btoa(OC.requestToken) // eslint-disable-line
-__webpack_public_path__ = OC.linkTo('text', 'js') // eslint-disable-line
-
-Vue.prototype.t = t
-Vue.prototype.OCA = OCA
+__webpack_public_path__ = OC.linkTo('text', 'js/') // eslint-disable-line
 
 documentReady(() => {
 	const sharingToken = document.getElementById('sharingToken').value
@@ -25,14 +20,23 @@ documentReady(() => {
 	body.append(container)
 
 	if (mimetype === 'text/markdown') {
-		const vm = new Vue({
-			render: h => h(Editor, {
-				props: {
-					active: true,
-					shareToken: sharingToken
-				}
+		Promise.all([
+			import('vue'),
+			import('./components/EditorWrapper')
+		]).then((imports) => {
+			const Vue = imports[0].default
+			Vue.prototype.t = window.t
+			Vue.prototype.OCA = window.OCA
+			const Editor = imports[1].default
+			const vm = new Vue({
+				render: h => h(Editor, {
+					props: {
+						active: true,
+						shareToken: sharingToken
+					}
+				})
 			})
+			vm.$mount(document.getElementById('preview'))
 		})
-		vm.$mount(document.getElementById('preview'))
 	}
 })


### PR DESCRIPTION
This will improve the size of the initial loaded bundles as stated in #35. One bundle is still pretty big, but that is fine as it will only be loaded once the editor is used.