### PR TITLE
ci: keep screenshots of failing tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -95,5 +95,14 @@ jobs:
           parallel: false
           wait-on: '${{ env.CYPRESS_baseUrl }}'
           working-directory: 'apps/${{ env.APP_NAME }}'
+          config: video=false
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+
+      - name: Upload test failure screenshots
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Upload screenshots
+          path: apps/${{ env.APP_NAME }}/cypress/screenshots/
+          retention-days: 5


### PR DESCRIPTION
Disable videos as the result is hardly usable.

Add a screenshot download at the end of a failed job. For an example see: https://github.com/nextcloud/text/actions/runs/1606482863

* Target version: master 
