### PR TITLE
Fix rich workspaces on case insensitive filesystems

### DIFF
--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -24,17 +24,15 @@ class WorkspaceService {
 	}
 
 	public function getFile(Folder $folder) {
-		$file = null;
 		foreach ($this->getSupportedFilenames() as $filename) {
 			if ($folder->nodeExists($filename)) {
 				try {
-					$file = $folder->get($filename);
+					return $folder->get($filename);
 				} catch (NotFoundException $e) {
 				}
-				continue;
 			}
 		}
-		return $file;
+		return null;
 	}
 
 	public function getSupportedFilenames() {


### PR DESCRIPTION
Fixes #807 

This fixes multiple files showing up on case-insensitive filenames as otherwise
the IFolder::get call creates multiple entries in the filecache for the same file. In addition to the fix now the behaviour is actually the correct one where the first matching filename of supported names is picked up for creating the file and obtaining in case there are multiple names matching.