### PR TITLE
Catch StorageNotAvailable exceptions

### DIFF
--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -60,6 +60,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
+use OCP\Files\StorageNotAvailableException;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\Share\Exceptions\ShareNotFound;
@@ -134,6 +135,8 @@ class WorkspaceController extends OCSController {
 			}
 		} catch (NotFoundException $e) {
 			return new DataResponse(['message' => 'No valid folder found'], Http::STATUS_BAD_REQUEST);
+		} catch (StorageNotAvailableException $e) {
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
 
@@ -167,6 +170,8 @@ class WorkspaceController extends OCSController {
 			return new DataResponse(['message' => 'No valid folder found'], Http::STATUS_BAD_REQUEST);
 		} catch (ShareNotFound $e) {
 			return new DataResponse(['message' => 'No valid folder found'], Http::STATUS_BAD_REQUEST);
+		} catch (StorageNotAvailableException $e) {
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
 

--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -31,6 +31,7 @@ use OCA\DAV\Files\FilesHome;
 use OCA\Text\AppInfo\Application;
 use OCA\Text\Service\WorkspaceService;
 use OCP\Files\IRootFolder;
+use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
@@ -98,9 +99,13 @@ class WorkspacePlugin extends ServerPlugin {
 			$nodes = $this->rootFolder->getUserFolder($this->userId)->getById($node->getId());
 			if (count($nodes) > 0) {
 				/** @var File $file */
-				$file = $this->workspaceService->getFile($nodes[0]);
-				if ($file instanceof File) {
-					return $file->getContent();
+				try {
+					$file = $this->workspaceService->getFile($nodes[0]);
+					if ($file instanceof File) {
+						return $file->getContent();
+					}
+				} catch (StorageNotAvailableException $e) {
+					// If a storage is not available we can for the propfind response assume that there is no rich workspace present
 				}
 			}
 			return '';

--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -6,6 +6,7 @@ namespace OCA\Text\Service;
 
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
+use OCP\Files\StorageNotAvailableException;
 use OCP\IL10N;
 
 class WorkspaceService {
@@ -25,6 +26,7 @@ class WorkspaceService {
 
 	/**
 	 * @param Folder $folder
+	 * @throws StorageNotAvailableException
 	 * @return \OCP\Files\File
 	 */
 	public function getFile(Folder $folder) {


### PR DESCRIPTION
Fixes #992 

This could have caused the android app to not show a folder if any subdirectory contained an unavailable storage.