### PR TITLE
fix: keep editing while editor scrolls down

### DIFF
--- a/cypress/e2e/sections.spec.js
+++ b/cypress/e2e/sections.spec.js
@@ -93,8 +93,7 @@ describe('Content Sections', () => {
 			// Insert content above link
 			cy.getContent()
 				.type('{moveToStart}\n{moveToStart}# top \n')
-				.type('lorem ipsum \n'.repeat(25))
-				.type('{moveToEnd}\n')
+				.type('lorem ipsum \n'.repeat(25) + '{moveToEnd}\n')
 				.find('h1#top')
 				.should('not.be.inViewport')
 			// Click link and test view moved to anchor


### PR DESCRIPTION
Cypress considers the editor hidden when it starts scrolling. While typing this is fine.
But when a new type command starts cypress checks again and thinks the editor is hidden.

Join the two edit commands as a quick fix.

* Resolves: [ci failures](https://github.com/nextcloud/text/actions/runs/3239797387/jobs/5309623756) like in #3188 
* Target version: master 



