### PR TITLE
Avoid duplicate queries that were caused by running execute and the mapper find method

### DIFF
--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -64,8 +64,7 @@ class SessionMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('id', 'color', 'document_id', 'last_contact', 'user_id', 'guest_name')
 			->from($this->getTableName())
-			->where($qb->expr()->eq('document_id', $qb->createNamedParameter($documentId)))
-			->execute();
+			->where($qb->expr()->eq('document_id', $qb->createNamedParameter($documentId)));
 
 		return $this->findEntities($qb);
 	}
@@ -75,8 +74,7 @@ class SessionMapper extends QBMapper {
 		$qb->select('id', 'color', 'document_id', 'last_contact', 'user_id', 'guest_name')
 			->from($this->getTableName())
 			->where($qb->expr()->eq('document_id', $qb->createNamedParameter($documentId)))
-			->andWhere($qb->expr()->gt('last_contact', $qb->createNamedParameter(time() - SessionService::SESSION_VALID_TIME)))
-			->execute();
+			->andWhere($qb->expr()->gt('last_contact', $qb->createNamedParameter(time() - SessionService::SESSION_VALID_TIME)));
 
 		return $this->findEntities($qb);
 	}
@@ -85,8 +83,7 @@ class SessionMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('id', 'color', 'document_id', 'last_contact', 'user_id', 'guest_name')
 			->from($this->getTableName())
-			->where($qb->expr()->lt('last_contact', $qb->createNamedParameter(time() - SessionService::SESSION_VALID_TIME)))
-			->execute();
+			->where($qb->expr()->lt('last_contact', $qb->createNamedParameter(time() - SessionService::SESSION_VALID_TIME)));
 
 		return $this->findEntities($qb);
 	}

--- a/lib/Db/StepMapper.php
+++ b/lib/Db/StepMapper.php
@@ -46,8 +46,7 @@ class StepMapper extends QBMapper {
 		$qb
 			->setMaxResults(100)
 			->orderBy('version')
-			->orderBy('id')
-			->execute();
+			->orderBy('id');
 
 		return $this->findEntities($qb);
 	}


### PR DESCRIPTION
Avoid double queries on methods that would invoke execute anyways in the mapper class methods.
