### PR TITLE
[stable24] Make cypress CI faster

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [14]
-        containers: [1, 2, 3]
+        containers: [1, 2, 3, 4]
         php-versions: [ '7.4' ]
         databases: [ 'sqlite' ]
         server-versions: [ 'stable24' ]

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -54,12 +54,6 @@ jobs:
           ref: ${{ matrix.server-versions }}
           path: apps/viewer
 
-      - name: npm install, build viewer in testing mode
-        working-directory: apps/viewer
-        run: |
-          npm ci
-          TESTING=true npm run build
-
       - name: Checkout ${{ env.APP_NAME }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [14]
-        # containers: [1, 2, 3]
+        containers: [1, 2, 3]
         php-versions: [ '7.4' ]
         databases: [ 'sqlite' ]
         server-versions: [ 'stable24' ]
@@ -105,7 +105,7 @@ jobs:
         uses: cypress-io/github-action@v3
         with:
           record: true
-          parallel: false
+          parallel: true
           wait-on: '${{ env.CYPRESS_baseUrl }}'
           working-directory: 'apps/${{ env.APP_NAME }}'
           config: defaultCommandTimeout=10000,video=false


### PR DESCRIPTION
- Reenable multiple cypress ocntainers
- No need to build viewer anymore
- Add one more container


Backport of https://github.com/nextcloud/text/pull/2494
