### PR TITLE
[stable24] fix: return promise in cypress command to wait for it

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -141,7 +141,7 @@ Cypress.Commands.add('shareFileToUser', (userId, password, path, targetUserId) =
 
 Cypress.Commands.add('createFolder', dirName => {
 	cy.window().then(win => {
-		win.OC.Files.getClient().createDirectory(dirName)
+		return win.OC.Files.getClient().createDirectory(dirName)
 	})
 })
 


### PR DESCRIPTION
Tests were failing because cypress proceeded
with adding files to a folder that had not been created yet:
https://github.com/nextcloud/text/runs/6780248454?check_suite_focus=true

This also happened on stable24: https://github.com/nextcloud/text/runs/7165024139?check_suite_focus=true

Signed-off-by: Max <max@nextcloud.com>

* Target version: stable24


