### PR TITLE
Hard-code the templateName's extension

### DIFF
--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -85,7 +85,7 @@ const registerFileCreate = () => {
 			menu.addMenuEntry({
 				id: 'file',
 				displayName: t('text', 'New text document'),
-				templateName: t('text', 'New text document.md'),
+				templateName: t('text', 'New text document') + '.md',
 				iconClass: 'icon-filetype-text',
 				fileType: 'file',
 				actionHandler: function(name) {


### PR DESCRIPTION
* Resolves: #316 
* Target version: master

### Summary

This hardcodes the `.md` extension of files created in the Files app, as recommended in #316.