### PR TITLE
Fix calling setLastContact on boolean

### DIFF
--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -111,6 +111,9 @@ class SessionService {
 		return $this->sessionMapper->deleteInactive($documentId);
 	}
 
+	/**
+	 * @return bool|Session
+	 */
 	public function getSession($documentId, $sessionId, $token) {
 		if ($this->session !== null) {
 			return $this->session;
@@ -123,10 +126,9 @@ class SessionService {
 		}
 	}
 
-	public function isValidSession($documentId, $sessionId, $token) {
-		try {
-			$session = $this->getSession($documentId, $sessionId, $token);
-		} catch (DoesNotExistException $e) {
+	public function isValidSession($documentId, $sessionId, $token): bool {
+		$session = $this->getSession($documentId, $sessionId, $token);
+		if ($session === false) {
 			return false;
 		}
 		// TODO: move to cache


### PR DESCRIPTION
* Resolves: https://sentry.io/share/issue/e2f18ccec8ea44cf8cfe1dbfa703c802/
* Target version: master 

### Summary

`\OCA\Text\Service\SessionService::getSession` doesn't always return a `Session` object but `false` when it can't find a session. This seems to happen frequently and thus causes Sentry reports.

I don't know the logic of this app but it might also make sense to change `getSession` so that it doesn't catch the `DoesNotExistException` but just let it bubble up to the callers. Otherwise each of the callers has to be adjusted for the occasional boolean return value.
