### PR TITLE
Cancel other jobs for the same ref

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,6 +7,10 @@ on:
       - master
       - stable*
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   APP_NAME: text
   CYPRESS_baseUrl: http://localhost:8081/index.php


### PR DESCRIPTION
Saves us some CI time as with this only one cypress job will be running for a pull request, still pending ones from previous pushes will be canceled.