### PR TITLE
ci: increase cypress default command timeout

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -100,7 +100,7 @@ jobs:
           parallel: false
           wait-on: '${{ env.CYPRESS_baseUrl }}'
           working-directory: 'apps/${{ env.APP_NAME }}'
-          config: video=false
+          config: defaultCommandTimeout=10000,video=false
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 


### PR DESCRIPTION
Prevent timeouts due to slow CI runs by waiting longer for normal commands.

Some of our commands open the editor which has to load quite a bit of additional javascript.
This can be slow on CI.
Instead of failing after 4 seconds - wait 10 seconds when run in CI.

Signed-off-by: Max <max@nextcloud.com>

* Target version: master 


