### PR TITLE
[a11y] Enable tab navigation over SessionList

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
 				"@tiptap/extension-underline": "^2.0.0-beta.25",
 				"@tiptap/suggestion": "^2.0.0-beta.97",
 				"@tiptap/vue-2": "^2.0.0-beta.84",
+				"focus-trap": "^6.9.4",
 				"markdown-it": "^13.0.0",
 				"markdown-it-container": "^3.0.0",
 				"markdown-it-front-matter": "^0.2.3",
@@ -9893,6 +9894,14 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/focus-trap": {
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
+			"integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
+			"dependencies": {
+				"tabbable": "^5.3.3"
+			}
+		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
@@ -17777,6 +17786,11 @@
 			"dependencies": {
 				"acorn-node": "^1.2.0"
 			}
+		},
+		"node_modules/tabbable": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+			"integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
 		},
 		"node_modules/table": {
 			"version": "6.8.0",
@@ -27388,6 +27402,14 @@
 			"dev": true,
 			"peer": true
 		},
+		"focus-trap": {
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
+			"integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
+			"requires": {
+				"tabbable": "^5.3.3"
+			}
+		},
 		"follow-redirects": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
@@ -33372,6 +33394,11 @@
 			"requires": {
 				"acorn-node": "^1.2.0"
 			}
+		},
+		"tabbable": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+			"integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
 		},
 		"table": {
 			"version": "6.8.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"@tiptap/extension-underline": "^2.0.0-beta.25",
 		"@tiptap/suggestion": "^2.0.0-beta.97",
 		"@tiptap/vue-2": "^2.0.0-beta.84",
+		"focus-trap": "^6.9.4",
 		"markdown-it": "^13.0.0",
 		"markdown-it-container": "^3.0.0",
 		"markdown-it-front-matter": "^0.2.3",
@@ -110,6 +111,7 @@
 		"@nextcloud/eslint-config": "^8.0.0",
 		"@nextcloud/stylelint-config": "^2.1.2",
 		"@nextcloud/webpack-vue-config": "^5.2.1",
+		"@vitejs/plugin-vue2": "^1.1.2",
 		"@vue/test-utils": "^1.3.0",
 		"@vue/vue2-jest": "^28.0.1",
 		"cypress": "^10.3.0",
@@ -125,7 +127,6 @@
 		"mitt": "^3.0.0",
 		"vite": "^3.0.2",
 		"vite-plugin-commonjs": "^0.5.0",
-		"@vitejs/plugin-vue2": "^1.1.2",
 		"vue-demi": "^0.13.5",
 		"vue-template-compiler": "^2.7.8"
 	},

--- a/src/components/Editor/SessionList.vue
+++ b/src/components/Editor/SessionList.vue
@@ -143,7 +143,7 @@ export default {
 			this.$refs.form.focus()
 		},
 		revertFocus() {
-			this.$editor.chain().focus().run()
+			this.$editor.commands.focus()
 		},
 	},
 }

--- a/src/components/Editor/SessionList.vue
+++ b/src/components/Editor/SessionList.vue
@@ -21,7 +21,10 @@
   -->
 
 <template>
-	<Popover class="session-list" placement="bottom">
+	<Popover class="session-list"
+		placement="bottom"
+		@after-show="applyFocus"
+		@after-hide="revertFocus">
 		<button slot="trigger"
 			v-tooltip.bottom="label"
 			:title="label"
@@ -48,14 +51,16 @@
 						<span v-if="session.userId === null" class="guest-label">({{ t('text', 'guest') }})</span>
 					</li>
 				</ul>
-				<input id="toggle-color-annotations"
-					v-model="showAuthorAnnotations"
-					type="checkbox"
-					class="checkbox">
-				<label for="toggle-color-annotations">{{ t('text', 'Show author colors') }}</label>
-				<p class="hint">
-					{{ t('text', 'Author colors are only shown until everyone has closed the document.') }}
-				</p>
+				<form ref="form" tabindex="0" @submit.prevent>
+					<input id="toggle-color-annotations"
+						v-model="showAuthorAnnotations"
+						type="checkbox"
+						class="checkbox">
+					<label for="toggle-color-annotations">{{ t('text', 'Show author colors') }}</label>
+					<p class="hint">
+						{{ t('text', 'Author colors are only shown until everyone has closed the document.') }}
+					</p>
+				</form>
 			</div>
 		</template>
 	</Popover>
@@ -66,6 +71,7 @@ import Popover from '@nextcloud/vue/dist/Components/Popover'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import AvatarWrapper from './AvatarWrapper.vue'
 import store from '../../mixins/store.js'
+import { useEditorMixin } from '../Editor.provider.js'
 
 const COLLABORATOR_IDLE_TIME = 60
 const COLLABORATOR_DISCONNECT_TIME = 90
@@ -79,7 +85,7 @@ export default {
 	directives: {
 		tooltip: Tooltip,
 	},
-	mixins: [store],
+	mixins: [store, useEditorMixin],
 	props: {
 		sessions: {
 			type: Object,
@@ -130,6 +136,14 @@ export default {
 		},
 		sessionsVisible() {
 			return this.participantsWithoutCurrent.slice(0, 3)
+		},
+	},
+	methods: {
+		applyFocus() {
+			this.$refs.form.focus()
+		},
+		revertFocus() {
+			this.$editor.chain().focus().run()
 		},
 	},
 }
@@ -186,9 +200,16 @@ export default {
 			.session-label {
 				padding-right: 3px;
 			}
+
 			.guest-label {
 				padding-left: 3px;
 				color: var(--color-text-maxcontrast);
+			}
+
+			&:focus-visible {
+				box-shadow: 0 0 0 2px inset var(--color-primary) !important;
+				border-radius: var(--border-radius);
+				background-position: 12px center;
 			}
 		}
 	}

--- a/src/components/Editor/SessionList.vue
+++ b/src/components/Editor/SessionList.vue
@@ -23,8 +23,8 @@
 <template>
 	<Popover class="session-list"
 		placement="bottom"
-		@after-show="applyFocus"
-		@after-hide="revertFocus">
+		@after-show="useFocusTrap"
+		@apply-hide="clearFocusTrap">
 		<button slot="trigger"
 			v-tooltip.bottom="label"
 			:title="label"
@@ -37,7 +37,7 @@
 				:size="40" />
 		</button>
 		<template #default>
-			<div class="session-menu">
+			<div ref="wrapper" class="session-menu">
 				<slot name="lastSaved" />
 				<ul>
 					<slot />
@@ -51,7 +51,7 @@
 						<span v-if="session.userId === null" class="guest-label">({{ t('text', 'guest') }})</span>
 					</li>
 				</ul>
-				<form ref="form" tabindex="0" @submit.prevent>
+				<form tabindex="0" @submit.prevent>
 					<input id="toggle-color-annotations"
 						v-model="showAuthorAnnotations"
 						type="checkbox"
@@ -72,6 +72,7 @@ import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import AvatarWrapper from './AvatarWrapper.vue'
 import store from '../../mixins/store.js'
 import { useEditorMixin } from '../Editor.provider.js'
+import { createFocusTrap } from 'focus-trap'
 
 const COLLABORATOR_IDLE_TIME = 60
 const COLLABORATOR_DISCONNECT_TIME = 90
@@ -139,11 +140,18 @@ export default {
 		},
 	},
 	methods: {
-		applyFocus() {
-			this.$refs.form.focus()
+		/**
+		 * Add focus trap for accessibility.
+		 */
+		useFocusTrap() {
+			this.$nextTick(() => {
+				this.$focusTrap = createFocusTrap(this.$refs.wrapper)
+				this.$focusTrap.activate()
+			})
 		},
-		revertFocus() {
-			this.$editor.commands.focus()
+		clearFocusTrap() {
+			this.$focusTrap?.deactivate()
+			this.$focusTrap = null
 		},
 	},
 }


### PR DESCRIPTION
* Resolves: #2733
* Target version: master 

### Summary

Enable tab usage on session list popover.

- Add visual feedback about focus
- restore focus on editor after close popover



https://user-images.githubusercontent.com/1561347/182258054-60e7216b-06c4-42b1-ab5e-900fe471e6b9.mp4

https://user-images.githubusercontent.com/1561347/182258071-2f35f429-037b-4500-9a17-4755e7c2ecb6.mp4


