### PR TITLE
Log the exceptions as INFO

### DIFF
--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -159,7 +159,7 @@ class ApiService {
 		try {
 			$file = $this->documentService->getFileForSession($session, $token);
 		} catch (NotFoundException $e) {
-			$this->logger->logException($e);
+			$this->logger->logException($e, ['level' => ILogger::INFO]);
 			return new DataResponse([
 				'message' => 'File not found'
 			], 404);
@@ -176,7 +176,7 @@ class ApiService {
 		} catch (NotFoundException $e) {
 			return new DataResponse([], 404);
 		} catch (Exception $e) {
-			$this->logger->logException($e);
+			$this->logger->logException($e, ['level' => ILogger::INFO]);
 			return new DataResponse([
 				'message' => $e->getMessage()
 			], 500);


### PR DESCRIPTION
There is no need to log them as ERROR
They pollute the log otherwise a lot (and sentry)

https://sentry.io/share/issue/19f13ece0b524602b26b0a53a0a0289e/