### PR TITLE
Fix Cypress image tests

### DIFF
--- a/cypress/integration/images.spec.js
+++ b/cypress/integration/images.spec.js
@@ -161,10 +161,7 @@ describe('Test all image insertion methods', () => {
 		})
 	})
 
-	it('Close the editor and delete the user', () => {
-		cy.openFile('test.md')
-		cy.get('#viewer .modal-header button.header-close').click()
-		cy.get('#viewer').should('not.exist')
+	it('Delete the user', () => {
 		cy.nextcloudDeleteUser(randUser, 'password')
 	})
 


### PR DESCRIPTION
Don't open the viewer before deleting the user in images cypress tests. This can cause an editor sync failure right after the test user has been deleted which makes the test fails.

