### PR TITLE
DirectEditing: Set session user for DirectSession editing

### DIFF
--- a/lib/Controller/DirectSessionController.php
+++ b/lib/Controller/DirectSessionController.php
@@ -55,15 +55,11 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 use OCP\IUserManager;
 use OCP\IUserSession;
-use OCP\Share\IShare;
 
 class DirectSessionController extends Controller {
 	private ApiService $apiService;
 	private IManager $directManager;
 	private IUserSession $userSession;
-	/**
-	 * @var \OCP\IUserManager
-	 */
 	private IUserManager $userManager;
 
 	public function __construct(string $appName, IRequest $request, ApiService $apiService, IManager $directManager, IUserSession $userSession, IUserManager $userManager) {

--- a/lib/Controller/DirectSessionController.php
+++ b/lib/Controller/DirectSessionController.php
@@ -53,17 +53,25 @@ use OCP\AppFramework\Http\Response;
 use OCP\DirectEditing\IManager;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
+use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\Share\IShare;
 
 class DirectSessionController extends Controller {
-	private IShare $share;
 	private ApiService $apiService;
 	private IManager $directManager;
+	private IUserSession $userSession;
+	/**
+	 * @var \OCP\IUserManager
+	 */
+	private IUserManager $userManager;
 
-	public function __construct(string $appName, IRequest $request, ApiService $apiService, IManager $directManager) {
+	public function __construct(string $appName, IRequest $request, ApiService $apiService, IManager $directManager, IUserSession $userSession, IUserManager $userManager) {
 		parent::__construct($appName, $request);
 		$this->apiService = $apiService;
 		$this->directManager = $directManager;
+		$this->userSession = $userSession;
+		$this->userManager = $userManager;
 	}
 
 	/**
@@ -106,6 +114,7 @@ class DirectSessionController extends Controller {
 	 * @PublicPage
 	 */
 	public function push(int $documentId, int $sessionId, string $sessionToken, int $version, array $steps, string $token): DataResponse {
+		$this->loginTokenUser($token);
 		return $this->apiService->push($documentId, $sessionId, $sessionToken, $version, $steps, $token);
 	}
 
@@ -114,6 +123,7 @@ class DirectSessionController extends Controller {
 	 * @PublicPage
 	 */
 	public function sync(string $token, int $documentId, int $sessionId, string $sessionToken, int $version = 0, string $autosaveContent = null, bool $force = false, bool $manualSave = false): DataResponse {
+		$this->loginTokenUser($token);
 		return $this->apiService->sync($documentId, $sessionId, $sessionToken, $version, $autosaveContent, $force, $manualSave, $token);
 	}
 
@@ -123,5 +133,13 @@ class DirectSessionController extends Controller {
 	 */
 	public function updateSession(int $documentId, int $sessionId, string $sessionToken, string $guestName) {
 		return $this->apiService->updateSession($documentId, $sessionId, $sessionToken, $guestName);
+	}
+
+	private function loginTokenUser(string $token) {
+		$tokenObject = $this->directManager->getToken($token);
+		$user = $this->userManager->get($tokenObject->getUser());
+		if ($user !== null) {
+			$this->userSession->setUser($user);
+		}
 	}
 }


### PR DESCRIPTION

fixes https://github.com/nextcloud/android/issues/10237
fixes #2821


* Resolves: #2821
* Target version: master 

### Summary

Set session user for DirectSession editing to have it available for the file put activities event

