### PR TITLE
Support heic/heif attachments as photos

### DIFF
--- a/lib/Controller/AttachmentController.php
+++ b/lib/Controller/AttachmentController.php
@@ -51,6 +51,8 @@ class AttachmentController extends Controller {
 		'image/bmp',
 		'image/svg+xml',
 		'image/webp',
+		'image/heic',
+		'image/heif',
 	];
 
 	private AttachmentService $attachmentService;


### PR DESCRIPTION
This small change is actually enough to support HEIC/HEIF files as image attachments.

This requires to have ImageMagic and the php-imagick module installed and the relevant preview providers enabled.
To enable the providers, one would need to have that in config.php:
``` php
'enabledPreviewProviders' =>
  array (
        1 => 'OC\\Preview\\HEIF',
        2 => 'OC\\Preview\\HEIC',
  ),
```

If the providers are not enabled, heic/heif files are considered as media attachment.