### PR TITLE
ci: only run php unit tests when php files changed

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,10 +2,26 @@ name: PHPUnit
 
 on:
   pull_request:
+    paths:
+      - .github/workflows/phpunit.yml
+      - appinfo/**
+      - composer.*
+      - lib/**
+      - psalm.xml
+      - templates/**
+      - tests/**
   push:
     branches:
       - master
       - stable*
+    paths:
+      - .github/workflows/phpunit.yml
+      - appinfo/**
+      - composer.*
+      - lib/**
+      - psalm.xml
+      - templates/**
+      - tests/**
 
 env:
   APP_NAME: text


### PR DESCRIPTION
They take 10 minutes to setup nextcloud
and block available CI runners.

This is particularly wasteful with javascript dependency updates.
Dependabot will rebase the pending updates
upon every push to the underlying branch.

Signed-off-by: Max <max@nextcloud.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


