### PR TITLE
Fix/dav

### DIFF
--- a/cypress/e2e/propfind.spec.js
+++ b/cypress/e2e/propfind.spec.js
@@ -1,0 +1,89 @@
+/**
+ * @copyright Copyright (c) 2022 Max <max@nextcloud.com>
+ *
+ * @author Max <max@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { randHash } from '../utils/index.js'
+const randUser = randHash()
+
+describe('Text PROPFIND extension ', function() {
+	const richWorkspace = '{http://nextcloud.org/ns}rich-workspace'
+
+	before(function() {
+		cy.nextcloudCreateUser(randUser, 'password')
+	})
+
+	beforeEach(function() {
+		cy.login(randUser, 'password')
+	})
+
+	describe('with workspaces enabled', function() {
+
+		beforeEach(function() {
+			cy.configureText('workspace_enabled', 1)
+		})
+
+		// Android app relies on this to detect rich workspace availability
+		it('always adds rich workspace property', function() {
+			cy.uploadFile('empty.md', 'text/markdown', '/Readme.md')
+			cy.propfindFolder('/')
+				.should('have.property', richWorkspace, '')
+			cy.uploadFile('test.md', 'text/markdown', '/Readme.md')
+			cy.propfindFolder('/')
+				.should('have.property', richWorkspace, '## Hello world\n')
+			cy.removeFile('/Readme.md')
+			cy.propfindFolder('/')
+				.should('have.property', richWorkspace, '')
+		})
+
+		// Android app relies on this when navigating nested folders
+		it('adds rich workspace property to nested folders', function() {
+			cy.createFolder('/workspace')
+			cy.propfindFolder('/', 1)
+				.then(results => results.pop().propStat[0].properties)
+				.should('have.property', richWorkspace, '')
+			cy.uploadFile('test.md', 'text/markdown', '/workspace/Readme.md')
+			cy.propfindFolder('/', 1)
+				.then(results => results.pop().propStat[0].properties)
+				.should('have.property', richWorkspace, '## Hello world\n')
+		})
+
+	})
+
+	describe('with workspaces disabled', function() {
+
+		beforeEach(function() {
+			cy.configureText('workspace_enabled', 0)
+		})
+
+		it('does not return a rich workspace property', function() {
+			cy.propfindFolder('/')
+				.should('not.have.property', richWorkspace)
+			cy.uploadFile('test.md', 'text/markdown', '/Readme.md')
+			cy.propfindFolder('/')
+				.should('not.have.property', richWorkspace)
+			cy.createFolder('/without-workspace')
+			cy.propfindFolder('/', 1)
+				.then(results => results.pop().propStat[0].properties)
+				.should('not.have.property', richWorkspace)
+		})
+
+	})
+})

--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -98,8 +98,9 @@ class WorkspacePlugin extends ServerPlugin {
 		// Only return the property for the parent node and ignore it for further in depth nodes
 		if ($propFind->getDepth() === $this->server->getHTTPDepth(1)) {
 			$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($node) {
+				$owner = $this->userId ?? $node->getFileInfo()->getStorage()->getOwner('');
 				/** @var Folder[] $nodes */
-				$nodes = $this->rootFolder->getUserFolder($this->userId)->getById($node->getId());
+				$nodes = $this->rootFolder->getUserFolder($owner)->getById($node->getId());
 				if (count($nodes) > 0) {
 					/** @var File $file */
 					try {
@@ -121,7 +122,7 @@ class WorkspacePlugin extends ServerPlugin {
 					try {
 						$file = $this->workspaceService->getFile($nodes[0]);
 						if ($file instanceof File) {
-							return $file->getFileInfo()->getName();
+							return $file->getFileInfo()->getId();
 						}
 					} catch (StorageNotAvailableException $e) {
 						// If a storage is not available we can for the propfind response assume that there is no rich workspace present

--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -96,7 +96,7 @@ class WorkspacePlugin extends ServerPlugin {
 		}
 
 		// Only return the property for the parent node and ignore it for further in depth nodes
-		if ($propFind->getDepth() === $this->server->getHTTPDepth()) {
+		if ($propFind->getDepth() === $this->server->getHTTPDepth(1)) {
 			$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($node) {
 				/** @var Folder[] $nodes */
 				$nodes = $this->rootFolder->getUserFolder($this->userId)->getById($node->getId());

--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -96,40 +96,38 @@ class WorkspacePlugin extends ServerPlugin {
 		}
 
 		// Only return the property for the parent node and ignore it for further in depth nodes
-		if ($propFind->getDepth() === $this->server->getHTTPDepth(1)) {
-			$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($node) {
-				$owner = $this->userId ?? $node->getFileInfo()->getStorage()->getOwner('');
-				/** @var Folder[] $nodes */
-				$nodes = $this->rootFolder->getUserFolder($owner)->getById($node->getId());
-				if (count($nodes) > 0) {
-					/** @var File $file */
-					try {
-						$file = $this->workspaceService->getFile($nodes[0]);
-						if ($file instanceof File) {
-							return $file->getContent();
-						}
-					} catch (StorageNotAvailableException $e) {
-						// If a storage is not available we can for the propfind response assume that there is no rich workspace present
+		$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($node) {
+			$owner = $this->userId ?? $node->getFileInfo()->getStorage()->getOwner('');
+			/** @var Folder[] $nodes */
+			$nodes = $this->rootFolder->getUserFolder($owner)->getById($node->getId());
+			if (count($nodes) > 0) {
+				/** @var File $file */
+				try {
+					$file = $this->workspaceService->getFile($nodes[0]);
+					if ($file instanceof File) {
+						return $file->getContent();
 					}
+				} catch (StorageNotAvailableException $e) {
+					// If a storage is not available we can for the propfind response assume that there is no rich workspace present
 				}
-				return '';
-			});
-			$propFind->handle(self::WORKSPACE_FILE_PROPERTY, function () use ($node) {
-				/** @var Folder[] $nodes */
-				$nodes = $this->rootFolder->getUserFolder($this->userId)->getById($node->getId());
-				if (count($nodes) > 0) {
-					/** @var File $file */
-					try {
-						$file = $this->workspaceService->getFile($nodes[0]);
-						if ($file instanceof File) {
-							return $file->getFileInfo()->getId();
-						}
-					} catch (StorageNotAvailableException $e) {
-						// If a storage is not available we can for the propfind response assume that there is no rich workspace present
+			}
+			return '';
+		});
+		$propFind->handle(self::WORKSPACE_FILE_PROPERTY, function () use ($node) {
+			/** @var Folder[] $nodes */
+			$nodes = $this->rootFolder->getUserFolder($this->userId)->getById($node->getId());
+			if (count($nodes) > 0) {
+				/** @var File $file */
+				try {
+					$file = $this->workspaceService->getFile($nodes[0]);
+					if ($file instanceof File) {
+						return $file->getFileInfo()->getId();
 					}
+				} catch (StorageNotAvailableException $e) {
+					// If a storage is not available we can for the propfind response assume that there is no rich workspace present
 				}
-				return '';
-			});
-		}
+			}
+			return '';
+		});
 	}
 }

--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -97,25 +97,38 @@ class WorkspacePlugin extends ServerPlugin {
 
 		// Only return the property for the parent node and ignore it for further in depth nodes
 		if ($propFind->getDepth() === $this->server->getHTTPDepth()) {
-			$owner = $this->userId ?? $node->getFileInfo()->getStorage()->getOwner('');
-			/** @var Folder[] $nodes */
-			$nodes = $this->rootFolder->getUserFolder($owner)->getById($node->getId());
-			if (count($nodes) > 0) {
-				try {
+			$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($node) {
+				/** @var Folder[] $nodes */
+				$nodes = $this->rootFolder->getUserFolder($this->userId)->getById($node->getId());
+				if (count($nodes) > 0) {
 					/** @var File $file */
-					$file = $this->workspaceService->getFile($nodes[0]);
-					if ($file instanceof File) {
-						$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($file) {
+					try {
+						$file = $this->workspaceService->getFile($nodes[0]);
+						if ($file instanceof File) {
 							return $file->getContent();
-						});
-						$propFind->handle(self::WORKSPACE_FILE_PROPERTY, function () use ($file) {
-							return $file->getFileInfo()->getId();
-						});
+						}
+					} catch (StorageNotAvailableException $e) {
+						// If a storage is not available we can for the propfind response assume that there is no rich workspace present
 					}
-				} catch (StorageNotAvailableException $e) {
-					// If a storage is not available we can for the propfind response assume that there is no rich workspace present
 				}
-			}
+				return '';
+			});
+			$propFind->handle(self::WORKSPACE_FILE_PROPERTY, function () use ($node) {
+				/** @var Folder[] $nodes */
+				$nodes = $this->rootFolder->getUserFolder($this->userId)->getById($node->getId());
+				if (count($nodes) > 0) {
+					/** @var File $file */
+					try {
+						$file = $this->workspaceService->getFile($nodes[0]);
+						if ($file instanceof File) {
+							return $file->getFileInfo()->getName();
+						}
+					} catch (StorageNotAvailableException $e) {
+						// If a storage is not available we can for the propfind response assume that there is no rich workspace present
+					}
+				}
+				return '';
+			});
 		}
 	}
 }


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/32514
* Target version: master and stable24

### Summary

Clients expects this behavior:
If rich-workspaces is enabled and readme.md is empty or does not exist, it must return "".
If disabled -> null.
If readme.md has content -> show content

This revert to it and also make it possible in a separate commit to not have to add  'Depth: 1' in the curl request to get the workspace information


