### PR TITLE
text: fix cypress selector to find the right image

### DIFF
--- a/cypress/e2e/images.spec.js
+++ b/cypress/e2e/images.spec.js
@@ -79,11 +79,11 @@ const clickOnImageAction = (actionName) => {
  */
 const checkImage = (documentId, imageName, imageId, index) => {
 	const encodedName = fixedEncodeURIComponent(imageName)
+	const src = `.attachments.${documentId}/${encodedName}`
 
-	cy.log('Check the image is visible and well formed', { documentId, imageName, imageId, index, encodedName })
+	cy.log('Check the image is visible and well formed', documentId, imageName, imageId, index, encodedName)
 	return new Cypress.Promise((resolve, reject) => {
-		cy.get('#editor [data-component="image-view"]')
-			.filter('[data-src=".attachments.' + documentId + '/' + encodedName + '"]')
+		cy.get(`#editor [data-component="image-view"][data-src="${src}"]`)
 			.find('.image__view') // wait for load finish
 			.within(($el) => {
 				// keep track that we have created this image in the attachment dir


### PR DESCRIPTION
`get().filter()` might not take into account elements
that did not exist in the dom yet when the `get` part was fired.

`.filter()` would then wait for the elements that already existed
during `.get()` to contain the newly created image.

Signed-off-by: Max <max@nextcloud.com>

* Target version: master 
* fixes failures like https://github.com/nextcloud/text/runs/6966514212?check_suite_focus=true
