### PR TITLE
renovate: group jest and vue2-jest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,13 @@
       ]
     },
     {
+      "groupName": "jest",
+      "matchPackageNames": [
+        "jest",
+        "@vue/vue2-jest"
+      ]
+    },
+    {
       "matchUpdateTypes": ["major"],
       "matchBaseBranches": ["stable25", "stable24", "stable23"],
       "enabled": false


### PR DESCRIPTION
They need to be upgraded together. Otherwise the install fails: https://github.com/nextcloud/text/pull/3167

* Target version: master 
* superseeds: #3167, #3166 

