### PR TITLE
Adjust blockquote color to grey

### DIFF
--- a/css/prosemirror.scss
+++ b/css/prosemirror.scss
@@ -123,6 +123,7 @@
 	blockquote {
 		padding-left: 1em;
 		border-left: 4px solid var(--color-primary);
+		color: var(--color-text-maxcontrast);
 		margin-left: 0;
 		margin-right: 0;
 	}


### PR DESCRIPTION
It’s a bit nicer and usually quotes are not the same as text color:

Before:
![blockquote old](https://user-images.githubusercontent.com/925062/60181926-95710480-9823-11e9-8208-300f2ebc6fb9.png)

After:
![blockquote now](https://user-images.githubusercontent.com/925062/60181927-95710480-9823-11e9-8d00-0d6dbb01ccc2.png)
