### PR TITLE
Adjust side padding on mobile and min-width on desktop

### DIFF
--- a/src/components/EditorWrapper.vue
+++ b/src/components/EditorWrapper.vue
@@ -424,9 +424,11 @@ export default {
 	}
 
 	.editor__content {
-		max-width: 630px;
+		max-width: 670px;
 		margin: auto;
 		& /deep/ .ProseMirror {
+			margin: 0;
+			padding: 14px;
 			padding-bottom: 200px;
 		}
 	}


### PR DESCRIPTION
Just some detail fixes on the side-padding on mobile (was too low) and increasing the min-width on desktop which curiously enough equates to 80 characters on Firefox but  85 or so on Chrome … (even using em). And probably needs to be adjusted a bit again when we move to Noto. ;)

Anyhow @juliushaertl check it out.