### PR TITLE
Fix/eslint warning

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
     - name: npm install
       run: npm ci
     - name: eslint
-      run: npm run lint
+      run: npm run lint -- --max-warnings 0
     env:
       CI: true
 

--- a/cypress/e2e/propfind.spec.js
+++ b/cypress/e2e/propfind.spec.js
@@ -3,7 +3,7 @@
  *
  * @author Max <max@nextcloud.com>
  *
- * @license GNU AGPL version 3 or any later version
+ * @license AGPL-3.0-or-later
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
* Resolves warnings when running eslint
* Target version: master 

### Summary
Fix a license warning.
Also make the ci fail on npm lint warnings. We do not have any warnings right now. Let's make sure they do not sneak in by accident.

