### PR TITLE
WIP: Test also CommonMark serialization

### DIFF
--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -15,6 +15,7 @@ import createEditor from "../EditorFactory";
  * Please add test belonging to some Node or Mark to the corresponding file in './nodes/` or `./marks/`
  */
 
+// Goal: Input (commonmark) markdown should result in same output markdown
 describe('Commonmark', () => {
 	const skippedMarkdownTests = [
 		// we interpret this as front matter
@@ -24,45 +25,18 @@ describe('Commonmark', () => {
 		// contain comments
 		309, 308,
 		// < > are escaped, because HTML is disabled for markdown-it
-		201, 490, 493, 523, 535
+		//201, 490, 493, 523, 535
 	];
-
-	const normalize = (str) => {
-		// https://github.com/markdown-it/markdown-it/blob/df4607f1d4d4be7fdc32e71c04109aea8cc373fa/test/commonmark.js#L10
-		return str.replace(/<blockquote><\/blockquote>/g, '<blockquote>\n</blockquote>')
-			.replace(/<span class="keep-md">([^<]+)<\/span>/g, '$1')
-			.replace(/<br data-syntax=".{1,2}" \/>/g, '<br />\n')
-			.replace(/<ul data-bullet="."/g, '<ul')
-	}
-
-	// special treatment because we use markdown-it-image-figures
-	const figureImageMarkdownTests = [
-		516, 519, 530, 571, 572, 573, 574, 575, 576, 577, 579, 580, 581, 582, 583, 584, 585, 587, 588, 590
-	]
 
 	spec.forEach((entry) => {
 		// We do not support HTML
-		if (entry.section === 'HTML blocks' || entry.section === 'Raw HTML') return;
-
-		if (skippedMarkdownTests.indexOf(entry.example) !== -1) {
+		if (entry.section === 'HTML blocks' ||
+			entry.section === 'Raw HTML'	||
+			skippedMarkdownTests.indexOf(entry.example) !== -1) {
 			return
 		}
 
-		test('commonmark parsing ' + entry.example, () => {
-			let expected = entry.markdown.includes('__')
-				? entry.html.replace(/<strong>/g, '<u>').replace(/<\/strong>/g, '</u>')
-				: entry.html
-			if (figureImageMarkdownTests.indexOf(entry.example) !== -1) {
-				expected = expected.replace(/<p>/g, '<figure>').replace(/<\/p>/g, '</figure>')
-			}
-
-			const rendered = markdownit.render(entry.markdown)
-
-			// Ignore special markup for untouched markdown
-			expect(normalize(rendered)).toBe(expected)
-		})
-
-		test('commonmark serialization ' + entry.example, () => {
+		test('serializing ' + entry.example, () => {
 			const expected = markdownit.render(entry.markdown)
 			const serialized = markdownThroughEditorHtml(expected)
 

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -20,9 +20,11 @@ describe('Commonmark', () => {
 		// we interpret this as front matter
 		96, 98,
 		// contain HTML
-		21, 31, 201, 344, 474, 475, 476, 490, 493, 523, 535, 642, 643,
+		21, 31, 344, 474, 475, 476, 642, 643,
 		// contain comments
 		309, 308,
+		// < > are escaped, because HTML is disabled for markdown-it
+		201, 490, 493, 523, 535
 	];
 
 	const normalize = (str) => {
@@ -58,6 +60,18 @@ describe('Commonmark', () => {
 
 			// Ignore special markup for untouched markdown
 			expect(normalize(rendered)).toBe(expected)
+		})
+
+		test('commonmark serialization ' + entry.example, () => {
+			const expected = markdownit.render(entry.markdown)
+			const serialized = markdownThroughEditorHtml(expected)
+
+			try {
+				expect(markdownit.render(serialized)).toBe(expected)
+			} catch(e) {
+				// This is just for debugging, so jest shows also the difference within the two markdown source codes
+				expect(markdownit.render(serialized) + '\n\n' + serialized).toBe(expected + '\n\n' + entry.markdown)
+			}
 		})
 	})
 })


### PR DESCRIPTION
### Summary
As two different markdown strings can be semantically the same, we can test if the resulting rendered HTML are syntactically equal.

Currently about hundred test cases fail because of a known limitation of `prosemirror-markdown` not able to serialize nested marks correctly, see https://github.com/ProseMirror/prosemirror-markdown/issues/82

So the CI test results can be used as a reference for identifiying problem for #2702 and also what needs to be fixed so that markdown files stay unchanged (#593)