### PR TITLE
An empty string is a valid encoded result

### DIFF
--- a/cypress/e2e/viewer.spec.js
+++ b/cypress/e2e/viewer.spec.js
@@ -31,6 +31,7 @@ describe('Open test.md in viewer', function() {
 
 		// Upload test files
 		cy.uploadFile('test.md', 'text/markdown')
+		cy.uploadFile('empty.md', 'text/markdown')
 	})
 
 	beforeEach(function() {
@@ -58,6 +59,29 @@ describe('Open test.md in viewer', function() {
 		const editor = viewer.get('#editor .ProseMirror')
 		editor.should('contain', 'Hello world')
 		editor.get('h2').should('contain', 'Hello world')
+
+		cy.log('Inspect menubar')
+		cy.getActionEntry('undo').should('be.visible')
+		cy.getActionEntry('bold').should('be.visible')
+
+		cy.screenshot()
+	})
+
+	it('Open an empty file', function() {
+		cy.openFile('empty.md')
+
+		cy.log('Inspect viewer')
+		const viewer = cy.get('#viewer')
+		viewer.should('be.visible')
+			.and('have.class', 'modal-mask')
+			.and('not.have.class', 'icon-loading')
+		viewer.get('.modal-title').should('contain', 'empty.md')
+		viewer.get('.modal-header button.action-item__menutoggle')
+			.should('be.visible')
+
+		cy.log('Inspect editor')
+		const editor = viewer.get('#editor .ProseMirror')
+		editor.should('contain', '')
 
 		cy.log('Inspect menubar')
 		cy.getActionEntry('undo').should('be.visible')

--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -111,7 +111,7 @@ class ApiService {
 			$content = $baseFile->getContent();
 
 			$content = $this->encodingService->encodeToUtf8($content);
-			if (!$content) {
+			if ($content === null) {
 				$this->logger->log(ILogger::WARN, 'Failed to encode file to UTF8. File ID: ' . $file->getId());
 			}
 		} catch (NotFoundException $e) {

--- a/lib/Service/EncodingService.php
+++ b/lib/Service/EncodingService.php
@@ -42,7 +42,8 @@ class EncodingService {
 			return null;
 		}
 
-		return mb_convert_encoding($string, 'UTF-8', $encoding);
+		$encoded = mb_convert_encoding($string, 'UTF-8', $encoding);
+		return is_string($encoded) ? $encoded : null;
 	}
 
 	public function detectEncoding(string $string): ?string {

--- a/lib/TextFile.php
+++ b/lib/TextFile.php
@@ -63,7 +63,7 @@ class TextFile implements ISimpleFile {
 
 	public function getContent() {
 		$content = $this->encodingService->encodeToUtf8($this->file->getContent());
-		if (!$content) {
+		if ($content === null) {
 			throw new NotFoundException('File not compatible with text because it could not be encoded to UTF-8.');
 		}
 


### PR DESCRIPTION
Steps to reproduce on master:

- Have an empty empty file
- Open it


Otherwise PHP would consider the empty string a failed encoding.