### PR TITLE
Use public link previews for relative paths

### DIFF
--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -106,12 +106,24 @@ export default {
 			if (this.hasPreviewUrl) {
 				return this.src
 			}
-			if (this.fileId) {
-				return generateUrl('/core/preview') + `?fileId=${this.fileId}&x=1024&y=1024&a=true`
+
+			const isPublic = document.getElementById('isPublic')?.value === '1'
+			const sharingToken = document.getElementById('sharingToken')?.value
+			const previewPath = (!isPublic ? generateUrl('/core/preview.png') : generateUrl('/apps/files_sharing/publicpreview/' + sharingToken))
+
+			if (this.fileId && !isPublic) {
+				return previewPath + `?fileId=${this.fileId}&x=1024&y=1024&a=true`
 			}
+
+			if (isPublic) {
+				const f = FileList.getCurrentDirectory() + '/' + this.src.split('?')[0]
+				const pathParam = encodeURIComponent(path.normalize(f))
+				return previewPath + `?file=${pathParam}&x=1024&y=1024&a=true`
+			}
+
 			const f = FileList.getCurrentDirectory() + '/' + this.src
 			const pathParam = encodeURIComponent(path.normalize(f))
-			return generateUrl('/core/preview.png') + `?file=${pathParam}&x=1024&y=1024&a=true`
+			return previewPath + `?file=${pathParam}&x=1024&y=1024&a=true`
 		},
 		fileId() {
 			return getQueryVariable(this.src, 'fileId')

--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -100,6 +100,9 @@ export default {
 	},
 	computed: {
 		imageUrl() {
+			if (this.src.startsWith('http://') || this.src.startsWith('https://')) {
+				return this.src
+			}
 			if (this.hasPreviewUrl) {
 				return this.src
 			}
@@ -114,7 +117,7 @@ export default {
 			return getQueryVariable(this.src, 'fileId')
 		},
 		hasPreviewUrl() {
-			return this.src.match(/^(\/index.php)?\/core\/preview/)
+			return this.src.match(/^(\/index.php)?\/core\/preview/) || this.src.match(/^(\/index.php)?\/apps\/files_sharing\/publicpreview\//)
 		},
 		mimeIcon() {
 			const mime = getQueryVariable(this.src, 'mimetype')

--- a/src/tests/nodes/ImageView.spec.js
+++ b/src/tests/nodes/ImageView.spec.js
@@ -50,4 +50,11 @@ describe('Image View src attribute based on markdown', () => {
 		expect(wrapper.find('.image__main').attributes('src'))
 			.toBe('/core/preview.png?file=%2Fcurrent%2Fsub%2Fasdf.jpg&x=1024&y=1024&a=true')
 	})
+
+	test('public share link previews are just used as they are', () => {
+		const wrapper = factory({src: 'https://nextcloud/index.php/apps/files_sharing/publicpreview/CSYoWifBzrsMWeA?file=/deck11-calendar.png&x=1760&y=990&a=true'})
+		expect(wrapper.vm.isSupportedImage).toBe(true)
+		expect(wrapper.find('.image__main').attributes('src'))
+			.toBe('https://nextcloud/index.php/apps/files_sharing/publicpreview/CSYoWifBzrsMWeA?file=/deck11-calendar.png&x=1760&y=990&a=true')
+	})
 })


### PR DESCRIPTION
Follow up to #1057 to make sure inserted images are accessible if they are in the same or sub directory of a share link

- [ ] Wait for #1057 to be merged
- [ ] Add tests
