### PR TITLE
Use full list of supported filenames when obtaining the name to create

### DIFF
--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -85,11 +85,6 @@ class WorkspaceController extends OCSController {
 	/** @var IURLGenerator */
 	private $urlGenerator;
 
-	private const SUPPORTED_FILENAMES = [
-		'README.md',
-		'Readme.md',
-		'readme.md'
-	];
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 
@@ -184,7 +179,7 @@ class WorkspaceController extends OCSController {
 			if ($folder instanceof Folder) {
 				$file = $this->getFile($folder);
 				if ($file === null) {
-					$token = $this->directEditingManager->create($path . '/'. self::SUPPORTED_FILENAMES[0], Application::APP_NAME, 'textdocument');
+					$token = $this->directEditingManager->create($path . '/'. $this->workspaceService->getSupportedFilenames()[0], Application::APP_NAME, 'textdocument');
 				} else {
 					$token = $this->directEditingManager->open($path . '/'. $file->getName(), Application::APP_NAME);
 				}
@@ -201,7 +196,7 @@ class WorkspaceController extends OCSController {
 
 	private function getFile(Folder $folder) {
 		$file = null;
-		foreach (self::SUPPORTED_FILENAMES as $filename) {
+		foreach ($this->workspaceService->getSupportedFilenames() as $filename) {
 			if ($folder->nodeExists($filename)) {
 				$file = $folder->get($filename);
 				continue;

--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -37,7 +37,7 @@ class WorkspaceService {
 		return $file;
 	}
 
-	private function getSupportedFilenames() {
+	public function getSupportedFilenames() {
 		return array_merge([
 			$this->l10n->t('Readme') . '.md'
 		], self::SUPPORTED_STATIC_FILENAMES);


### PR DESCRIPTION
This makes sure that newly created files use the translation of "Readme.md" and the translated files are properly picked up for opening.

cc @jancborchardt 