### PR TITLE
Only return workspace property for top node in a propfind request

### DIFF
--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -93,7 +93,9 @@ class WorkspacePlugin extends ServerPlugin {
 		if (!$workspaceAvailable || !$workspaceEnabled) {
 			return;
 		}
-		if ($propFind->getDepth() > 0) {
+
+		// Only return the property for the parent node and ignore it for further in depth nodes
+		if ($propFind->getDepth() === $this->server->getHTTPDepth()) {
 			$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($node) {
 				/** @var Folder[] $nodes */
 				$nodes = $this->rootFolder->getUserFolder($this->userId)->getById($node->getId());


### PR DESCRIPTION
Fixes #1507 and #1104  while preserving the compatiblity with the previous fix for Android https://github.com/nextcloud/text/pull/994

This makes sure that no matter what depth is requested for the propfind we only return the rich workspace property for the current requested base directory. 