### PR TITLE
Fix cypress tests on stable24

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,7 +23,7 @@ jobs:
         # containers: [1, 2, 3]
         php-versions: [ '7.4' ]
         databases: [ 'sqlite' ]
-        server-versions: [ 'master' ]
+        server-versions: [ 'stable24' ]
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}

--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -59,11 +59,11 @@ describe('Workspace', function() {
 			['strike', 's'],
 		].forEach(([button, tag]) => {
 			menuButton(button)
-				.click()
+				.click({ force: true })
 				.should('have.class', 'is-active')
 			cy.get(`.ProseMirror ${tag}`).should('contain', 'Format me')
 			menuButton(button)
-				.click()
+				.click({ force: true })
 				.should('not.have.class', 'is-active')
 		})
 	})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -33,7 +33,7 @@ Cypress.Commands.add('login', (user, password, { route, onBeforeLoad } = {}) => 
 		cy.visit(route)
 		cy.get('input[name=user]').type(user)
 		cy.get('input[name=password]').type(password)
-		cy.get('.submit-wrapper input[type=submit]').click()
+		cy.get('#submit-wrapper input[type=submit]').click()
 		cy.url().should('include', route)
 	})
 	// in case the session already existed but we are on a different route...


### PR DESCRIPTION
- Revert "adapt cypress login command to small change in 25"
- Use stable24 branch in cypress tests


* Resolves: # <!-- related github issue -->
* Target version: stable24

### Summary


