### PR TITLE
Distinguish second and third-level list entries

### DIFF
--- a/css/prosemirror.scss
+++ b/css/prosemirror.scss
@@ -132,6 +132,16 @@ div.ProseMirror {
 		list-style-type: disc;
 	}
 
+	// Second-level list entries
+	ul > li > ul > li {
+		list-style-type: circle;
+	}
+
+	// Third-level and further down list entries
+	ul > li > ul > li ul li {
+		list-style-type: square;
+	}
+
 	blockquote {
 		padding-left: 1em;
 		border-left: 4px solid var(--color-primary-element);


### PR DESCRIPTION
Can’t test at the moment because my local setup is broken, but this should distinguish the sublevels in lists like so:

- 1st level is a filled circle
  - 2nd level is an empty circle
    - 3rd level and below is a square
      - 4th level