### PR TITLE
Use file path instead of folder for direct workspace opening

### DIFF
--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -178,7 +178,7 @@ class WorkspaceController extends OCSController {
 				if ($file === null) {
 					$token = $this->directEditingManager->create($path . '/'. self::SUPPORTED_FILENAMES[0], Application::APP_NAME, 'textdocument');
 				} else {
-					$token = $this->directEditingManager->open($path, Application::APP_NAME);
+					$token = $this->directEditingManager->open($path . '/'. $file->getName(), Application::APP_NAME);
 				}
 				return new DataResponse([
 					'url' => $this->urlGenerator->linkToRouteAbsolute('files.DirectEditingView.edit', ['token' => $token])


### PR DESCRIPTION
Path was not properly set for opening existing rich workspace files in https://github.com/nextcloud/text/pull/451