### PR TITLE
[stable23] fix: update psalm baseline to account for changes in server

### DIFF
--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,27 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.x-dev@">
   <file src="lib/AppInfo/Application.php">
+    <InvalidArgument occurrences="1">
+      <code>RegisterDirectEditorEventListener::class</code>
+    </InvalidArgument>
     <UndefinedClass occurrences="3">
       <code>BeforeTemplateRenderedEvent</code>
       <code>LoadAdditionalScriptsEvent</code>
       <code>LoadViewer</code>
     </UndefinedClass>
   </file>
-  <file src="lib/Command/ResetDocument.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>void</code>
-    </ImplementedReturnTypeMismatch>
-  </file>
   <file src="lib/Controller/DirectSessionController.php">
     <UndefinedClass occurrences="1">
       <code>InvalidTokenException</code>
     </UndefinedClass>
-  </file>
-  <file src="lib/Controller/PublicSessionController.php">
-    <InvalidCatch occurrences="1"/>
-    <MissingDependency occurrences="1">
-      <code>ShareNotFound</code>
-    </MissingDependency>
   </file>
   <file src="lib/Controller/SettingsController.php">
     <UndefinedThisPropertyAssignment occurrences="1">
@@ -32,32 +24,20 @@
     </UndefinedThisPropertyFetch>
   </file>
   <file src="lib/Controller/WorkspaceController.php">
-    <InvalidCatch occurrences="2"/>
     <InvalidReturnType occurrences="3">
       <code>DataResponse</code>
       <code>DataResponse</code>
       <code>DataResponse</code>
     </InvalidReturnType>
-    <MissingDependency occurrences="9">
-      <code>$e</code>
-      <code>$e</code>
+    <MissingDependency occurrences="4">
       <code>$this-&gt;rootFolder</code>
       <code>$this-&gt;rootFolder</code>
       <code>IRootFolder</code>
       <code>IRootFolder</code>
-      <code>ShareNotFound</code>
-      <code>StorageNotAvailableException</code>
-      <code>StorageNotAvailableException</code>
     </MissingDependency>
-    <UndefinedClass occurrences="1">
-      <code>Exception</code>
-    </UndefinedClass>
     <UndefinedInterfaceMethod occurrences="1">
       <code>open</code>
     </UndefinedInterfaceMethod>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;logger</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="lib/DAV/WorkspacePlugin.php">
     <UndefinedClass occurrences="1">
@@ -65,7 +45,9 @@
     </UndefinedClass>
   </file>
   <file src="lib/Db/SessionMapper.php">
-    <MoreSpecificImplementedParamType occurrences="1"/>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>Session update(Session $session)</code>
+    </MoreSpecificImplementedParamType>
   </file>
   <file src="lib/Db/StepMapper.php">
     <InvalidReturnStatement occurrences="1"/>
@@ -100,19 +82,14 @@
     <UndefinedDocblockClass occurrences="1"/>
   </file>
   <file src="lib/Service/DocumentService.php">
-    <InvalidCatch occurrences="3"/>
     <InvalidScalarArgument occurrences="1"/>
     <MismatchingDocblockReturnType occurrences="1">
       <code>Entity</code>
     </MismatchingDocblockReturnType>
-    <MissingDependency occurrences="7">
+    <MissingDependency occurrences="3">
       <code>$this-&gt;rootFolder</code>
       <code>IRootFolder</code>
       <code>IRootFolder</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
     </MissingDependency>
     <UndefinedClass occurrences="2">
       <code>File</code>
@@ -167,9 +144,6 @@
     <InvalidNullableReturnType occurrences="1">
       <code>\OCP\Files\File</code>
     </InvalidNullableReturnType>
-    <MissingDependency occurrences="1">
-      <code>StorageNotAvailableException</code>
-    </MissingDependency>
     <NullableReturnStatement occurrences="1">
       <code>null</code>
     </NullableReturnStatement>


### PR DESCRIPTION
https://github.com/nextcloud/server/commit/003f2b59c92fa5a9455ddacea11ee0d66c828f5b changed the types psalm expects and thus triggered an error not yet recorded in the baseline.
Signed-off-by: Max <max@nextcloud.com>

