### PR TITLE
fix: more robust script to run cypress locally

### DIFF
--- a/cypress/runLocal.sh
+++ b/cypress/runLocal.sh
@@ -1,18 +1,29 @@
 #!/bin/bash
 
-export CYPRESS_baseUrl=http://localhost:8081/index.php
-export APP_SOURCE=$PWD/..
+export CYPRESS_DIR=$(dirname -- "$(readlink -f "${BASH_SOURCE}")")
+export CYPRESS_baseUrl=${CYPRESS_baseUrl:-http://localhost:8081/index.php}
+export APP_SOURCE=$CYPRESS_DIR/..
 
 function finish {
 	docker-compose down
 }
 trap finish EXIT
 
-docker-compose up -d
+cd $CYPRESS_DIR
+if [ ! -f $(npm bin)/wait-on ]
+then
+	npm install --no-save wait-on
+fi
 
-npm install --no-save wait-on
-$(npm bin)/wait-on -i 500 -t 240000 $CYPRESS_baseUrl || (cd cypress && docker-compose logs && exit 1)
-docker-compose exec -T nextcloud bash /var/www/html/apps/text/cypress/server.sh
+# start server if it's not running yet
+if $(npm bin)/wait-on -i 500 -t 1000 $CYPRESS_baseUrl
+then
+	echo Server is up at $CYPRESS_baseUrl
+else
+	docker-compose up -d
+	$(npm bin)/wait-on -i 500 -t 240000 $CYPRESS_baseUrl || ( docker-compose logs ; exit 1 )
+	docker-compose exec -T nextcloud bash /var/www/html/apps/text/cypress/server.sh
+fi
 
 (cd .. && $(npm bin)/cypress $@)
 


### PR DESCRIPTION
* Use `BASH_SOURCE` rather than `PWD` to retrieve `CYPRESS_DIR`
  independently of where the script was called from.
* Ensure docker-compose is called inside the `CYPRESS_DIR`.
* Respect `CYPRESS_baseUrl` when set in environment.
* Check if server is already running at `CYPRESS_baseUrl`
  before starting one with `docker-compose`
* Exit if the server does not start,
  even if `docker-compose logs` also fails.

Signed-off-by: Azul <azul@riseup.net>

* Target version: master 
