### PR TITLE
cypress: use master branch of nextcloud server

### DIFF
--- a/cypress/docker-compose.yml
+++ b/cypress/docker-compose.yml
@@ -10,6 +10,5 @@ services:
         environment:
             CYPRESS_baseUrl:
             APP_SOURCE:
-            BRANCH: bugfix/noid/initial-stte-cspv3
         volumes:
             - ${APP_SOURCE}:/var/www/html/apps/text


### PR DESCRIPTION
* Target version: master 

### Summary

The `bugfix/noid/initial-stte-cspv3` branch has been merged into master in
https://github.com/nextcloud/server/pull/22636 .

It does not exist anymore which will cause issues when trying to run the cypress tests.

Remove the `$BRANCH` environment variable from the docker-compose.yml.

