### PR TITLE
Stable22 update cypress

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -11,17 +11,10 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-const {
-	addMatchImageSnapshotPlugin
-} = require('cypress-image-snapshot/plugin')
 const browserify = require('@cypress/browserify-preprocessor')
-
-module.exports = (on) => {
-}
 
 module.exports = (on, config) => {
 
 	on('file:preprocessor', browserify())
 
-	addMatchImageSnapshotPlugin(on, config)
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -20,10 +20,7 @@
  *
  */
 
-import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command'
 import axios from '@nextcloud/axios'
-
-addMatchImageSnapshotCommand()
 
 const url = Cypress.config('baseUrl').replace(/\/index.php\/?$/g, '')
 Cypress.env('baseUrl', url)
@@ -110,15 +107,4 @@ Cypress.Commands.add('openFile', fileName => {
 Cypress.Commands.add('deleteFile', fileName => {
 	cy.get(`#fileList tr[data-file="${fileName}"] a.name .action-menu`).click()
 	cy.get(`#fileList tr[data-file="${fileName}"] a.name + .popovermenu .action-delete`).click()
-})
-
-Cypress.Commands.overwrite('matchImageSnapshot', (originalFn, subject, name, options) => {
-	// hide avatar because random colour break the visual regression tests
-	cy.window().then(win => {
-		const avatarDiv = win.document.querySelector('.avatardiv')
-		if (avatarDiv) {
-			avatarDiv.remove()
-		}
-	})
-	return originalFn(subject, name, options)
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"babel-loader": "~8.2.2",
 				"clean-webpack-plugin": "~3.0.0",
 				"css-loader": "~5.2.7",
-				"cypress": "~7.5.0",
+				"cypress": "~9.2.0",
 				"eslint": "~6.8.0",
 				"eslint-config-standard": "~14.1.1",
 				"eslint-friendly-formatter": "~4.0.1",
@@ -2561,54 +2561,10 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/@cypress/listr-verbose-renderer": {
-			"version": "0.4.1",
-			"integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^1.1.3",
-				"cli-cursor": "^1.0.2",
-				"date-fns": "^1.27.2",
-				"figures": "^1.7.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@cypress/listr-verbose-renderer/node_modules/ansi-styles": {
-			"version": "2.2.1",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@cypress/listr-verbose-renderer/node_modules/chalk": {
-			"version": "1.1.3",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@cypress/listr-verbose-renderer/node_modules/supports-color": {
-			"version": "2.0.0",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
 		"node_modules/@cypress/request": {
-			"version": "2.88.5",
-			"integrity": "sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==",
+			"version": "2.88.10",
+			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
+			"integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
 			"dev": true,
 			"dependencies": {
 				"aws-sign2": "~0.7.0",
@@ -2618,26 +2574,60 @@
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
+				"http-signature": "~1.3.6",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
 				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.2",
 				"safe-buffer": "^5.1.2",
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
+				"uuid": "^8.3.2"
 			},
 			"engines": {
 				"node": ">= 6"
 			}
 		},
+		"node_modules/@cypress/request/node_modules/http-signature": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+			"integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+			"dev": true,
+			"dependencies": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^2.0.2",
+				"sshpk": "^1.14.1"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/@cypress/request/node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+			"dev": true
+		},
+		"node_modules/@cypress/request/node_modules/jsprim": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+			"integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+			"dev": true,
+			"engines": [
+				"node >=0.6.0"
+			],
+			"dependencies": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.4.0",
+				"verror": "1.10.0"
+			}
+		},
 		"node_modules/@cypress/request/node_modules/punycode": {
 			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true,
 			"engines": {
@@ -2646,6 +2636,7 @@
 		},
 		"node_modules/@cypress/request/node_modules/tough-cookie": {
 			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
 			"dependencies": {
@@ -2654,6 +2645,15 @@
 			},
 			"engines": {
 				"node": ">=0.8"
+			}
+		},
+		"node_modules/@cypress/request/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@cypress/xvfb": {
@@ -2858,20 +2858,6 @@
 			"version": "2.0.0",
 			"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
 			"dev": true
-		},
-		"node_modules/@jest/core/node_modules/ansi-escapes": {
-			"version": "4.3.1",
-			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.11.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/@jest/core/node_modules/ansi-regex": {
 			"version": "5.0.0",
@@ -3259,20 +3245,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/@jest/environment/node_modules/load-json-file": {
-			"version": "4.0.0",
-			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
-				"strip-bom": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@jest/environment/node_modules/locate-path": {
 			"version": "3.0.0",
 			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
@@ -3316,50 +3288,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/parse-json": {
-			"version": "4.0.0",
-			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-			"dev": true,
-			"dependencies": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/path-type": {
-			"version": "3.0.0",
-			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-			"dev": true,
-			"dependencies": {
-				"pify": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/pify": {
-			"version": "3.0.0",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/read-pkg": {
-			"version": "3.0.0",
-			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-			"dev": true,
-			"dependencies": {
-				"load-json-file": "^4.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@jest/environment/node_modules/read-pkg-up": {
@@ -4884,8 +4812,7 @@
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.6",
-			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-			"dev": true
+			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw=="
 		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
@@ -5438,6 +5365,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.2"
+			}
+		},
+		"node_modules/ansi-colors": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/ansi-escapes": {
@@ -7333,14 +7269,15 @@
 			}
 		},
 		"node_modules/cli-cursor": {
-			"version": "1.0.2",
-			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
 			"dev": true,
 			"dependencies": {
-				"restore-cursor": "^1.0.1"
+				"restore-cursor": "^3.1.0"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
 			}
 		},
 		"node_modules/cli-table3": {
@@ -8126,32 +8063,35 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
 		},
 		"node_modules/cypress": {
-			"version": "7.5.0",
-			"integrity": "sha512-tw3v6nrTJoEzT37+Nf6RK+DvdTfhMb8EJYskZx7oskZ+J9qQ1QHWA4dH8Eoe/Mr/wE47o+7PK6O9tgqhRy6IHg==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-9.2.0.tgz",
+			"integrity": "sha512-Jn26Tprhfzh/a66Sdj9SoaYlnNX6Mjfmj5PHu2a7l3YHXhrgmavM368wjCmgrxC6KHTOv9SpMQGhAJn+upDViA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@cypress/listr-verbose-renderer": "^0.4.1",
-				"@cypress/request": "^2.88.5",
+				"@cypress/request": "^2.88.10",
 				"@cypress/xvfb": "^1.2.4",
 				"@types/node": "^14.14.31",
 				"@types/sinonjs__fake-timers": "^6.0.2",
 				"@types/sizzle": "^2.3.2",
 				"arch": "^2.2.0",
 				"blob-util": "^2.0.2",
-				"bluebird": "^3.7.2",
+				"bluebird": "3.7.2",
 				"cachedir": "^2.3.0",
 				"chalk": "^4.1.0",
 				"check-more-types": "^2.24.0",
+				"cli-cursor": "^3.1.0",
 				"cli-table3": "~0.6.0",
 				"commander": "^5.1.0",
 				"common-tags": "^1.8.0",
 				"dayjs": "^1.10.4",
-				"debug": "4.3.2",
+				"debug": "^4.3.2",
+				"enquirer": "^2.3.6",
 				"eventemitter2": "^6.4.3",
 				"execa": "4.1.0",
 				"executable": "^4.1.1",
 				"extract-zip": "2.0.1",
+				"figures": "^3.2.0",
 				"fs-extra": "^9.1.0",
 				"getos": "^3.2.1",
 				"is-ci": "^3.0.0",
@@ -8163,7 +8103,7 @@
 				"minimist": "^1.2.5",
 				"ospath": "^1.2.2",
 				"pretty-bytes": "^5.6.0",
-				"ramda": "~0.27.1",
+				"proxy-from-env": "1.0.0",
 				"request-progress": "^3.0.0",
 				"supports-color": "^8.1.1",
 				"tmp": "~0.2.1",
@@ -8390,20 +8330,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/cypress/node_modules/onetime": {
-			"version": "5.1.2",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/cypress/node_modules/path-key": {
 			"version": "3.1.1",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
@@ -8488,11 +8414,6 @@
 				"tr46": "^1.0.1",
 				"webidl-conversions": "^4.0.2"
 			}
-		},
-		"node_modules/date-fns": {
-			"version": "1.30.1",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-			"dev": true
 		},
 		"node_modules/date-format-parse": {
 			"version": "0.2.6",
@@ -8965,6 +8886,18 @@
 			},
 			"engines": {
 				"node": ">=4.3.0 <5.0.0 || >=5.10"
+			}
+		},
+		"node_modules/enquirer": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-colors": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.6"
 			}
 		},
 		"node_modules/entities": {
@@ -9883,14 +9816,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/exit-hook": {
-			"version": "1.1.1",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/expand-brackets": {
 			"version": "2.1.4",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
@@ -10463,15 +10388,18 @@
 			"integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
 		},
 		"node_modules/figures": {
-			"version": "1.7.0",
-			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
 			"dev": true,
 			"dependencies": {
-				"escape-string-regexp": "^1.0.5",
-				"object-assign": "^4.1.0"
+				"escape-string-regexp": "^1.0.5"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -10503,11 +10431,6 @@
 			"peerDependencies": {
 				"webpack": "^4.0.0 || ^5.0.0"
 			}
-		},
-		"node_modules/file-loader/node_modules/@types/json-schema": {
-			"version": "7.0.6",
-			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-			"dev": true
 		},
 		"node_modules/file-loader/node_modules/ajv": {
 			"version": "6.12.6",
@@ -11572,20 +11495,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/inquirer/node_modules/ansi-escapes": {
-			"version": "4.3.1",
-			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.11.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/inquirer/node_modules/ansi-regex": {
 			"version": "5.0.0",
 			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
@@ -11621,17 +11530,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/inquirer/node_modules/cli-cursor": {
-			"version": "3.1.0",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-			"dev": true,
-			"dependencies": {
-				"restore-cursor": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/inquirer/node_modules/color-convert": {
 			"version": "2.0.1",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
@@ -11653,20 +11551,6 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
 		},
-		"node_modules/inquirer/node_modules/figures": {
-			"version": "3.2.0",
-			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-			"dev": true,
-			"dependencies": {
-				"escape-string-regexp": "^1.0.5"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/inquirer/node_modules/has-flag": {
 			"version": "4.0.0",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
@@ -11681,40 +11565,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/inquirer/node_modules/onetime": {
-			"version": "5.1.0",
-			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/inquirer/node_modules/restore-cursor": {
-			"version": "3.1.0",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
-			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/inquirer/node_modules/rxjs": {
-			"version": "6.5.5",
-			"integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^1.9.0"
-			},
-			"engines": {
-				"npm": ">=2.0.0"
 			}
 		},
 		"node_modules/inquirer/node_modules/string-width": {
@@ -12531,20 +12381,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/jest-changed-files/node_modules/onetime": {
-			"version": "5.1.2",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/jest-changed-files/node_modules/path-key": {
@@ -15636,20 +15472,6 @@
 			"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
 			"dev": true
 		},
-		"node_modules/jest-watcher/node_modules/ansi-escapes": {
-			"version": "4.3.1",
-			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.11.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/jest-watcher/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
@@ -16008,21 +15830,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/jest/node_modules/import-local": {
-			"version": "3.0.2",
-			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
-			"dev": true,
-			"dependencies": {
-				"pkg-dir": "^4.2.0",
-				"resolve-cwd": "^3.0.0"
-			},
-			"bin": {
-				"import-local-fixture": "fixtures/cli.js"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/jest/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
@@ -16144,28 +15951,6 @@
 			"version": "4.0.0",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/pkg-dir": {
-			"version": "4.2.0",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
-			"dependencies": {
-				"find-up": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/resolve-cwd": {
-			"version": "3.0.0",
-			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-			"dev": true,
-			"dependencies": {
-				"resolve-from": "^5.0.0"
-			},
 			"engines": {
 				"node": ">=8"
 			}
@@ -17130,17 +16915,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/log-update/node_modules/cli-cursor": {
-			"version": "3.1.0",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-			"dev": true,
-			"dependencies": {
-				"restore-cursor": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/log-update/node_modules/color-convert": {
 			"version": "2.0.1",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
@@ -17166,32 +16940,6 @@
 			"version": "3.0.0",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/log-update/node_modules/onetime": {
-			"version": "5.1.2",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/restore-cursor": {
-			"version": "3.1.0",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
-			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			},
 			"engines": {
 				"node": ">=8"
 			}
@@ -18737,11 +18485,18 @@
 			}
 		},
 		"node_modules/onetime": {
-			"version": "1.1.0",
-			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
 			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/optionator": {
@@ -19799,6 +19554,12 @@
 			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 			"dev": true
 		},
+		"node_modules/proxy-from-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+			"dev": true
+		},
 		"node_modules/proxy-polyfill": {
 			"version": "0.3.2",
 			"integrity": "sha512-ENKSXOMCewnQTOyqrQXxEjIhzT6dy572mtehiItbDoIUF5Sv5UkmRUc8kowg2MFvr232Uo8rwRpNg3V5kgTKbA=="
@@ -19912,11 +19673,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/ramda": {
-			"version": "0.27.1",
-			"integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-			"dev": true
-		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
@@ -19950,11 +19706,6 @@
 			"peerDependencies": {
 				"webpack": "^4.0.0 || ^5.0.0"
 			}
-		},
-		"node_modules/raw-loader/node_modules/@types/json-schema": {
-			"version": "7.0.6",
-			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-			"dev": true
 		},
 		"node_modules/raw-loader/node_modules/ajv": {
 			"version": "6.12.5",
@@ -20378,15 +20129,16 @@
 			"deprecated": "https://github.com/lydell/resolve-url#deprecated"
 		},
 		"node_modules/restore-cursor": {
-			"version": "1.0.1",
-			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
 			"dev": true,
 			"dependencies": {
-				"exit-hook": "^1.0.0",
-				"onetime": "^1.0.0"
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
 			}
 		},
 		"node_modules/ret": {
@@ -21450,10 +21202,6 @@
 				"webpack": "^4.0.0 || ^5.0.0"
 			}
 		},
-		"node_modules/style-loader/node_modules/@types/json-schema": {
-			"version": "7.0.6",
-			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw=="
-		},
 		"node_modules/style-loader/node_modules/ajv": {
 			"version": "6.12.6",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
@@ -21631,11 +21379,6 @@
 				"stylelint": "^13.0.0",
 				"webpack": "^4.0.0 || ^5.0.0"
 			}
-		},
-		"node_modules/stylelint-webpack-plugin/node_modules/@types/json-schema": {
-			"version": "7.0.6",
-			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-			"dev": true
 		},
 		"node_modules/stylelint-webpack-plugin/node_modules/ajv": {
 			"version": "6.12.6",
@@ -22013,21 +21756,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/stylelint/node_modules/log-symbols": {
-			"version": "4.1.0",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^4.1.0",
-				"is-unicode-supported": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/stylelint/node_modules/lru-cache": {
@@ -22777,20 +22505,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/terminal-link/node_modules/ansi-escapes": {
-			"version": "4.3.1",
-			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.11.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/terser": {
 			"version": "4.8.0",
 			"integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
@@ -23202,17 +22916,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/type-fest": {
-			"version": "0.11.0",
-			"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/typedarray": {
 			"version": "0.0.6",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
@@ -23531,11 +23234,6 @@
 				}
 			}
 		},
-		"node_modules/url-loader/node_modules/@types/json-schema": {
-			"version": "7.0.6",
-			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-			"dev": true
-		},
 		"node_modules/url-loader/node_modules/ajv": {
 			"version": "6.12.6",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
@@ -23851,30 +23549,6 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/vue-eslint-parser/node_modules/espree": {
-			"version": "6.2.1",
-			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-			"dev": true,
-			"dependencies": {
-				"acorn": "^7.1.1",
-				"acorn-jsx": "^5.2.0",
-				"eslint-visitor-keys": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/vue-eslint-parser/node_modules/espree/node_modules/acorn": {
-			"version": "7.4.1",
-			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-			"dev": true,
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/vue-eslint-parser/node_modules/ms": {
@@ -24363,20 +24037,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/webpack-cli/node_modules/onetime": {
-			"version": "5.1.2",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/webpack-cli/node_modules/path-key": {
@@ -26607,44 +26267,10 @@
 				}
 			}
 		},
-		"@cypress/listr-verbose-renderer": {
-			"version": "0.4.1",
-			"integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"cli-cursor": "^1.0.2",
-				"date-fns": "^1.27.2",
-				"figures": "^1.7.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
 		"@cypress/request": {
-			"version": "2.88.5",
-			"integrity": "sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==",
+			"version": "2.88.10",
+			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
+			"integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -26654,34 +26280,69 @@
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
+				"http-signature": "~1.3.6",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
 				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.2",
 				"safe-buffer": "^5.1.2",
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
+				"uuid": "^8.3.2"
 			},
 			"dependencies": {
+				"http-signature": {
+					"version": "1.3.6",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+					"integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+					"dev": true,
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"jsprim": "^2.0.2",
+						"sshpk": "^1.14.1"
+					}
+				},
+				"json-schema": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+					"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+					"dev": true
+				},
+				"jsprim": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+					"integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+					"dev": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.3.0",
+						"json-schema": "0.4.0",
+						"verror": "1.10.0"
+					}
+				},
 				"punycode": {
 					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 					"dev": true
 				},
 				"tough-cookie": {
 					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 					"dev": true,
 					"requires": {
 						"psl": "^1.1.28",
 						"punycode": "^2.1.1"
 					}
+				},
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+					"dev": true
 				}
 			}
 		},
@@ -26849,14 +26510,6 @@
 					"version": "2.0.0",
 					"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
 					"dev": true
-				},
-				"ansi-escapes": {
-					"version": "4.3.1",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.11.0"
-					}
 				},
 				"ansi-regex": {
 					"version": "5.0.0",
@@ -27148,17 +26801,6 @@
 						"supports-color": "^6.1.0"
 					}
 				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
 				"locate-path": {
 					"version": "3.0.0",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
@@ -27188,38 +26830,6 @@
 					"version": "2.2.0",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"path-type": {
-					"version": "3.0.0",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
 				},
 				"read-pkg-up": {
 					"version": "4.0.0",
@@ -28433,8 +28043,7 @@
 		},
 		"@types/json-schema": {
 			"version": "7.0.6",
-			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-			"dev": true
+			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw=="
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -28921,6 +28530,12 @@
 		"amdefine": {
 			"version": "1.0.1",
 			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi-colors": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
 			"dev": true
 		},
 		"ansi-escapes": {
@@ -30386,11 +30001,12 @@
 			}
 		},
 		"cli-cursor": {
-			"version": "1.0.2",
-			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^1.0.1"
+				"restore-cursor": "^3.1.0"
 			}
 		},
 		"cli-table3": {
@@ -31009,31 +30625,34 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
 		},
 		"cypress": {
-			"version": "7.5.0",
-			"integrity": "sha512-tw3v6nrTJoEzT37+Nf6RK+DvdTfhMb8EJYskZx7oskZ+J9qQ1QHWA4dH8Eoe/Mr/wE47o+7PK6O9tgqhRy6IHg==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-9.2.0.tgz",
+			"integrity": "sha512-Jn26Tprhfzh/a66Sdj9SoaYlnNX6Mjfmj5PHu2a7l3YHXhrgmavM368wjCmgrxC6KHTOv9SpMQGhAJn+upDViA==",
 			"dev": true,
 			"requires": {
-				"@cypress/listr-verbose-renderer": "^0.4.1",
-				"@cypress/request": "^2.88.5",
+				"@cypress/request": "^2.88.10",
 				"@cypress/xvfb": "^1.2.4",
 				"@types/node": "^14.14.31",
 				"@types/sinonjs__fake-timers": "^6.0.2",
 				"@types/sizzle": "^2.3.2",
 				"arch": "^2.2.0",
 				"blob-util": "^2.0.2",
-				"bluebird": "^3.7.2",
+				"bluebird": "3.7.2",
 				"cachedir": "^2.3.0",
 				"chalk": "^4.1.0",
 				"check-more-types": "^2.24.0",
+				"cli-cursor": "^3.1.0",
 				"cli-table3": "~0.6.0",
 				"commander": "^5.1.0",
 				"common-tags": "^1.8.0",
 				"dayjs": "^1.10.4",
-				"debug": "4.3.2",
+				"debug": "^4.3.2",
+				"enquirer": "^2.3.6",
 				"eventemitter2": "^6.4.3",
 				"execa": "4.1.0",
 				"executable": "^4.1.1",
 				"extract-zip": "2.0.1",
+				"figures": "^3.2.0",
 				"fs-extra": "^9.1.0",
 				"getos": "^3.2.1",
 				"is-ci": "^3.0.0",
@@ -31045,7 +30664,7 @@
 				"minimist": "^1.2.5",
 				"ospath": "^1.2.2",
 				"pretty-bytes": "^5.6.0",
-				"ramda": "~0.27.1",
+				"proxy-from-env": "1.0.0",
 				"request-progress": "^3.0.0",
 				"supports-color": "^8.1.1",
 				"tmp": "~0.2.1",
@@ -31207,14 +30826,6 @@
 						"path-key": "^3.0.0"
 					}
 				},
-				"onetime": {
-					"version": "5.1.2",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
 				"path-key": {
 					"version": "3.1.1",
 					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
@@ -31282,11 +30893,6 @@
 					}
 				}
 			}
-		},
-		"date-fns": {
-			"version": "1.30.1",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-			"dev": true
 		},
 		"date-format-parse": {
 			"version": "0.2.6",
@@ -31683,6 +31289,15 @@
 						"readable-stream": "^2.0.1"
 					}
 				}
+			}
+		},
+		"enquirer": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^4.1.1"
 			}
 		},
 		"entities": {
@@ -32338,11 +31953,6 @@
 			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
 			"dev": true
 		},
-		"exit-hook": {
-			"version": "1.1.1",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-			"dev": true
-		},
 		"expand-brackets": {
 			"version": "2.1.4",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
@@ -32781,12 +32391,12 @@
 			"integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
 		},
 		"figures": {
-			"version": "1.7.0",
-			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5",
-				"object-assign": "^4.1.0"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -32806,11 +32416,6 @@
 				"schema-utils": "^3.0.0"
 			},
 			"dependencies": {
-				"@types/json-schema": {
-					"version": "7.0.6",
-					"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-					"dev": true
-				},
 				"ajv": {
 					"version": "6.12.6",
 					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
@@ -33617,14 +33222,6 @@
 				"through": "^2.3.6"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "4.3.1",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.11.0"
-					}
-				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
@@ -33648,14 +33245,6 @@
 						"supports-color": "^7.1.0"
 					}
 				},
-				"cli-cursor": {
-					"version": "3.1.0",
-					"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^3.1.0"
-					}
-				},
 				"color-convert": {
 					"version": "2.0.1",
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
@@ -33674,14 +33263,6 @@
 					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 					"dev": true
 				},
-				"figures": {
-					"version": "3.2.0",
-					"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5"
-					}
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
@@ -33691,31 +33272,6 @@
 					"version": "3.0.0",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
-				},
-				"onetime": {
-					"version": "5.1.0",
-					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
-				"restore-cursor": {
-					"version": "3.1.0",
-					"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-					"dev": true,
-					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"rxjs": {
-					"version": "6.5.5",
-					"integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.9.0"
-					}
 				},
 				"string-width": {
 					"version": "4.2.0",
@@ -34343,15 +33899,6 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"import-local": {
-					"version": "3.0.2",
-					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
-					"dev": true,
-					"requires": {
-						"pkg-dir": "^4.2.0",
-						"resolve-cwd": "^3.0.0"
-					}
-				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
@@ -34440,22 +33987,6 @@
 					"version": "4.0.0",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
-					}
-				},
-				"resolve-cwd": {
-					"version": "3.0.0",
-					"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-					"dev": true,
-					"requires": {
-						"resolve-from": "^5.0.0"
-					}
 				},
 				"slash": {
 					"version": "3.0.0",
@@ -34598,14 +34129,6 @@
 					"dev": true,
 					"requires": {
 						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
 					}
 				},
 				"path-key": {
@@ -36934,14 +36457,6 @@
 					"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
 					"dev": true
 				},
-				"ansi-escapes": {
-					"version": "4.3.1",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.11.0"
-					}
-				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
@@ -37731,14 +37246,6 @@
 					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
 					"dev": true
 				},
-				"cli-cursor": {
-					"version": "3.1.0",
-					"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^3.1.0"
-					}
-				},
 				"color-convert": {
 					"version": "2.0.1",
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
@@ -37761,23 +37268,6 @@
 					"version": "3.0.0",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
-				"restore-cursor": {
-					"version": "3.1.0",
-					"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-					"dev": true,
-					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
-					}
 				},
 				"slice-ansi": {
 					"version": "4.0.0",
@@ -38979,9 +38469,13 @@
 			}
 		},
 		"onetime": {
-			"version": "1.1.0",
-			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-			"dev": true
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^2.1.0"
+			}
 		},
 		"optionator": {
 			"version": "0.8.3",
@@ -39789,6 +39283,12 @@
 			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 			"dev": true
 		},
+		"proxy-from-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+			"dev": true
+		},
 		"proxy-polyfill": {
 			"version": "0.3.2",
 			"integrity": "sha512-ENKSXOMCewnQTOyqrQXxEjIhzT6dy572mtehiItbDoIUF5Sv5UkmRUc8kowg2MFvr232Uo8rwRpNg3V5kgTKbA=="
@@ -39879,11 +39379,6 @@
 			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
 			"dev": true
 		},
-		"ramda": {
-			"version": "0.27.1",
-			"integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-			"dev": true
-		},
 		"randombytes": {
 			"version": "2.1.0",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
@@ -39908,11 +39403,6 @@
 				"schema-utils": "^3.0.0"
 			},
 			"dependencies": {
-				"@types/json-schema": {
-					"version": "7.0.6",
-					"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-					"dev": true
-				},
 				"ajv": {
 					"version": "6.12.5",
 					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
@@ -40233,12 +39723,13 @@
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"restore-cursor": {
-			"version": "1.0.1",
-			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
 			"dev": true,
 			"requires": {
-				"exit-hook": "^1.0.0",
-				"onetime": "^1.0.0"
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"ret": {
@@ -41034,10 +40525,6 @@
 				"schema-utils": "^3.0.0"
 			},
 			"dependencies": {
-				"@types/json-schema": {
-					"version": "7.0.6",
-					"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw=="
-				},
 				"ajv": {
 					"version": "6.12.6",
 					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
@@ -41326,15 +40813,6 @@
 					"dev": true,
 					"requires": {
 						"p-locate": "^4.1.0"
-					}
-				},
-				"log-symbols": {
-					"version": "4.1.0",
-					"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^4.1.0",
-						"is-unicode-supported": "^0.1.0"
 					}
 				},
 				"lru-cache": {
@@ -41739,11 +41217,6 @@
 				"schema-utils": "^3.0.0"
 			},
 			"dependencies": {
-				"@types/json-schema": {
-					"version": "7.0.6",
-					"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-					"dev": true
-				},
 				"ajv": {
 					"version": "6.12.6",
 					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
@@ -41993,16 +41466,6 @@
 			"requires": {
 				"ansi-escapes": "^4.2.1",
 				"supports-hyperlinks": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "4.3.1",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.11.0"
-					}
-				}
 			}
 		},
 		"terser": {
@@ -42341,11 +41804,6 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
-		"type-fest": {
-			"version": "0.11.0",
-			"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-			"dev": true
-		},
 		"typedarray": {
 			"version": "0.0.6",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
@@ -42575,11 +42033,6 @@
 				"schema-utils": "^3.0.0"
 			},
 			"dependencies": {
-				"@types/json-schema": {
-					"version": "7.0.6",
-					"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-					"dev": true
-				},
 				"ajv": {
 					"version": "6.12.6",
 					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
@@ -42819,23 +42272,6 @@
 					"requires": {
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
-					}
-				},
-				"espree": {
-					"version": "6.2.1",
-					"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-					"dev": true,
-					"requires": {
-						"acorn": "^7.1.1",
-						"acorn-jsx": "^5.2.0",
-						"eslint-visitor-keys": "^1.1.0"
-					},
-					"dependencies": {
-						"acorn": {
-							"version": "7.4.1",
-							"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-							"dev": true
-						}
 					}
 				},
 				"ms": {
@@ -43207,14 +42643,6 @@
 					"dev": true,
 					"requires": {
 						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
 					}
 				},
 				"path-key": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "text",
 			"version": "3.3.0",
 			"license": "agpl",
 			"dependencies": {
@@ -61,7 +62,6 @@
 				"clean-webpack-plugin": "~3.0.0",
 				"css-loader": "~5.2.7",
 				"cypress": "~7.5.0",
-				"cypress-image-snapshot": "~4.0.1",
 				"eslint": "~6.8.0",
 				"eslint-config-standard": "~14.1.1",
 				"eslint-friendly-formatter": "~4.0.1",
@@ -93,8 +93,8 @@
 				"webpack-merge": "~5.7.3"
 			},
 			"engines": {
-				"node": ">=14.0.0",
-				"npm": ">=7.0.0"
+				"node": "^14.0.0",
+				"npm": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/cli": {
@@ -5503,17 +5503,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/app-path": {
-			"version": "3.2.0",
-			"integrity": "sha512-PQPaKXi64FZuofJkrtaO3I5RZESm9Yjv7tkeJaDz4EZMeBBfGtr5MyQ3m5AC7F0HVrISBLatPxAAAgvbe418fQ==",
-			"dev": true,
-			"dependencies": {
-				"execa": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/aproba": {
 			"version": "1.2.0",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
@@ -8189,25 +8178,6 @@
 				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/cypress-image-snapshot": {
-			"version": "4.0.1",
-			"integrity": "sha512-PBpnhX/XItlx3/DAk5ozsXQHUi72exybBNH5Mpqj1DVmjq+S5Jd9WE5CRa4q5q0zuMZb2V2VpXHth6MjFpgj9Q==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^2.4.1",
-				"fs-extra": "^7.0.1",
-				"glob": "^7.1.3",
-				"jest-image-snapshot": "4.2.0",
-				"pkg-dir": "^3.0.0",
-				"term-img": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"peerDependencies": {
-				"cypress": "^4.5.0"
-			}
-		},
 		"node_modules/cypress/node_modules/@types/node": {
 			"version": "14.17.3",
 			"integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
@@ -10771,19 +10741,6 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
-		"node_modules/fs-extra": {
-			"version": "7.0.1",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
-			}
-		},
 		"node_modules/fs-minipass": {
 			"version": "2.1.0",
 			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
@@ -10887,14 +10844,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/get-stdin": {
-			"version": "5.0.1",
-			"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/get-stream": {
@@ -11073,11 +11022,6 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
-		},
-		"node_modules/glur": {
-			"version": "1.1.2",
-			"integrity": "sha1-8g6jbbEDv8KSNDkh8fkeg8NGdok=",
-			"dev": true
 		},
 		"node_modules/gonzales-pe": {
 			"version": "4.3.0",
@@ -12488,18 +12432,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/iterm2-version": {
-			"version": "4.2.0",
-			"integrity": "sha512-IoiNVk4SMPu6uTcK+1nA5QaHNok2BMDLjSl5UomrOixe5g4GkylhPwuiGdw00ysSCrXAKNMfFTu+u/Lk5f6OLQ==",
-			"dev": true,
-			"dependencies": {
-				"app-path": "^3.2.0",
-				"plist": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/jed": {
 			"version": "1.1.1",
 			"integrity": "sha1-elSbvZ/+FYWwzQoZHiAwVb7ldLQ="
@@ -13687,59 +13619,6 @@
 			},
 			"engines": {
 				"node": ">=8.0"
-			}
-		},
-		"node_modules/jest-image-snapshot": {
-			"version": "4.2.0",
-			"integrity": "sha512-6aAqv2wtfOgxiJeBayBCqHo1zX+A12SUNNzo7rIxiXh6W6xYVu8QyHWkada8HeRi+QUTHddp0O0Xa6kmQr+xbQ==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^1.1.3",
-				"get-stdin": "^5.0.1",
-				"glur": "^1.1.2",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"pixelmatch": "^5.1.0",
-				"pngjs": "^3.4.0",
-				"rimraf": "^2.6.2",
-				"ssim.js": "^3.1.1"
-			},
-			"engines": {
-				"node": ">= 10.14.2"
-			},
-			"peerDependencies": {
-				"jest": ">=20 <=26"
-			}
-		},
-		"node_modules/jest-image-snapshot/node_modules/ansi-styles": {
-			"version": "2.2.1",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/jest-image-snapshot/node_modules/chalk": {
-			"version": "1.1.3",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/jest-image-snapshot/node_modules/supports-color": {
-			"version": "2.0.0",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/jest-jasmine2": {
@@ -19207,25 +19086,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/pixelmatch": {
-			"version": "5.2.1",
-			"integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
-			"dev": true,
-			"dependencies": {
-				"pngjs": "^4.0.1"
-			},
-			"bin": {
-				"pixelmatch": "bin/pixelmatch"
-			}
-		},
-		"node_modules/pixelmatch/node_modules/pngjs": {
-			"version": "4.0.1",
-			"integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/pkg-dir": {
 			"version": "3.0.0",
 			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
@@ -19298,50 +19158,10 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/plist": {
-			"version": "3.0.2",
-			"integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
-			"dev": true,
-			"dependencies": {
-				"base64-js": "^1.5.1",
-				"xmlbuilder": "^9.0.7",
-				"xmldom": "^0.5.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/plist/node_modules/base64-js": {
-			"version": "1.5.1",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/pn": {
 			"version": "1.1.0",
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
 			"dev": true
-		},
-		"node_modules/pngjs": {
-			"version": "3.4.0",
-			"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0.0"
-			}
 		},
 		"node_modules/popper.js": {
 			"version": "1.16.1",
@@ -21338,11 +21158,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/ssim.js": {
-			"version": "3.5.0",
-			"integrity": "sha512-Aj6Jl2z6oDmgYFFbQqK7fght19bXdOxY7Tj03nF+03M9gCBAjeIiO8/PlEGMfKDwYpw4q6iBqVq2YuREorGg/g==",
-			"dev": true
-		},
 		"node_modules/ssri": {
 			"version": "6.0.2",
 			"integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
@@ -22946,43 +22761,6 @@
 			"version": "4.0.0",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/term-img": {
-			"version": "4.1.0",
-			"integrity": "sha512-DFpBhaF5j+2f7kheKFc1ajsAUUDGOaNPpKPtiIMxlbfud6mvfFZuWGnTRpaujUa5J7yl6cIw/h6nyr4mSsENPg==",
-			"dev": true,
-			"dependencies": {
-				"ansi-escapes": "^4.1.0",
-				"iterm2-version": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/term-img/node_modules/ansi-escapes": {
-			"version": "4.3.2",
-			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.21.3"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/term-img/node_modules/type-fest": {
-			"version": "0.21.3",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/terminal-link": {
 			"version": "2.1.1",
@@ -24901,26 +24679,10 @@
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
 		},
-		"node_modules/xmlbuilder": {
-			"version": "9.0.7",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/xmlchars": {
 			"version": "2.2.0",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
-		},
-		"node_modules/xmldom": {
-			"version": "0.5.0",
-			"integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			}
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
@@ -29207,14 +28969,6 @@
 				}
 			}
 		},
-		"app-path": {
-			"version": "3.2.0",
-			"integrity": "sha512-PQPaKXi64FZuofJkrtaO3I5RZESm9Yjv7tkeJaDz4EZMeBBfGtr5MyQ3m5AC7F0HVrISBLatPxAAAgvbe418fQ==",
-			"dev": true,
-			"requires": {
-				"execa": "^1.0.0"
-			}
-		},
 		"aproba": {
 			"version": "1.2.0",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
@@ -31494,19 +31248,6 @@
 				}
 			}
 		},
-		"cypress-image-snapshot": {
-			"version": "4.0.1",
-			"integrity": "sha512-PBpnhX/XItlx3/DAk5ozsXQHUi72exybBNH5Mpqj1DVmjq+S5Jd9WE5CRa4q5q0zuMZb2V2VpXHth6MjFpgj9Q==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.1",
-				"fs-extra": "^7.0.1",
-				"glob": "^7.1.3",
-				"jest-image-snapshot": "4.2.0",
-				"pkg-dir": "^3.0.0",
-				"term-img": "^4.0.0"
-			}
-		},
 		"dash-ast": {
 			"version": "1.0.0",
 			"integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
@@ -33241,16 +32982,6 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
-		"fs-extra": {
-			"version": "7.0.1",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			}
-		},
 		"fs-minipass": {
 			"version": "2.1.0",
 			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
@@ -33336,11 +33067,6 @@
 		"get-package-type": {
 			"version": "0.1.0",
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-			"dev": true
-		},
-		"get-stdin": {
-			"version": "5.0.1",
-			"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
 			"dev": true
 		},
 		"get-stream": {
@@ -33482,11 +33208,6 @@
 				"lodash": "~4.17.10",
 				"minimatch": "~3.0.2"
 			}
-		},
-		"glur": {
-			"version": "1.1.2",
-			"integrity": "sha1-8g6jbbEDv8KSNDkh8fkeg8NGdok=",
-			"dev": true
 		},
 		"gonzales-pe": {
 			"version": "4.3.0",
@@ -34487,15 +34208,6 @@
 			"requires": {
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
-			}
-		},
-		"iterm2-version": {
-			"version": "4.2.0",
-			"integrity": "sha512-IoiNVk4SMPu6uTcK+1nA5QaHNok2BMDLjSl5UomrOixe5g4GkylhPwuiGdw00ysSCrXAKNMfFTu+u/Lk5f6OLQ==",
-			"dev": true,
-			"requires": {
-				"app-path": "^3.2.0",
-				"plist": "^3.0.1"
 			}
 		},
 		"jed": {
@@ -35706,46 +35418,6 @@
 					"requires": {
 						"is-number": "^7.0.0"
 					}
-				}
-			}
-		},
-		"jest-image-snapshot": {
-			"version": "4.2.0",
-			"integrity": "sha512-6aAqv2wtfOgxiJeBayBCqHo1zX+A12SUNNzo7rIxiXh6W6xYVu8QyHWkada8HeRi+QUTHddp0O0Xa6kmQr+xbQ==",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"get-stdin": "^5.0.1",
-				"glur": "^1.1.2",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"pixelmatch": "^5.1.0",
-				"pngjs": "^3.4.0",
-				"rimraf": "^2.6.2",
-				"ssim.js": "^3.1.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
 				}
 			}
 		},
@@ -39573,21 +39245,6 @@
 				"node-modules-regexp": "^1.0.0"
 			}
 		},
-		"pixelmatch": {
-			"version": "5.2.1",
-			"integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
-			"dev": true,
-			"requires": {
-				"pngjs": "^4.0.1"
-			},
-			"dependencies": {
-				"pngjs": {
-					"version": "4.0.1",
-					"integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
-					"dev": true
-				}
-			}
-		},
 		"pkg-dir": {
 			"version": "3.0.0",
 			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
@@ -39638,31 +39295,9 @@
 				"find-up": "^2.1.0"
 			}
 		},
-		"plist": {
-			"version": "3.0.2",
-			"integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
-			"dev": true,
-			"requires": {
-				"base64-js": "^1.5.1",
-				"xmlbuilder": "^9.0.7",
-				"xmldom": "^0.5.0"
-			},
-			"dependencies": {
-				"base64-js": {
-					"version": "1.5.1",
-					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-					"dev": true
-				}
-			}
-		},
 		"pn": {
 			"version": "1.1.0",
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-			"dev": true
-		},
-		"pngjs": {
-			"version": "3.4.0",
-			"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
 			"dev": true
 		},
 		"popper.js": {
@@ -41177,11 +40812,6 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
-		"ssim.js": {
-			"version": "3.5.0",
-			"integrity": "sha512-Aj6Jl2z6oDmgYFFbQqK7fght19bXdOxY7Tj03nF+03M9gCBAjeIiO8/PlEGMfKDwYpw4q6iBqVq2YuREorGg/g==",
-			"dev": true
-		},
 		"ssri": {
 			"version": "6.0.2",
 			"integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
@@ -42352,30 +41982,6 @@
 				"yallist": {
 					"version": "4.0.0",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
-				}
-			}
-		},
-		"term-img": {
-			"version": "4.1.0",
-			"integrity": "sha512-DFpBhaF5j+2f7kheKFc1ajsAUUDGOaNPpKPtiIMxlbfud6mvfFZuWGnTRpaujUa5J7yl6cIw/h6nyr4mSsENPg==",
-			"dev": true,
-			"requires": {
-				"ansi-escapes": "^4.1.0",
-				"iterm2-version": "^4.1.0"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "4.3.2",
-					"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.21.3"
-					}
-				},
-				"type-fest": {
-					"version": "0.21.3",
-					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 					"dev": true
 				}
 			}
@@ -43826,19 +43432,9 @@
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
 		},
-		"xmlbuilder": {
-			"version": "9.0.7",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-			"dev": true
-		},
 		"xmlchars": {
 			"version": "2.2.0",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-			"dev": true
-		},
-		"xmldom": {
-			"version": "0.5.0",
-			"integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
 			"dev": true
 		},
 		"xtend": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"babel-loader": "~8.2.2",
 		"clean-webpack-plugin": "~3.0.0",
 		"css-loader": "~5.2.7",
-		"cypress": "~7.5.0",
+		"cypress": "~9.2.0",
 		"eslint": "~6.8.0",
 		"eslint-config-standard": "~14.1.1",
 		"eslint-friendly-formatter": "~4.0.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
 		"clean-webpack-plugin": "~3.0.0",
 		"css-loader": "~5.2.7",
 		"cypress": "~7.5.0",
-		"cypress-image-snapshot": "~4.0.1",
 		"eslint": "~6.8.0",
 		"eslint-config-standard": "~14.1.1",
 		"eslint-friendly-formatter": "~4.0.1",


### PR DESCRIPTION
* Target version: stable22
* Backport removal of `cypress-image-snapshot`.
* Update cypress to latest.

This will allow using the new session feature in our tests.

