### PR TITLE
Trigger cypress on push/pull_request

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,6 +1,11 @@
 name: Cypress
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable*
 
 env:
   APP_NAME: text


### PR DESCRIPTION
Cypress workflow runs seemed to fail since the merge of #2026 on dependabot pull requests, the only noticable difference was the events that trigger them compared to https://github.com/nextcloud/viewer/blob/master/.github/workflows/cypress.yml, so this should hopefully let github actions pass the record key again also on dependabot pull request.