### PR TITLE
Prevent caching `false` in SessionService

### DIFF
--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -165,12 +165,17 @@ class SessionService {
 
 		try {
 			$data = $this->sessionMapper->find($documentId, $sessionId, $token);
-			$this->cache->set($token, json_encode($data), self::SESSION_VALID_TIME - 30);
-			return $data;
+			$jsonData = json_encode($data);
+
+			if ($jsonData) {
+				$this->cache->set($token, json_encode($data), self::SESSION_VALID_TIME - 30);
+				return $data;
+			}
 		} catch (DoesNotExistException $e) {
-			$this->session = false;
-			return false;
 		}
+
+		$this->session = false;
+		return false;
 	}
 
 	public function isValidSession($documentId, $sessionId, $token): bool {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/text/issues/1091
* Target version: master 

### Summary
If we receive non-serializable data from the session mapper (e.g. `NULL`) we should not try to cache it. Trying to cache it results in value `false` getting cached which later fails to be decoded. 
