### PR TITLE
Fix actions bar accessibility

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -31,7 +31,9 @@
 					<template v-else>
 						<div v-show="$index < iconCount" :key="icon.label" v-click-outside="() => hideChildMenu(icon)"
 							class="submenu">
-							<button :class="childIconClass(isActive, icon.children, )" @click.prevent="toggleChildMenu(icon)" />
+							<button :class="childIconClass(isActive, icon.children, )"
+								:title="icon.label"
+								@click.prevent="toggleChildMenu(icon)" />
 							<div :class="{open: isChildMenuVisible(icon)}" class="popovermenu menu-center">
 								<popover-menu :menu="childPopoverMenu(isActive, commands, icon.children, icon)" />
 							</div>


### PR DESCRIPTION
TODO, needs help:
- [ ] The 3-dot menu is currently not accessible. `.action-item__menutoggle` needs an `aria-label="More actions"`, but I couldn’t find how to add that.


Fixed:
- Add titles to menubar icons, fix accessibility
- Add action title to Headings menu too