### PR TITLE
composer: Specify php version so dependabot respects it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
             "email": "jus@bitgrid.net"
         }
     ],
-    "require": {},
+    "require": {
+      "php": "^7.3|^8.0"
+    },
     "scripts": {
       "lint": "find . -name \\*.php -not -path './vendor/*' -print0 | xargs -0 -n1 php -l",
       "cs:check": "php-cs-fixer fix --dry-run --diff",


### PR DESCRIPTION
Dependabot just came up with an invalid composer.lock for php 7.3.
It picks the lowest version requirement from composer.json
and selects the dependencies based upon that.

Specify our php versions so Dependabot can take them into account.

Signed-off-by: Max <max@nextcloud.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


