### PR TITLE
Show link url in popover

### DIFF
--- a/src/EditorFactory.js
+++ b/src/EditorFactory.js
@@ -76,7 +76,7 @@ const createEditor = ({ content, onInit, onUpdate, extensions, enableRichEditing
 			new CodeBlock(),
 			new ListItem(),
 			new Link({
-				openOnClick: true,
+				openOnClick: false,
 			}),
 			new Image(),
 			new Placeholder({

--- a/src/components/MenuBubble.vue
+++ b/src/components/MenuBubble.vue
@@ -22,6 +22,7 @@
 
 <template>
 	<EditorMenuBubble v-slot="{ commands, isActive, getMarkAttrs, menu }"
+		:is-active-callback="({ isActive }) => isActive.link()"
 		class="menububble"
 		:editor="editor"
 		@hide="hideLinkMenu">
@@ -37,12 +38,13 @@
 			</form>
 
 			<template v-else>
+				<a :href="getMarkAttrs('link').href" target="_blank" class="icon-external">{{ getMarkAttrs('link').href }}</a>
 				<button
 					class="menububble__button"
 					:class="{ 'is-active': isActive.link() }"
 					@click="showLinkMenu(getMarkAttrs('link'))">
-					<span v-tooltip="isActive.link() ? 'Update Link' : 'Add Link'" class="icon-link" />
-					<span class="menububble__buttontext">{{ t('text', 'Add link') }}</span>
+					<span v-tooltip="isActive.link() ? t('text', 'Update Link') : t('text', 'Add Link')" class="icon-link" />
+					<span class="menububble__buttontext">{{ isActive.link() ? t('text', 'Update Link') : t('text', 'Add Link') }}</span>
 				</button>
 			</template>
 		</div>
@@ -147,6 +149,17 @@ export default {
 			border: none;
 			background: transparent;
 			min-width: 150px;
+		}
+
+		.icon-external {
+			max-width: 50vw;
+			text-overflow: ellipsis;
+			overflow: hidden;
+			display: block;
+			white-space: nowrap;
+			padding: 5px 20px 5px 5px;
+			background-position: right;
+			margin-right: 5px;
 		}
 	}
 </style>


### PR DESCRIPTION
Make sure that the link is not directly opened but presented to the user to avoid that someone might get tricked into clicking a link that opens some unwanted page.

Currently even hovering the link is not working to preview it as this is prevented by browsers if `contenteditable` is set to true.

Requires https://github.com/scrumpy/tiptap/pull/614

