### PR TITLE
update: use cypress action v4

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -103,7 +103,7 @@ jobs:
           npm run build
 
       - name: Cypress run
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@v4
         with:
           record: true
           parallel: true


### PR DESCRIPTION
~~This will hopefully fix a deprecation notice on github job runs~~ 
Turns out it still uses the deprecated syntax. Still better to be on the latest i guess.

https://github.com/cypress-io/github-action/pull/621 will hopefully fix the warning.

* Target version: master, stable25, stable24, stable23



