### PR TITLE
Limit renovate PR creation to the night during weekdays

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "extends": [
     "config:base"
   ],
+  "timezone": "Europe/Berlin",
+  "schedule": [
+    "before 5am every weekday",
+    "every weekend"
+  ],
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "rebaseWhen": "conflicted",


### PR DESCRIPTION
Set timezone to Europe/Berlin [CET/CEST] as reference and set schedule to "before 5am" for weekdays. Since most of our team live in CE(S)T this should work well. Others in our team live in CE(S)T-5, which still works well with this schedule.

Signed-off-by: Jonas <jonas@freesources.org>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


