### PR TITLE
Remove EPUB mimetype

### DIFF
--- a/src/helpers/mime.js
+++ b/src/helpers/mime.js
@@ -29,7 +29,6 @@ const openMimetypesPlainText = [
 	'application/cmd',
 	'application/x-empty',
 	'application/x-msdos-program',
-	'application/epub+zip',
 	'application/javascript',
 	'application/json',
 	'application/x-perl',


### PR DESCRIPTION
* Resolves: #787
* Target version: master 

### Summary
An EPUB is a zip archive, so opening it for editing as plaintext is unexpected behavior and risks corrupting the file.