### PR TITLE
fix: path for workspaces

### DIFF
--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -107,7 +107,8 @@ class WorkspaceController extends OCSController {
 	 */
 	public function folder(string $path = '/'): DataResponse {
 		try {
-			$folder = $this->rootFolder->getUserFolder($this->userId)->get($path);
+			$userFolder = $this->rootFolder->getUserFolder($this->userId);
+			$folder = $userFolder->get($path);
 			if ($folder instanceof Folder) {
 				$file = $this->workspaceService->getFile($folder);
 				if ($file === null) {
@@ -124,7 +125,7 @@ class WorkspaceController extends OCSController {
 						'id' => $file->getId(),
 						'mimetype' => $file->getMimetype(),
 						'name' => $file->getName(),
-						'path' => $file->getPath()
+						'path' => $userFolder->getRelativePath($file->getPath())
 					],
 					'folder' => [
 						'permissions' => $folder->getPermissions()


### PR DESCRIPTION
We need the relative path inside a users home directory
to fetch the folder content for the filepicker.

$file->getPath() gets the absolute path
including username and files.

Instead use $path which we already know and append the file name.

Frankly I have no idea if this is the right way to do this in the Controller
as I am not familiar with the `OCP/Files` API. This works for me and i hope it illustrates the problem. Feel free to fix in a different way.