### PR TITLE
fix: use BRANCH when checking out viewer

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -2,6 +2,7 @@ FROM nextcloudci/server:server-17
 
 RUN mkdir /var/www/html/data
 RUN chown -R www-data:www-data /var/www/html/data
+ENV BRANCH master
 
 ENTRYPOINT /usr/local/bin/initAndRun.sh
 

--- a/cypress/server.sh
+++ b/cypress/server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-git clone https://github.com/nextcloud/viewer /var/www/html/apps/viewer
+git clone https://github.com/nextcloud/viewer --branch $BRANCH /var/www/html/apps/viewer
 su www-data -c "
 php occ config:system:set force_language --value en
 php /var/www/html/occ app:enable viewer


### PR DESCRIPTION
Use the viewer that fits the nextcloud release.

Currently cypress tests are failing for all branches
even though the cause seems to be a recent commit to viewers stable branch.

Cypress runs for the stable23 branch of text
should use the stable23 branch of server
and the stable23 branch of viewer
so they match the actual releases that will go out.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


