### PR TITLE
Cypress: Avoid failing tests due to page reload conditions causing exceptions

### DIFF
--- a/cypress/integration/share.spec.js
+++ b/cypress/integration/share.spec.js
@@ -52,6 +52,9 @@ describe('Open test.md in viewer', function() {
 			.should('contain', 'test.md')
 	})
 	after(function () {
+		cy.on('uncaught:exception', (err, runnable) => {
+			return false
+		})
 		cy.visit('/apps/files')
 		cy.logout()
 	})


### PR DESCRIPTION
This should hopefully avoid failures like in https://github.com/nextcloud/text/runs/3961812279 where the page navigation in the after all hook caused an exception that is thrown which then marks a test as failed. Instead we just ignore that since the page is navigating away.