### PR TITLE
Allow pasting an image from the clipboard

### DIFF
--- a/src/components/EditorWrapper.vue
+++ b/src/components/EditorWrapper.vue
@@ -37,6 +37,7 @@
 			<div v-if="tiptap"
 				id="editor"
 				:class="{ draggedOver }"
+				@image-paste="onPaste"
 				@dragover.prevent.stop="draggedOver = true"
 				@dragleave.prevent.stop="draggedOver = false"
 				@drop.prevent.stop="onEditorDrop">
@@ -565,6 +566,9 @@ export default {
 
 		hideHelp() {
 			this.displayHelp = false
+		},
+		onPaste(e) {
+			this.uploadImageFiles(e.detail.files)
 		},
 		onEditorDrop(e) {
 			this.uploadImageFiles(e.dataTransfer.files)

--- a/src/nodes/Image.js
+++ b/src/nodes/Image.js
@@ -21,6 +21,7 @@
  */
 
 import TiptapImage from '@tiptap/extension-image'
+import { Plugin } from 'prosemirror-state'
 import ImageView from './ImageView'
 import { VueNodeViewRenderer } from '@tiptap/vue-2'
 
@@ -37,6 +38,29 @@ const Image = TiptapImage.extend({
 
 	addNodeView() {
 		return VueNodeViewRenderer(ImageView)
+	},
+
+	addProseMirrorPlugins() {
+		return [
+			new Plugin({
+				props: {
+					handlePaste: (view, event, slice) => {
+						// only prevent the paste if it contains files
+						if (event.clipboardData.files && event.clipboardData.files.length > 0) {
+							// let the editor wrapper catch this custom event
+							const customEvent = new CustomEvent('image-paste', {
+								bubbles: true,
+								detail: {
+									files: event.clipboardData.files,
+								},
+							})
+							event.target.dispatchEvent(customEvent)
+							return true
+						}
+					},
+				},
+			}),
+		]
 	},
 
 })


### PR DESCRIPTION
Let's include that in the image drag'n'drop #2264 

This handles the case in which the paste event also contains some text (like when the image is copied from the EyeOfGnome image viewer). The text is ignored and not pasted.

The logic is to catch the event in the Image prosemirror plugin, prevent it and dispatch a bubbled custom one for the editor wrapper which performs the upload.

This could alternatively be done anywhere else, in any other Node, we could extend the Text one for example.