### PR TITLE
npm: remove our own dependency on entities.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
 				"@tiptap/suggestion": "^2.0.0-beta.90",
 				"@tiptap/vue-2": "^2.0.0-beta.69",
 				"core-js": "^3.21.1",
-				"entities": "^3.0.1",
 				"escape-html": "^1.0.3",
 				"highlight.js": "^10.7.2",
 				"lowlight": "^1.20.0",
@@ -8262,6 +8261,8 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
 			"integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -27780,7 +27781,9 @@
 		"entities": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-			"integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+			"integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+			"dev": true,
+			"peer": true
 		},
 		"envinfo": {
 			"version": "7.8.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
 		"@tiptap/suggestion": "^2.0.0-beta.90",
 		"@tiptap/vue-2": "^2.0.0-beta.69",
 		"core-js": "^3.21.1",
-		"entities": "^3.0.1",
 		"escape-html": "^1.0.3",
 		"highlight.js": "^10.7.2",
 		"lowlight": "^1.20.0",


### PR DESCRIPTION
It was introduced in b757b003c
to make sure we use entities >2.0 to satisfy some dependencies.

But we do not depend on it ourselves.

Signed-off-by: Max <max@nextcloud.com>


* Superseeds #2282 
* Target version: master 


