### PR TITLE
Add migration to fix oracle issues with the database schema

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -1,0 +1,74 @@
+name: PHPUnit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable*
+
+env:
+  APP_NAME: text
+
+jobs:
+  oci:
+    runs-on: ubuntu-latest
+
+    strategy:
+      # do not stop on another job's failure
+      fail-fast: false
+      matrix:
+        php-versions: ['7.4']
+        databases: ['oci']
+        server-versions: ['master']
+
+    name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
+
+    services:
+      oracle:
+        image: deepdiver/docker-oracle-xe-11g # "wnameless/oracle-xe-11g-r2"
+        ports:
+          - "1521:1521"
+
+    steps:
+      - name: Checkout server
+        uses: actions/checkout@v2
+        with:
+          repository: nextcloud/server
+          ref: ${{ matrix.server-versions }}
+
+      - name: Checkout submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+
+      - name: Checkout app
+        uses: actions/checkout@v2
+        with:
+          path: apps/${{ env.APP_NAME }}
+
+      - name: Set up PHPUnit
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer i
+
+      - name: Set up php ${{ matrix.php-versions }}
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-versions }}"
+          extensions: mbstring, iconv, fileinfo, intl, oci8
+          tools: phpunit:8.5.2
+          coverage: none
+
+      - name: Set up Nextcloud
+        run: |
+          mkdir data
+          ./occ maintenance:install --verbose --database=oci --database-name=XE --database-host=127.0.0.1 --database-port=1521 --database-user=autotest --database-pass=owncloud --admin-user admin --admin-pass admin
+          php -f index.php
+          ./occ app:enable --force ${{ env.APP_NAME }}
+
+      - name: PHPUnit
+        working-directory: apps/${{ env.APP_NAME }}/tests
+        run: phpunit -c phpunit.xml
+

--- a/lib/Migration/Version030201Date20201116110353.php
+++ b/lib/Migration/Version030201Date20201116110353.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Text\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Type;
+use OCP\DB\ISchemaWrapper;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version030201Date20201116110353 extends SimpleMigrationStep {
+
+	/** @var bool */
+	private $isOracle;
+
+	public function __construct(IConfig $config) {
+		$this->isOracle = $config->getSystemValue('dbtype', 'sqlite') === 'oci';
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$this->ensureColumnIsNullable($schema, 'text_steps', 'version');
+
+		if ($this->isOracle) {
+			// Drop table if we are on oracle and recreate it with the next migration Version030201Date20201116123153
+			if ($schema->hasTable('text_documents')) {
+				$schema->dropTable('text_documents');
+			}
+		} else {
+			$this->ensureColumnIsNullable($schema, 'text_documents', 'current_version');
+			$this->ensureColumnIsNullable($schema, 'text_documents', 'last_saved_version');
+			$table = $schema->getTable('text_documents');
+			$column = $table->getColumn('id');
+			if ($column->getAutoincrement()) {
+				$table->changeColumn('id', [
+					'autoincrement' => false,
+				]);
+			}
+		}
+
+		return $schema;
+	}
+
+	protected function ensureColumnIsNullable(ISchemaWrapper $schema, string $tableName, string $columnName): bool {
+		$table = $schema->getTable($tableName);
+		$column = $table->getColumn($columnName);
+
+		if ($column->getNotnull()) {
+			$column->setNotnull(false);
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/lib/Migration/Version030201Date20201116123153.php
+++ b/lib/Migration/Version030201Date20201116123153.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Text\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Type;
+use OCP\DB\ISchemaWrapper;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version030201Date20201116123153 extends SimpleMigrationStep {
+
+	/** @var bool */
+	private $isOracle;
+
+	public function __construct(IConfig $config) {
+		$this->isOracle = $config->getSystemValue('dbtype', 'sqlite') === 'oci';
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		if (!$this->isOracle) {
+			return null;
+		}
+
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('text_documents')) {
+			// Recreate table from the first migration since we cannot alter the autoincrement on the id column with oracle
+			$table = $schema->createTable('text_documents');
+			$table->addColumn('id', Type::BIGINT, [
+				'notnull' => true,
+				'unsigned' => true,
+			]);
+			$table->addColumn('current_version', Type::BIGINT, [
+				// 'notnull' => true,
+				'notnull' => false,
+				'default' => 0,
+				'unsigned' => true,
+			]);
+			$table->addColumn('last_saved_version', Type::BIGINT, [
+				// 'notnull' => true,
+				'notnull' => false,
+				'default' => 0,
+				'unsigned' => true,
+			]);
+			$table->addColumn('last_saved_version_time', Type::BIGINT, [
+				'length' => 20,
+				'unsigned' => true,
+			]);
+			$table->addColumn('last_saved_version_etag', Type::STRING, [
+				'notnull' => false,
+				'length' => 64,
+				'default' => ''
+			]);
+			$table->addColumn('base_version_etag', TYPE::STRING, [
+				'notnull' => false,
+				'length' => 64,
+				'default' => ''
+			]);
+			$table->setPrimaryKey(['id']);
+			return $schema;
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
- Fix columns that had a notnull constraint set but used a default integer value which fails on oracle
- Remove autoincrement from oc_text_documents primary key since it is a file id that is inserted here
  - For oracle we need to drop the old table and recreate it. This is fine since it was never working before so the table doesn't have any useful information.