### PR TITLE
Do not attempt to load a non-existing script

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -1,6 +1,5 @@
 <?php
 script('text', 'text-text');
-style('text', 'icons');
 ?>
 <div id="app-content">
 	<div id="maineditor"></div>


### PR DESCRIPTION
This fixes flaky loading failures when using direcrt editing, as sometimes the redirect of the not found resource is triggered too early which then leads to an updated CSRF token due to the redirect to the login page when requesting the not found style.

I think the redirect should be addresses separately and we should return a proper 404 in server for those cases, but this should fix the issues with text.