### PR TITLE
package: expose ImageResolver so it can be provided to RichTextReader

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,17 +9,25 @@
   </head>
   <body>
     <div id="app"></div>
+	<script>
+	OC = { webroot: '/OC_WEBROOT' }
+	</script>
     <script type="module">
-	    import { RichTextReader } from './src/package.js'
+	    import { RichTextReader, ImageResolver, IMAGE_RESOLVER } from './src/package.js'
 		import Vue from 'vue'
+		import content from './src/tests/fixtures/basic.md?raw'
 		const app = new Vue({
 			data() {
 				return {
-					content: '**Hello There**',
+					content
 				}
 			},
-			provide: {
-				currentDirectory: '/'
+			provide() {
+				const val = {}
+				Object.defineProperties(val, {
+					[IMAGE_RESOLVER]: { get: () => this.$imageResolver },
+				})
+				return val
 			},
 			render: (h) => h('div', [
 				h('textarea', {
@@ -38,6 +46,14 @@
 					props: { content: app.content }
 				}),
 			]),
+			created() {
+				this.$imageResolver = new ImageResolver({
+					currentDirectory: '/dir/',
+					shareToken: 'SHARE_TOKEN',
+					user: { uid: 'USER_UID' },
+					fileId: '4173',
+				})
+			},
 		})
 	    app.$mount('#app')
     </script>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nextcloud/text",
 	"description": "Collaborative document editing",
-	"version": "25.0.0-alpha.5",
+	"version": "25.0.0-alpha.7",
 	"authors": [
 		{
 			"name": "Julius Härtl",

--- a/src/package.js
+++ b/src/package.js
@@ -21,5 +21,7 @@
 */
 
 import RichTextReader from './components/RichTextReader.vue'
+import ImageResolver from './services/ImageResolver.js'
+import { IMAGE_RESOLVER } from './components/EditorWrapper.provider.js'
 
-export { RichTextReader }
+export { RichTextReader, ImageResolver, IMAGE_RESOLVER }

--- a/src/tests/fixtures/basic.md
+++ b/src/tests/fixtures/basic.md
@@ -1,0 +1,11 @@
+**Hello There**
+
+# Heading
+
+[link](href)
+![image](src.png)
+
+
+|table| heading| row|
+| --- | --- | --- |
+|first| body| row|


### PR DESCRIPTION
* Target version: master 

### Summary

In order to resolve images correctly in various contexts the RichTextReader needs an ImageResolver. The ImageResolver implements a resolve function that turns a `src` attribute into a full url that can be retrieved from the server.

Texts `ImageResolver` is quite powerful and flexible. So let's expose it so it can be used by other apps such as collectives.

