### PR TITLE
Bump cypress from 9.2.1 to 9.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
 				"@vue/test-utils": "^1.3.0",
 				"@vue/vue2-jest": "^27.0.0-alpha.4",
 				"babel-core": "^7.0.0-bridge.0",
-				"cypress": "^9.2.1",
+				"cypress": "^9.3.1",
 				"cypress-file-upload": "^5.0.8",
 				"jest": "^27.4.7",
 				"jest-environment-jsdom": "^27.4.6",
@@ -3683,9 +3683,9 @@
 			}
 		},
 		"node_modules/@types/sinonjs__fake-timers": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-			"integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+			"integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
 			"dev": true
 		},
 		"node_modules/@types/sizzle": {
@@ -6729,20 +6729,21 @@
 			"dev": true
 		},
 		"node_modules/cypress": {
-			"version": "9.2.1",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-9.2.1.tgz",
-			"integrity": "sha512-LVEe4yWCo4xO0Vd8iYjFHRyd5ulRvM56XqMgAdn05Qb9kJ6iJdO/MmjKD8gNd768698cp1FDuSmFQZHVZGk+Og==",
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-9.3.1.tgz",
+			"integrity": "sha512-BODdPesxX6bkVUnH8BVsV8I/jn57zQtO1FEOUTiuG2us3kslW7g0tcuwiny7CKCmJUZz8S/D587ppC+s58a+5Q==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
 				"@cypress/request": "^2.88.10",
 				"@cypress/xvfb": "^1.2.4",
 				"@types/node": "^14.14.31",
-				"@types/sinonjs__fake-timers": "^6.0.2",
+				"@types/sinonjs__fake-timers": "8.1.1",
 				"@types/sizzle": "^2.3.2",
 				"arch": "^2.2.0",
 				"blob-util": "^2.0.2",
-				"bluebird": "3.7.2",
+				"bluebird": "^3.7.2",
+				"buffer": "^5.6.0",
 				"cachedir": "^2.3.0",
 				"chalk": "^4.1.0",
 				"check-more-types": "^2.24.0",
@@ -6809,6 +6810,30 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/cypress/node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
 			}
 		},
 		"node_modules/cypress/node_modules/chalk": {
@@ -23554,9 +23579,9 @@
 			}
 		},
 		"@types/sinonjs__fake-timers": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-			"integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+			"integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
 			"dev": true
 		},
 		"@types/sizzle": {
@@ -26047,19 +26072,20 @@
 			}
 		},
 		"cypress": {
-			"version": "9.2.1",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-9.2.1.tgz",
-			"integrity": "sha512-LVEe4yWCo4xO0Vd8iYjFHRyd5ulRvM56XqMgAdn05Qb9kJ6iJdO/MmjKD8gNd768698cp1FDuSmFQZHVZGk+Og==",
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-9.3.1.tgz",
+			"integrity": "sha512-BODdPesxX6bkVUnH8BVsV8I/jn57zQtO1FEOUTiuG2us3kslW7g0tcuwiny7CKCmJUZz8S/D587ppC+s58a+5Q==",
 			"dev": true,
 			"requires": {
 				"@cypress/request": "^2.88.10",
 				"@cypress/xvfb": "^1.2.4",
 				"@types/node": "^14.14.31",
-				"@types/sinonjs__fake-timers": "^6.0.2",
+				"@types/sinonjs__fake-timers": "8.1.1",
 				"@types/sizzle": "^2.3.2",
 				"arch": "^2.2.0",
 				"blob-util": "^2.0.2",
-				"bluebird": "3.7.2",
+				"bluebird": "^3.7.2",
+				"buffer": "^5.6.0",
 				"cachedir": "^2.3.0",
 				"chalk": "^4.1.0",
 				"check-more-types": "^2.24.0",
@@ -26102,6 +26128,16 @@
 					"dev": true,
 					"requires": {
 						"color-convert": "^2.0.1"
+					}
+				},
+				"buffer": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.1.13"
 					}
 				},
 				"chalk": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"@vue/test-utils": "^1.3.0",
 		"@vue/vue2-jest": "^27.0.0-alpha.4",
 		"babel-core": "^7.0.0-bridge.0",
-		"cypress": "^9.2.1",
+		"cypress": "^9.3.1",
 		"cypress-file-upload": "^5.0.8",
 		"jest": "^27.4.7",
 		"jest-environment-jsdom": "^27.4.6",


### PR DESCRIPTION
#2122 was not picked up by drone... let's see if this will be.

Bumps [cypress](https://github.com/cypress-io/cypress) from 9.2.1 to 9.3.1.
- [Release notes](https://github.com/cypress-io/cypress/releases)
- [Changelog](https://github.com/cypress-io/cypress/blob/develop/.releaserc.base.js)
- [Commits](https://github.com/cypress-io/cypress/compare/v9.2.1...v9.3.1)

---
updated-dependencies:
- dependency-name: cypress
  dependency-type: direct:development
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>
