### PR TITLE
Allow linking to directories in addition to linking to files.

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -450,7 +450,7 @@ export default {
 						href,
 					})
 				})
-			}, false, [], true, undefined, this.linkPath)
+			}, false, [], true, undefined, this.linkPath, { allowDirectoryChooser: true })
 		},
 		optimalPathTo(targetFile) {
 			const absolutePath = targetFile.split('/')

--- a/src/components/MenuBubble.vue
+++ b/src/components/MenuBubble.vue
@@ -151,10 +151,14 @@ export default {
 				client.getFileInfo(file).then((_status, fileInfo) => {
 					const path = optimalPath(this.filePath, `${fileInfo.path}/${fileInfo.name}`)
 					const encodedPath = path.split('/').map(encodeURIComponent).join('/')
-					command({ href: `${encodedPath}?fileId=${fileInfo.id}` })
+					if (fileInfo.mimetype === 'httpd/unix-directory') {
+						command({ href: `${encodedPath}/?fileId=${fileInfo.id}` })
+					} else {
+						command({ href: `${encodedPath}?fileId=${fileInfo.id}` })
+					}
 					this.hideLinkMenu()
 				})
-			}, false, [], true, undefined, startPath)
+			}, false, [], true, undefined, startPath, { allowDirectoryChooser: true })
 		},
 		setLinkUrl(command, url) {
 			// Heuristics for determining if we need a https:// prefix.

--- a/src/helpers/links.js
+++ b/src/helpers/links.js
@@ -59,8 +59,13 @@ const domHref = function(node) {
 	if (match) {
 		const [, relPath, id] = match
 		const currentDir = basedir(OCA.Viewer.file)
-		const dir = absolutePath(currentDir, basedir(relPath))
-		return generateUrl(`/apps/files/?dir=${dir}&openfile=${id}#relPath=${relPath}`)
+		if (relPath.slice(-1) === '/') {
+			const dir = absolutePath(currentDir, relPath)
+			return generateUrl(`/apps/files/?dir=${dir}&openfile=${id}`)
+		} else {
+			const dir = absolutePath(currentDir, basedir(relPath))
+			return generateUrl(`/apps/files/?dir=${dir}&openfile=${id}#relPath=${relPath}`)
+		}
 	}
 }
 


### PR DESCRIPTION
The link syntax supported is:

```
[LINK_TEXT_AS_NORMAL](RELATIVE/PATH/WITH/TRAILING/SLASH/?fileId=FILE_ID_OF_DIRECTORY)
```

In the current implementation clicking on the link leads to a new tab or
window where the linked directory is shown.

The difference to the syntax for ordinary files is just the missing
file-name at the end.


* Resolves: #2162
* Target version: master 

### Summary


