### PR TITLE
fix: use stable22 branch for cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,7 +18,7 @@ jobs:
         # containers: [1, 2, 3]
         php-versions: [ '7.4' ]
         databases: [ 'sqlite' ]
-        server-versions: [ 'master' ]
+        server-versions: [ 'stable22' ]
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}

--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -2,6 +2,7 @@ FROM nextcloudci/server:server-17
 
 RUN mkdir /var/www/html/data
 RUN chown -R www-data:www-data /var/www/html/data
+ENV BRANCH stable22
 
 ENTRYPOINT /usr/local/bin/initAndRun.sh
 


### PR DESCRIPTION
* Resolves: CI failures in stable22 branch.
* Target version: stable22

### Summary

The server image will use the BRANCH environment variable
to determine which branch of the server to checkout:
https://github.com/nextcloud/docker-ci/blob/master/server/initnc.sh#L3-L12

