### PR TITLE
Cache the session info in memcache

### DIFF
--- a/lib/Db/Session.php
+++ b/lib/Db/Session.php
@@ -30,6 +30,7 @@ use OCP\AppFramework\Db\Entity;
  * @method setLastContact(int $getTime)
  * @method getDocumentId()
  * @method getUserId()
+ * @method string getToken()
  */
 class Session extends Entity implements \JsonSerializable {
 
@@ -55,7 +56,8 @@ class Session extends Entity implements \JsonSerializable {
 			'token' => $this->token,
 			'color' => $this->color,
 			'lastContact' => $this->lastContact,
-			'guestName' => $this->guestName
+			'guestName' => $this->guestName,
+			'documentId' => $this->documentId,
 		];
 	}
 }


### PR DESCRIPTION
This should reduce the number of queries to the DB. Esp when editing a
file with a lot of people this can really add up.

In future work we might want to look into a way to only update the DB every 30 seconds or so with the last edit info. I mean it is not super duper crucial this is totally in sync I guess.