### PR TITLE
Use write permission when possible

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -409,7 +409,13 @@ class DocumentService {
 			throw new NotFoundException();
 		}
 
-		return $files[0];
+		// Workaround to always open files with edit permissions if multiple occurences of
+		// the same file id are in the user home, ideally we should also track the path of the file when opening
+		usort($files, function (Node $a, Node $b) {
+			return ($a->getPermissions() & Constants::PERMISSION_UPDATE) < ($b->getPermissions() & Constants::PERMISSION_UPDATE);
+		});
+
+		return array_shift($files);
 	}
 
 	/**


### PR DESCRIPTION
Fixes an issue where the same file is present in the users files multiple times, e.g. through different shares where on one the user has read only and on the other write permissions. As we currently only track file opening by file id there is no way to determine in the text app session which of the file mounts should be used so this patch makes sure we always use the widest permissions when trying to access the file.

The ideal solution would probably be to track the file open path for every session but that would of course then break editing sessions where the file is moved around, so i felt like this approach is the more feasible option, but I'm open for suggestions if anyone has better ideas to solve this.

Note this is also an issue for Collabora/ONLYOFFICE or any other app or code that attempts to get a file by id, so we might have plenty of other places where this is happening as just using the first element seems quite common in the existing codebase.