### PR TITLE
Fix workspace cypress test with narrow pages

### DIFF
--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -59,11 +59,11 @@ describe('Workspace', function() {
 			['strike', 's'],
 		].forEach(([button, tag]) => {
 			menuButton(button)
-				.click()
+				.click({ force: true })
 				.should('have.class', 'is-active')
 			cy.get(`.ProseMirror ${tag}`).should('contain', 'Format me')
 			menuButton(button)
-				.click()
+				.click({ force: true })
 				.should('not.have.class', 'is-active')
 		})
 	})


### PR DESCRIPTION
Force click on menu buttons so it works when they are hidden (in the dropdown).
