### PR TITLE
Use to correct cache to obtain version info

### DIFF
--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -46,14 +46,13 @@ use OCP\Lock\LockedException;
 
 class ApiService {
 
-	protected $cache;
+	protected $request;
 	protected $sessionService;
 	protected $documentService;
 	protected $logger;
 
-	public function __construct(IRequest $request, ICacheFactory $cacheFactory, SessionService $sessionService, DocumentService $documentService, ILogger $logger) {
+	public function __construct(IRequest $request, SessionService $sessionService, DocumentService $documentService, ILogger $logger) {
 		$this->request = $request;
-		$this->cache = $cacheFactory->createDistributed('textSession');
 		$this->sessionService = $sessionService;
 		$this->documentService = $documentService;
 		$this->logger = $logger;
@@ -157,9 +156,6 @@ class ApiService {
 	public function sync($documentId, $sessionId, $sessionToken, $version = 0, $autosaveContent = null, bool $force = false, bool $manualSave = false, $token = null): DataResponse {
 		if (!$this->sessionService->isValidSession($documentId, $sessionId, $sessionToken)) {
 			return new DataResponse([], 403);
-		}
-		if ($version === $this->cache->get('document-version-' . $documentId)) {
-			return new DataResponse(['steps' => []]);
 		}
 
 		try {

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -253,9 +253,11 @@ class DocumentService {
 		}
 	}
 
-	public function getSteps($documentId, $lastVersion) {
+	public function getSteps($documentId, $lastVersion): array {
+		if ($lastVersion === $this->cache->get('document-version-' . $documentId)) {
+			return [];
+		}
 		$steps = $this->stepMapper->find($documentId, $lastVersion);
-		//return $steps;
 		$unique_array = [];
 		foreach($steps as $step) {
 			$version = $step->getVersion();


### PR DESCRIPTION
* The documentservice writes to the text prefix. Not the textSession
  prefix. Hence we never found any of the cache entries. Thus always
  doing all the work.
