### PR TITLE
Adjust link and blockquote color to improve readability

### DIFF
--- a/css/prosemirror.scss
+++ b/css/prosemirror.scss
@@ -23,7 +23,7 @@
 	}
 
 	a {
-		color: var(--color-primary);
+		color: var(--color-primary-element);
 		text-decoration: underline;
 		padding: .5em 0;
 	}
@@ -122,7 +122,7 @@
 
 	blockquote {
 		padding-left: 1em;
-		border-left: 4px solid var(--color-primary);
+		border-left: 4px solid var(--color-primary-element);
 		color: var(--color-text-maxcontrast);
 		margin-left: 0;
 		margin-right: 0;


### PR DESCRIPTION
* Resolves: #248 
* Target version: master 

Adjust link color to avoid bad readability, when bright primary colors used. Also adjust blockquote accordingly to avoid repetition of the same issue. :-)


