### PR TITLE
Fix attachment cleanup when file names contain parenthesis

### DIFF
--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -20,6 +20,7 @@ class TextTest extends \PHPUnit\Framework\TestCase {
 			'a](a.png',
 			',;:!?.§-_a_',
 			'a`a`.png',
+			'aaa (2).png',
 		];
 		$content = "some content\n";
 		foreach ($contentNames as $name) {


### PR DESCRIPTION
To reproduce the issue (and check it works fine this fix :grin:):
* create a new markdown document and open it
* upload the same image twice so the second one is named `image (2).png`
* close the document
* check if `image (2).png` has been deleted in the attachment folder

The regex we were using did not match file names with parenthesis. The code is now a bit more complex but I couldn't find a way to make it work with one big single regex. So it first gets all the link targets and then filter to keep the `text://image?imageFileName=blabla.png` ones.

This should be backported to stable24 as it fixes #2338 .