### PR TITLE
Avoid race condition when adding steps and fix step entries with duplicate versions

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,6 +32,9 @@
 	<background-jobs>
 		<job>OCA\Text\Cron\Cleanup</job>
 	</background-jobs>
+	<commands>
+		<command>OCA\Text\Command\ResetDocument</command>
+	</commands>
 	<sabre>
 		<plugins>
 			<plugin>OCA\Text\DAV\WorkspacePlugin</plugin>

--- a/lib/Command/ResetDocument.php
+++ b/lib/Command/ResetDocument.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Text\Command;
+
+use OCA\Text\Db\DocumentMapper;
+use OCA\Text\Db\SessionMapper;
+use OCA\Text\Db\StepMapper;
+use OCA\Text\Service\DocumentService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ResetDocument extends Command {
+
+	protected $documentService;
+	protected $documentMapper;
+	protected $stepMapper;
+	protected $sessionMapper;
+
+	public function __construct(DocumentService $documentService, DocumentMapper $documentMapper, StepMapper $stepMapper, SessionMapper $sessionMapper) {
+		parent::__construct();
+
+		$this->documentService = $documentService;
+		$this->documentMapper = $documentMapper;
+		$this->stepMapper = $stepMapper;
+		$this->sessionMapper = $sessionMapper;
+	}
+
+	protected function configure() {
+		$this
+			->setName('text:reset')
+			->setDescription('Reset a text document')
+			->addArgument(
+				'file-id',
+				InputArgument::REQUIRED,
+				'File id of the document to rest'
+			)
+			->addOption(
+				'full',
+				'f',
+				null,
+				'Drop all existing steps and use the currently saved version'
+			)
+		;
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return void
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+
+		$fileId = $input->getArgument('file-id');
+		$fullReset = $input->getOption('full');
+
+		if ($fullReset) {
+			$output->writeln('Full document reset');
+			$this->documentService->resetDocument($fileId, true);
+		} else {
+			$output->writeln('Trying to restore to last saved version');
+			$document = $this->documentMapper->find($fileId);
+			$deleted = $this->stepMapper->deleteAfterVersion($fileId, $document->getLastSavedVersion());
+			if ($deleted > 0) {
+				$document->setCurrentVersion($document->getLastSavedVersion());
+				$this->documentMapper->update($document);
+				$this->sessionMapper->deleteByDocumentId($fileId);
+				$output->writeln('Reverted document to the last saved version');
+			} else {
+				$output->writeln('Failed revert changes that are newer than the last saved version');
+			}
+		}
+
+	}
+}
+
+

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -101,4 +101,12 @@ class SessionMapper extends QBMapper {
 		return $qb->execute();
 	}
 
+	public function deleteByDocumentId($documentId) {
+		/* @var $qb IQueryBuilder */
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('document_id', $qb->createNamedParameter($documentId)));
+		return $qb->execute();
+	}
+
 }

--- a/lib/Db/StepMapper.php
+++ b/lib/Db/StepMapper.php
@@ -47,6 +47,7 @@ class StepMapper extends QBMapper {
 		$qb
 			->setMaxResults(100)
 			->orderBy('version')
+			->orderBy('id')
 			->execute();
 
 		return $this->findEntities($qb);

--- a/lib/Db/StepMapper.php
+++ b/lib/Db/StepMapper.php
@@ -69,4 +69,14 @@ class StepMapper extends QBMapper {
 			->andWhere($qb->expr()->lte('version', $qb->createNamedParameter($version)))
 			->execute();
 	}
+
+	public function deleteAfterVersion($documentId, $version): int {
+		/* @var $qb IQueryBuilder */
+		$qb = $this->db->getQueryBuilder();
+		return $qb->delete($this->getTableName())
+			->where($qb->expr()->eq('document_id', $qb->createNamedParameter($documentId)))
+			->andWhere($qb->expr()->gt('version', $qb->createNamedParameter($version)))
+			->execute();
+	}
+
 }

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -228,7 +228,20 @@ class DocumentService {
 	}
 
 	public function getSteps($documentId, $lastVersion) {
-		return $this->stepMapper->find($documentId, $lastVersion);
+		$steps = $this->stepMapper->find($documentId, $lastVersion);
+		//return $steps;
+		$unique_array = [];
+		foreach($steps as $step) {
+			$version = $step->getVersion();
+			if (!array_key_exists($version, $unique_array)) {
+				$unique_array[(string)$version] = $step;
+			} else {
+				// found duplicate step
+				// FIXME: verify that this version is the correct one
+				//$this->stepMapper->delete($step);
+			}
+		}
+		return array_values($unique_array);
 	}
 
 	/**


### PR DESCRIPTION
Attempt to fix broken documents as appeared in #331 

## ToDo

- [x] Check if just keeping the first matching version step is fine
- [x] Add occ command to restore broken documents to their last saved version
- [ ] Maybe a unique constraint on the table would also help


## Steps to reproduce

The step creation is hard to reproduce as this only occurs if two sessions add steps at almost the same time, however the broken document state can be simulated by manually adding a step for an existing version to the database. Assuming the last step for a document is version 7 (with one step included) the following insert statements adds a broken step on top:

```
INSERT INTO oc_text_steps VALUES (42, 1365, 117, '[{"stepType":"replace","from":58,"to":58,"slice":{"content":[{"type":"text","text":"a"}]}},{"stepType":"replace","from":58,"to":58,"slice":{"content":[{"type":"text","text":"f"}]}}]', 7)
```