### PR TITLE
fix: use stable21 branch for cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,9 +18,17 @@ jobs:
         # containers: [1, 2, 3]
         php-versions: [ '7.4' ]
         databases: [ 'sqlite' ]
-        server-versions: [ 'master' ]
+        server-versions: [ 'stable21' ]
 
     steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Set up npm7
+        run: npm i -g npm@7
+            
       - name: Checkout server
         uses: actions/checkout@v2
         with:

--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -2,6 +2,7 @@ FROM nextcloudci/server:server-17
 
 RUN mkdir /var/www/html/data
 RUN chown -R www-data:www-data /var/www/html/data
+ENV BRANCH stable21
 
 ENTRYPOINT /usr/local/bin/initAndRun.sh
 


### PR DESCRIPTION
* Resolves: ci build failures on stable21 branch
* Target version: stable21

### Summary

The server image will use the BRANCH environment variable
to determine which branch of the server to checkout:
https://github.com/nextcloud/docker-ci/blob/master/server/initnc.sh#L3-L12

So we were effectively using the latest master which led to test failures as it has a rewritten API for injecting app scripts.
