### PR TITLE
[stable 24] ci: only run php unit tests when php files changed

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,10 +2,26 @@ name: PHPUnit
 
 on:
   pull_request:
+    paths:
+      - .github/workflows/phpunit.yml
+      - appinfo/**
+      - composer.*
+      - lib/**
+      - psalm.xml
+      - templates/**
+      - tests/**
   push:
     branches:
       - master
       - stable*
+    paths:
+      - .github/workflows/phpunit.yml
+      - appinfo/**
+      - composer.*
+      - lib/**
+      - psalm.xml
+      - templates/**
+      - tests/**
 
 env:
   APP_NAME: text


### PR DESCRIPTION
* Backports: #2356
* Target version: stable24

### Summary

They take 10 minutes to setup nextcloud
and block available CI runners.
    
This is particularly wasteful with javascript dependency updates.
Dependabot will rebase the pending updates
upon every push to the underlying branch.

Backport to stable24 since we get lot of updates for tiptap packages there.

