### PR TITLE
Also register to urlChanged event to update RichWorkspace

### DIFF
--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -160,6 +160,9 @@ const FilesWorkspacePlugin = {
 				},
 			}).$mount(this.el)
 
+			fileList.$el.on('urlChanged', data => {
+				vm.path = data.dir.toString()
+			})
 			fileList.$el.on('changeDirectory', data => {
 				vm.path = data.dir.toString()
 			})


### PR DESCRIPTION
* Resolves: #1100
* Target version: master 

### Summary
In addition to "changeDirectory", which is only fired if a new directory is selected from within the file list, also register to "urlChanged", which is triggered whenever the URL is changed to show a different directory (e.g. when using the navigation bar)

