### PR TITLE
Catch the exception when a user no longer exists

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -343,7 +343,14 @@ class DocumentService {
 	 * @throws NotFoundException
 	 */
 	public function getFileById($fileId, $userId = null): Node {
-		$files = $this->rootFolder->getUserFolder($this->userId ?? $userId)->getById($fileId);
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($this->userId ?? $userId);
+		} catch (\OC\User\NoUserException $e) {
+			// It is a bit hacky to depend on internal exceptions here. But it is the best we can do for now
+			throw new NotFoundException();
+		}
+
+		$files = $userFolder->getById($fileId);
 		if (count($files) === 0) {
 			throw new NotFoundException();
 		}


### PR DESCRIPTION
Else this could result in a lot of log spam.


