### PR TITLE
Use '(n)' suffix instead of timestamp prefix for uploaded image names

### DIFF
--- a/lib/Service/ImageService.php
+++ b/lib/Service/ImageService.php
@@ -152,7 +152,7 @@ class ImageService {
 			throw new NotPermittedException('No write permissions');
 		}
 		$saveDir = $this->getAttachmentDirectoryForFile($textFile, true);
-		$fileName = (string) time() . '-' . $newFileName;
+		$fileName = $this->getUniqueFileName($saveDir, $newFileName);
 		$savedFile = $saveDir->newFile($fileName, $newFileResource);
 		return [
 			'name' => $fileName,
@@ -179,7 +179,7 @@ class ImageService {
 		}
 		$textFile = $this->getTextFilePublic($documentId, $shareToken);
 		$saveDir = $this->getAttachmentDirectoryForFile($textFile, true);
-		$fileName = (string) time() . '-' . $newFileName;
+		$fileName = $this->getUniqueFileName($saveDir, $newFileName);
 		$savedFile = $saveDir->newFile($fileName, $newFileResource);
 		return [
 			'name' => $fileName,
@@ -221,7 +221,7 @@ class ImageService {
 	private function copyImageFile(File $imageFile, Folder $saveDir, File $textFile): array {
 		$mimeType = $imageFile->getMimeType();
 		if (in_array($mimeType, ImageController::IMAGE_MIME_TYPES, true)) {
-			$fileName = (string) time() . '-' . $imageFile->getName();
+			$fileName = $this->getUniqueFileName($saveDir, $imageFile->getName());
 			$targetPath = $saveDir->getPath() . '/' . $fileName;
 			$targetFile = $imageFile->copy($targetPath);
 			// get file type and name
@@ -234,6 +234,23 @@ class ImageService {
 		return [
 			'error' => 'Unsupported file type',
 		];
+	}
+
+	/**
+	 * Get unique file name in a directory. Add '(n)' suffix.
+	 * @param Folder $dir
+	 * @param string $fileName
+	 * @return string
+	 */
+	private function getUniqueFileName(Folder $dir, string $fileName): string {
+		$extension = pathinfo($fileName, PATHINFO_EXTENSION);
+		$counter = 1;
+		$uniqueFileName = $fileName;
+		while ($dir->nodeExists($uniqueFileName)) {
+			$counter++;
+			$uniqueFileName = preg_replace('/\.' . $extension . '$/', ' (' . $counter . ').' . $extension, $fileName);
+		}
+		return $uniqueFileName;
 	}
 
 	/**

--- a/lib/Service/ImageService.php
+++ b/lib/Service/ImageService.php
@@ -242,13 +242,20 @@ class ImageService {
 	 * @param string $fileName
 	 * @return string
 	 */
-	private function getUniqueFileName(Folder $dir, string $fileName): string {
+	public static function getUniqueFileName(Folder $dir, string $fileName): string {
 		$extension = pathinfo($fileName, PATHINFO_EXTENSION);
 		$counter = 1;
 		$uniqueFileName = $fileName;
-		while ($dir->nodeExists($uniqueFileName)) {
-			$counter++;
-			$uniqueFileName = preg_replace('/\.' . $extension . '$/', ' (' . $counter . ').' . $extension, $fileName);
+		if ($extension !== '') {
+			while ($dir->nodeExists($uniqueFileName)) {
+				$counter++;
+				$uniqueFileName = preg_replace('/\.' . $extension . '$/', ' (' . $counter . ').' . $extension, $fileName);
+			}
+		} else {
+			while ($dir->nodeExists($uniqueFileName)) {
+				$counter++;
+				$uniqueFileName = preg_replace('/$/', ' (' . $counter . ')', $fileName);
+			}
 		}
 		return $uniqueFileName;
 	}

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -4,6 +4,7 @@ namespace OCA\Text\Tests;
 
 use OCA\Text\AppInfo\Application;
 use OCA\Text\Service\ImageService;
+use OCP\Files\Folder;
 
 class TextTest extends \PHPUnit\Framework\TestCase {
 	public function testDummy() {
@@ -33,5 +34,41 @@ class TextTest extends \PHPUnit\Framework\TestCase {
 		foreach ($contentNames as $contentName) {
 			$this->assertContains($contentName, $computedNames);
 		}
+	}
+
+	public function testGetUniqueFileName() {
+		$fileNameList = [
+			'foo.png',
+			'bar',
+			'plop.png',
+			'plop (2).png',
+			'lala.png',
+			'lala (2).png',
+			'lala (3).png',
+			'yay.png',
+			'yay (2).png',
+			'yay (3).png',
+			'yay (5).png',
+			'file.ext.ext',
+		];
+
+		$folder = $this->createMock(Folder::class);
+		$folder->expects(self::any())
+			->method('nodeExists')
+			->willReturnCallback(function ($name) use ($fileNameList) {
+				return in_array($name, $fileNameList);
+			});
+
+		// files that do not exist yet
+		$this->assertEquals('doesNotExistYet', ImageService::getUniqueFileName($folder, 'doesNotExistYet'));
+		$this->assertEquals('doesNotExistYet.png', ImageService::getUniqueFileName($folder, 'doesNotExistYet.png'));
+
+		// files that already exist
+		$this->assertEquals('foo (2).png', ImageService::getUniqueFileName($folder, 'foo.png'));
+		$this->assertEquals('bar (2)', ImageService::getUniqueFileName($folder, 'bar'));
+		$this->assertEquals('plop (3).png', ImageService::getUniqueFileName($folder, 'plop.png'));
+		$this->assertEquals('lala (4).png', ImageService::getUniqueFileName($folder, 'lala.png'));
+		$this->assertEquals('yay (4).png', ImageService::getUniqueFileName($folder, 'yay.png'));
+		$this->assertEquals('file.ext (2).ext', ImageService::getUniqueFileName($folder, 'file.ext.ext'));
 	}
 }


### PR DESCRIPTION
refs #2338

If `foo.png` is uploaded but already exists in the attachment folder, file is named `foo (2).png`. If uploaded again, `foo (3).png`. And so on.