### PR TITLE
Reduce 'Removed X inactive sessions' severity to debug

### DIFF
--- a/lib/Cron/Cleanup.php
+++ b/lib/Cron/Cleanup.php
@@ -74,7 +74,7 @@ class Cleanup extends TimedJob {
 			}
 		}
 		$removedSessions = $this->sessionService->removeInactiveSessions(null);
-		$this->logger->info('Removed ' . $removedSessions . ' inactive sessions');
+		$this->logger->debug('Removed ' . $removedSessions . ' inactive sessions');
 	}
 
 


### PR DESCRIPTION
* Resolves: #261 
* Target version: master 

### Summary

This simply reduces 'Removed X inactive sessions' log message severity to debug. Eventually I decided not to wrap it in `if ($removedSessions > 0)` as there are some other messages logged for debug level and doing so would not be consistent. 
