### PR TITLE
Image embed view design improvements, simplification

### DIFF
--- a/css/prosemirror.scss
+++ b/css/prosemirror.scss
@@ -76,7 +76,6 @@
 
 	img {
 		cursor: default;
-		max-height: 50vh;
 		max-width: 100%;
 	}
 

--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -168,10 +168,8 @@ export default {
 
 <style scoped lang="scss">
 	.image {
-		border: 1px solid transparent !important;
-		&:hover {
-			border: 1px solid var(--color-background-darker) !important;
-		}
+		margin: 0;
+		padding: 0;
 	}
 	.image__caption {
 		text-align: center;
@@ -195,6 +193,7 @@ export default {
 		background-color: var(--color-background-dark);
 		text-align: center;
 		padding: 20px;
+		border-radius: var(--border-radius);
 		.icon-image {
 			opacity: 0.7;
 		}


### PR DESCRIPTION
Before: Not using full width, unnecessary boxed-in styling when hovering:
![image view before](https://user-images.githubusercontent.com/925062/59937570-1d859180-9453-11e9-9ec3-d7d89e2ce22c.png)

Now: Just clean:
![image embed now](https://user-images.githubusercontent.com/925062/59937571-1d859180-9453-11e9-89c0-3690da06a14f.png)
