### PR TITLE
cleanup: explicit dependency on jest-environment-jsdom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,6 @@
 				"eslint-plugin-promise": "^6.0.0",
 				"eslint-plugin-vue": "^8.7.1",
 				"jest": "^27.5.1",
-				"jest-environment-jsdom": "^27.5.1",
 				"jest-raw-loader": "^1.0.1",
 				"jest-serializer-vue": "^2.0.2",
 				"regenerator-runtime": "^0.13.9",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
 		"eslint-plugin-promise": "^6.0.0",
 		"eslint-plugin-vue": "^8.7.1",
 		"jest": "^27.5.1",
-		"jest-environment-jsdom": "^27.5.1",
 		"jest-raw-loader": "^1.0.1",
 		"jest-serializer-vue": "^2.0.2",
 		"regenerator-runtime": "^0.13.9",


### PR DESCRIPTION
It is included by jest anyway.
So let's not manage its version separately.

* Target version: master 

This should prevent dependabot from trying to upgrade `jest-environment-jsdom` independently from jest itself like in #2352 