### PR TITLE
fix: cypress login with new session feature

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "https://localhost:8081/index.php/",
   "projectId": "hx9gqy",
   "viewportWidth": 1280,
-  "viewportHeight": 720
+  "viewportHeight": 720,
+  "experimentalSessionSupport": true
 }

--- a/cypress/integration/files.spec.js
+++ b/cypress/integration/files.spec.js
@@ -21,11 +21,8 @@
  */
 
 describe('Files default view', function() {
-	before(function() {
+	beforeEach(function() {
 		cy.login('admin', 'admin')
-	})
-	after(function() {
-		cy.logout()
 	})
 
 	it('See the default files list', function() {

--- a/cypress/integration/share.spec.js
+++ b/cypress/integration/share.spec.js
@@ -51,12 +51,8 @@ describe('Open test.md in viewer', function() {
 		cy.get('#fileList tr[data-file="test.md"]', {timeout: 10000})
 			.should('contain', 'test.md')
 	})
-	after(function () {
-		cy.on('uncaught:exception', (err, runnable) => {
-			return false
-		})
-		cy.visit('/apps/files')
-		cy.logout()
+	beforeEach(function() {
+		cy.login(randUser, 'password')
 	})
 
 	it('Shares the file as a public read only link', function () {

--- a/cypress/integration/viewer.spec.js
+++ b/cypress/integration/viewer.spec.js
@@ -32,13 +32,10 @@ describe('Open test.md in viewer', function() {
 
 		// Upload test files
 		cy.uploadFile('test.md', 'text/markdown')
-		cy.visit('/apps/files')
-
-		// wait a bit for things to be settled
-		cy.wait(1000)
 	})
-	after(function() {
-		cy.logout()
+
+	beforeEach(function() {
+		cy.login(randUser, 'password')
 	})
 
 	it('See test.md in the list', function() {
@@ -47,7 +44,6 @@ describe('Open test.md in viewer', function() {
 	})
 
 	it('Open the viewer on file click', function() {
-		cy.visit('/apps/files')
 		cy.openFile('test.md')
 		cy.get('#viewer').should('be.visible')
 		cy.get('#viewer .modal-title').should('contain', 'test.md')

--- a/cypress/integration/viewer.spec.js
+++ b/cypress/integration/viewer.spec.js
@@ -45,39 +45,32 @@ describe('Open test.md in viewer', function() {
 
 	it('Open the viewer on file click', function() {
 		cy.openFile('test.md')
-		cy.get('#viewer').should('be.visible')
-		cy.get('#viewer .modal-title').should('contain', 'test.md')
-		cy.get('#viewer .modal-header button.action-item__menutoggle').should('be.visible')
-		cy.get('#viewer .modal-header button.header-close').should('be.visible')
 
-		cy.wait(2000)
-		cy.get('#viewer', { timeout: 4000 })
-			.should('be.visible')
+		cy.log('Inspect viewer')
+		const viewer = cy.get('#viewer')
+		viewer.should('be.visible')
 			.and('have.class', 'modal-mask')
 			.and('not.have.class', 'icon-loading')
-	})
+		viewer.get('.modal-title').should('contain', 'test.md')
+		viewer.get('.modal-header button.action-item__menutoggle')
+			.should('be.visible')
 
-	it('Has opened the file', function() {
-		cy.get('#viewer #editor .ProseMirror').should('contain', 'Hello world')
-		cy.get('#viewer #editor .ProseMirror h2').should('contain', 'Hello world')
-	})
+		cy.log('Inspect editor')
+		const editor = viewer.get('#editor .ProseMirror')
+		editor.should('contain', 'Hello world')
+		editor.get('h2').should('contain', 'Hello world')
 
-	it('Shows the menu bar icons', function() {
-		// FIXME those checks are failing since the parent container is currently at 0x0 size
-		// due to the way we make the text app be a full screen viewer
-		// cy.get('#viewer-content #editor .menubar .menubar-icons .icon-undo').should('be.visible')
-		// cy.get('#viewer-content #editor .menubar .menubar-icons .icon-redo').should('be.visible')
-		// cy.get('#viewer-content #editor .menubar .menubar-icons .icon-bold').should('be.visible')
+		cy.log('Inspect menubar')
+		const menubar = editor.get('.menubar .menubar-icons')
+		menubar.get('.icon-undo').should('be.visible')
+		menubar.get('.icon-bold').should('be.visible')
+
+		cy.screenshot()
 	})
 
 	it('Closes the editor', function() {
-		cy.get('.modal-header button.header-close').click()
+		cy.openFile('test.md')
+		cy.get('#viewer .modal-header button.header-close').click()
 		cy.get('#viewer').should('not.exist')
-	})
-
-	it('Take screenshot', function() {
-		// gif is impossible to match with existing screenshot
-		// just taking a screenshot to manually compare if needed
-		cy.screenshot()
 	})
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,27 +26,19 @@ const url = Cypress.config('baseUrl').replace(/\/index.php\/?$/g, '')
 Cypress.env('baseUrl', url)
 
 Cypress.Commands.add('login', (user, password, route = '/apps/files') => {
-	cy.clearCookies()
-	Cypress.Cookies.defaults({
-		preserve: /^(oc|nc)/
+	cy.session(user, function () {
+		cy.visit(route)
+		cy.get('input[name=user]').type(user)
+		cy.get('input[name=password]').type(password)
+		cy.get('#submit-wrapper input[type=submit]').click()
+		cy.url().should('include', route)
 	})
+	// in case the session already existed but we are on a different route...
 	cy.visit(route)
-	cy.get('input[name=user]').type(user)
-	cy.get('input[name=password]').type(password)
-	cy.get('#submit-wrapper input[type=submit]').click()
-	cy.url().should('include', route)
 })
 
-Cypress.Commands.add('logout', () => {
-	Cypress.Cookies.defaults({
-		preserve: []
-	})
-
-	cy.clearLocalStorage()
-	cy.clearCookies()
-
-	Cypress.Cookies.defaults({
-		preserve: /^(oc|nc)/
+Cypress.Commands.add('logout', (route = '/') => {
+	cy.session('_guest', function () {
 	})
 })
 


### PR DESCRIPTION
Use the new session feature to create and reuse sessions:
https://docs.cypress.io/api/commands/session

The first time `login` with a given name is called
the steps described in the login function are performed
and cookies and localstorage are cached.

The next time `login` is called with the same name
cookies and localStorage are restored and used again.

This allows us to keep fast test runs
while still separating the tests more cleanly.

The old logout command was broken because of the way
we used `Cypress.Cookies.defaults({ preserve })` before:

Cypress runs all the `cy.*` commands during initialization
and builds a list of commands that are then executed during the tests.
However `Cypress.Cookies.defaults` is evaluated when preparing the list
not while performing the actual steps.

Signed-off-by: Azul <azul@riseup.net>

* Target version: master 
