### PR TITLE
Remove test routine from Makefile all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # later. See the COPYING file.
 app_name=$(notdir $(CURDIR))
 
-all: dev-setup lint build-js-production test
+all: dev-setup lint build-js-production
 
 # Dev env management
 dev-setup: clean clean-dev npm-init


### PR DESCRIPTION
### Steps

1. Clone the repo
2. Read the README and feel happy that there's a Makefile with an easy build step
3. Run `make`
4. Wait with excitement for the build to finish
5. Switch away as JS compilation is taking a while
6. Return after coffee

### Expected result
No test is run after buildling

### Actual result
Be surprised to see that docker is busy downloading some images

### Notes
This already caught me by surprise several times so I took the liberty to remove that step.
If it was intended to be part of "test before releasing" then maybe a "dist" target would be more suitable to include the test part before buildling the release tarball ?

