### PR TITLE
only return rich workspace when depth is 1 or greater

### DIFF
--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -93,24 +93,24 @@ class WorkspacePlugin extends ServerPlugin {
 		if (!$workspaceAvailable || !$workspaceEnabled) {
 			return;
 		}
-
-		$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($node) {
-			/** @var Folder[] $nodes */
-			$nodes = $this->rootFolder->getUserFolder($this->userId)->getById($node->getId());
-			if (count($nodes) > 0) {
-				/** @var File $file */
-				try {
-					$file = $this->workspaceService->getFile($nodes[0]);
-					if ($file instanceof File) {
-						return $file->getContent();
-					}
-				} catch (StorageNotAvailableException $e) {
+		if ($propFind->getDepth() > 0) {
+			$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($node) {
+				/** @var Folder[] $nodes */
+				$nodes = $this->rootFolder->getUserFolder($this->userId)->getById($node->getId());
+				if (count($nodes) > 0) {
+					/** @var File $file */
+					try {
+						$file = $this->workspaceService->getFile($nodes[0]);
+						if ($file instanceof File) {
+							return $file->getContent();
+					  }
+				  	} catch (StorageNotAvailableException $e) {
 					// If a storage is not available we can for the propfind response assume that there is no rich workspace present
+					}
 				}
-			}
-			return '';
-		});
-
+				return '';
+			});
+		}
 	}
 
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

the android  app folder request is like the following:

```
192.168.100.10 - danny [27/Aug/2020:20:28:55 +0000] "PROPFIND /remote.php/webdav/test_pictures/ HTTP/1.1" 504 160 "-" "Mozilla/5.0 (Android) Nextcloud-android/20200821" 60.001 

"req_header:"

host: 192.168.100.62
cookie: __Host-nc_sameSiteCookielax=true; __Host-nc_sameSiteCookiestrict=true; oc_sessionPassphrase=428y0C%2BAJYvfcgy6BE%2BxzCYtR0KVCB2ecibPGF2KMgs%2BVhBP%2BELw2PyIw5UkBdX04l%2BE7oaRxR%2BRKDtJqR5BD1Komj1zRzKU%2Bd0MvhSNwwzsxN3Vvi4xs4jgkoce30tf; ocf6hkhrls8q=tr7a4m80nudm0n9ie74u51o1nd
content-type: text/xml; charset=UTF-8
content-length: 789
user-agent: Mozilla/5.0 (Android) Nextcloud-android/20200821
depth: 1
authorization: Basic ZGFubnk6RE5CQWFybE5iRGZkMVgyeVdEdlVXbURMMk5XYmNrOFE2TDd5T2NacHNSMUVPZFZvd094U3htUXdqT0JtMkdneWU3VzFwVzNW

" req_body:"

<?xml version="1.0" encoding="UTF-8"?>
<D:propfind xmlns:D="DAV:">
    <D:prop>
        <owner-id xmlns="http://owncloud.org/ns" />
        <D:creationdate />
        <D:getetag />
        <permissions xmlns="http://owncloud.org/ns" />
        <D:getlastmodified />
        <id xmlns="http://owncloud.org/ns" />
        <D:getcontentlength />
        <favorite xmlns="http://owncloud.org/ns" />
        <D:resourcetype />
        <sharees xmlns="http://nextcloud.org/ns" />
        <mount-type xmlns="http://nextcloud.org/ns" />
        <rich-workspace xmlns="http://nextcloud.org/ns" />
        <D:displayname />
        <note xmlns="http://nextcloud.org/ns" />
        <D:getcontenttype />
        <has-preview xmlns="http://nextcloud.org/ns" />
        <size xmlns="http://owncloud.org/ns" />
        <is-encrypted xmlns="http://nextcloud.org/ns" />
        <owner-display-name xmlns="http://owncloud.org/ns" />
        <comments-unread xmlns="http://owncloud.org/ns" />
    </D:prop>
</D:propfind>


" resp_header:"

content-length: 160
content-type: text/html
connection: keep-alive

" resp_body:"

<html>
    <head>
        <title>504 Gateway Time-out</title>
    </head>
    <body>
        <center>
            <h1>504 Gateway Time-out</h1>
        </center>
        <hr>
            <center>nginx</center>
    </body>
</html>
```
by default: `depth:1` and include `rich-workspace` tag, this will result in nextcloud checking rich workspace for every subfolder within the requested folder, in this request it is `test_pictures`.

here is the folder structure:
```
.
├── xxx
├── xx
├── xxxx
├── xxx
├── xxxx
├── xxxx-xx
├── xx-xx
├── xxx
├── xxx
├── xx expo
├── xxx
├── xxxx
├── xx test result
├── xx
├── xx
├── xx
├── xxxxxxx照
├── xx
├── xxxxxx
├── xxx
├── xxxxx
└── xxxxx

22 directories, 0 files
```
in each of the folder, there could be hundreads of files, it take some time to find the README.txt file. multiply this time for each of the 22 folders, i always get a timeout. 

since the rich workspace file is for current folder, i don't see the necissity to get all of this for each subfolder , in the brower, they get this specifically using `https://localhost/ocs/v2.php/apps/text/workspace?path=/Photos`

