### PR TITLE
fix: cypress icon close selector

### DIFF
--- a/cypress/integration/viewer.spec.js
+++ b/cypress/integration/viewer.spec.js
@@ -52,7 +52,7 @@ describe('Open test.md in viewer', function() {
 		cy.get('#viewer').should('be.visible')
 		cy.get('#viewer .modal-title').should('contain', 'test.md')
 		cy.get('#viewer .modal-header button.action-item__menutoggle').should('be.visible')
-		cy.get('#viewer .modal-header button.icon-close').should('be.visible')
+		cy.get('#viewer .modal-header button.header-close').should('be.visible')
 
 		cy.wait(2000)
 		cy.get('#viewer', { timeout: 4000 })
@@ -75,7 +75,7 @@ describe('Open test.md in viewer', function() {
 	})
 
 	it('Closes the editor', function() {
-		cy.get('.modal-header button.icon-close').click()
+		cy.get('.modal-header button.header-close').click()
 		cy.get('#viewer').should('not.exist')
 	})
 


### PR DESCRIPTION
The markup of the close icon has changed.

See https://github.com/nextcloud/viewer/commit/f7bcfd0464987d889c706f3e3514d3db3ab73907
for a similar fix to the viewer itself.

Signed-off-by: Azul <azul@riseup.net>


* Resolves: failing CI builds such as https://github.com/nextcloud/text/pull/1800/checks?check_run_id=3218688098
* Target version: master 




