### PR TITLE
Adapt cypress login command to small change in login page

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -33,7 +33,7 @@ Cypress.Commands.add('login', (user, password, { route, onBeforeLoad } = {}) => 
 		cy.visit(route)
 		cy.get('input[name=user]').type(user)
 		cy.get('input[name=password]').type(password)
-		cy.get('#submit-wrapper input[type=submit]').click()
+		cy.get('.submit-wrapper input[type=submit]').click()
 		cy.url().should('include', route)
 	})
 	// in case the session already existed but we are on a different route...


### PR DESCRIPTION
In the login page, `submit-wrapper` is no longer an ID but a class.


