### PR TITLE
test: start using @nextcloud/cypress

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -25,4 +25,5 @@ module.exports = defineConfig({
 		// do not retry in `cypress open`
 		openMode: 0,
 	},
+	"numTestsKeptInMemory": 5,
 })

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -10,9 +10,6 @@ cy.getContent()
 ### Available custom commands
 | Command              | Function               | Parameters                          |
 | -------------------- | ---------------------- | ----------------------------------- |
-| `login`              | Log in `user`          | `user`, `password`                  |
-| `logout`             | Logout                 |                                     |
-| `nextcloudCreateUser`| Create a new user      | `user`, `password`                  |
 | `nextcloudUpdateUser`| Update user setting    | `user`, `password`, `key`, `value`  |
 | `nextcloudDeleteUser`| Delete user            | `user`                              |
 | `uploadFile`         | Upload file            | `fileName`, `mimeType`, `target`    |
@@ -35,3 +32,13 @@ cy.getContent()
 | `getActionEntry`     | Get menu entry         | `name`                              |
 | `getActionSubEntry`  | Get submenu entry (after menu clicked) | `name`              |
 | `openWorkspace`      | Open workspace and return Editor content |                   |
+
+### Commands from `@nextcloud/cypress`
+
+We also use some commands from `@nextcloud/cypress`:
+* `login(user)`
+* `logout()`
+* `createRandomUser().then(user => login(user))`
+* `createUser(user)`
+
+see https://github.com/nextcloud/nextcloud-cypress

--- a/cypress/e2e/FrontMatter.spec.js
+++ b/cypress/e2e/FrontMatter.spec.js
@@ -18,9 +18,10 @@
  *
  */
 
+import { User } from '@nextcloud/cypress'
 import { initUserAndFiles, randHash } from '../utils/index.js'
 
-const randUser = randHash()
+const randUser = new User(randHash(), 'password')
 
 describe('Front matter support', function() {
 	before(function() {
@@ -28,7 +29,8 @@ describe('Front matter support', function() {
 	})
 
 	beforeEach(function() {
-		cy.login(randUser, 'password')
+		cy.login(randUser)
+		cy.visit('/apps/files')
 	})
 
 	it('Open file with front matter', function() {

--- a/cypress/e2e/ImageView.spec.js
+++ b/cypress/e2e/ImageView.spec.js
@@ -1,7 +1,3 @@
-import { randHash } from '../utils/index.js'
-
-const currentUser = randHash()
-
 const refresh = () => cy.get('.files-controls .crumb:not(.hidden) a')
 	.last()
 	.click({ force: true })
@@ -12,10 +8,14 @@ const createMarkdown = (fileName, content) => {
 }
 
 describe('Image View', () => {
+	let user
 	before(() => {
 		// Init user
-		cy.nextcloudCreateUser(currentUser, 'password')
-		cy.login(currentUser, 'password')
+		cy.createRandomUser().then(u => {
+			user = u
+			cy.login(u)
+		})
+		cy.visit('/apps/files')
 
 		// Upload test files to user's storage
 		cy.createFolder('child-folder')
@@ -24,7 +24,8 @@ describe('Image View', () => {
 	})
 
 	beforeEach(() => {
-		cy.login(currentUser, 'password')
+		cy.login(user)
+		cy.visit('/apps/files')
 	})
 
 	describe('direct access', () => {
@@ -43,7 +44,7 @@ describe('Image View', () => {
 			cy.getContent()
 				.find('[data-component="image-view"] img')
 				.should('have.attr', 'src')
-				.should('contains', `/dav/files/${currentUser}/github.png`)
+				.should('contains', `/dav/files/${user.userId}/github.png`)
 		})
 
 		it('from child folder', () => {
@@ -61,7 +62,7 @@ describe('Image View', () => {
 			cy.getContent()
 				.find('[data-component="image-view"] img')
 				.should('have.attr', 'src')
-				.should('contains', `/dav/files/${currentUser}/child-folder/github.png`)
+				.should('contains', `/dav/files/${user.userId}/child-folder/github.png`)
 		})
 
 		it('from parent folder', () => {
@@ -81,7 +82,7 @@ describe('Image View', () => {
 			cy.getContent()
 				.find('[data-component="image-view"] img')
 				.should('have.attr', 'src')
-				.should('contains', `/dav/files/${currentUser}/github.png`)
+				.should('contain', `/dav/files/${user.userId}/github.png`)
 		})
 
 		it('with preview', () => {

--- a/cypress/e2e/MenuBar.spec.js
+++ b/cypress/e2e/MenuBar.spec.js
@@ -1,13 +1,15 @@
+import { User } from '@nextcloud/cypress'
 import { initUserAndFiles, randHash } from '../utils/index.js'
 
-const randUser = randHash()
+const randUser = new User(randHash(), 'password')
 const fileName = 'empty.md'
 
 describe('Test the rich text editor menu bar', function() {
 	before(() => initUserAndFiles(randUser, fileName))
 
 	beforeEach(function() {
-		cy.login(randUser, 'password', {
+		cy.login(randUser)
+		cy.visit('/apps/files', {
 			onBeforeLoad(win) {
 				cy.stub(win, 'open')
 					.as('winOpen')

--- a/cypress/e2e/Table.spec.js
+++ b/cypress/e2e/Table.spec.js
@@ -5,12 +5,13 @@ import createEditor from './../../src/tests/createEditor.js'
 import EditableTable from './../../src/nodes/EditableTable.js'
 import Markdown, { createMarkdownSerializer } from './../../src/extensions/Markdown.js'
 
+import { User } from '@nextcloud/cypress'
 import { initUserAndFiles, randHash } from '../utils/index.js'
 
-const randUser = randHash()
+const randUser = new User(randHash(), 'password')
 const fileName = 'empty.md'
 
-describe('ListItem extension integrated in the editor', () => {
+describe('Table extension integrated in the editor', () => {
 
 	const editor = createEditor({
 		content: '',
@@ -79,7 +80,8 @@ describe('table plugin', () => {
 	})
 
 	beforeEach(() => {
-		cy.login(randUser, 'password')
+		cy.login(randUser)
+		cy.visit('/apps/files')
 
 		cy.isolateTest({
 			sourceFile: fileName,

--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -21,10 +21,11 @@
  */
 
 import { initUserAndFiles, randHash } from '../utils/index.js'
+import { User } from '@nextcloud/cypress'
 import 'cypress-file-upload'
 
-const randUser = randHash()
-const randUser2 = randHash()
+const randUser = new User(randHash(), 'password')
+const randUser2 = new User(randHash(), 'password')
 let currentUser = randUser
 const attachmentFileNameToId = {}
 
@@ -153,12 +154,13 @@ describe('Test all attachment insertion methods', () => {
 		cy.uploadFile('github.png', 'image/png', 'sub/a/a.png')
 		cy.uploadFile('github.png', 'image/png', 'sub/b/b.png')
 
-		cy.nextcloudCreateUser(randUser2, 'password')
-		cy.shareFileToUser(randUser, 'password', 'test.md', randUser2)
+		cy.createUser(randUser2)
+		cy.shareFileToUser(randUser, 'test.md', randUser2)
 	})
 
 	beforeEach(() => {
-		cy.login(currentUser, 'password')
+		cy.login(currentUser)
+		cy.visit('/apps/files')
 	})
 
 	it('See test files in the list and display hidden files', () => {

--- a/cypress/e2e/conflict.spec.js
+++ b/cypress/e2e/conflict.spec.js
@@ -20,9 +20,10 @@
  *
  */
 
+import { User } from '@nextcloud/cypress'
 import { initUserAndFiles, randHash } from '../utils/index.js'
 
-const randUser = randHash()
+const randUser = new User(randHash(), 'password')
 const fileName = 'test.md'
 
 describe('Open test.md in viewer', function() {
@@ -33,7 +34,8 @@ describe('Open test.md in viewer', function() {
 	})
 
 	beforeEach(function() {
-		cy.login(randUser, 'password')
+		cy.login(randUser)
+		cy.visit('/apps/files')
 	})
 
 	it('displays conflicts', function() {

--- a/cypress/e2e/directediting.spec.js
+++ b/cypress/e2e/directediting.spec.js
@@ -1,9 +1,10 @@
+import { User } from '@nextcloud/cypress'
 import { initUserAndFiles, randHash } from '../utils/index.js'
 
-const randUser = randHash()
+const randUser = new User(randHash(), 'password')
 
 const createDirectEditingLink = (user, file) => {
-	cy.login(user, 'password')
+	cy.login(user)
 	return cy.request({
 		method: 'POST',
 		url: `${Cypress.env('baseUrl')}/ocs/v2.php/apps/files/api/v1/directEditing/open?format=json`,
@@ -11,7 +12,7 @@ const createDirectEditingLink = (user, file) => {
 		body: {
 			path: file,
 		},
-		auth: { user, pass: 'password' },
+		auth: { user: user.userId, pass: user.password },
 		headers: {
 			'OCS-ApiRequest': 'true',
 			'Content-Type': 'application/x-www-form-urlencoded',
@@ -19,13 +20,13 @@ const createDirectEditingLink = (user, file) => {
 	}).then(response => {
 		cy.log(response)
 		const token = response.body?.ocs?.data?.url
-		cy.log(`Created direct editing token for ${user}`, token)
+		cy.log(`Created direct editing token for ${user.userId}`, token)
 		return cy.wrap(token)
 	})
 }
 
 const createDirectEditingLinkForNewFile = (user, file) => {
-	cy.login(user, 'password')
+	cy.login(user)
 	return cy.request({
 		method: 'POST',
 		url: `${Cypress.env('baseUrl')}/ocs/v2.php/apps/files/api/v1/directEditing/create?format=json`,
@@ -35,7 +36,7 @@ const createDirectEditingLinkForNewFile = (user, file) => {
 			editorId: 'text',
 			creatorId: 'textdocument',
 		},
-		auth: { user, pass: 'password' },
+		auth: { user: user.userId, pass: user.password },
 		headers: {
 			'OCS-ApiRequest': 'true',
 			'Content-Type': 'application/x-www-form-urlencoded',
@@ -43,7 +44,7 @@ const createDirectEditingLinkForNewFile = (user, file) => {
 	}).then(response => {
 		cy.log(response)
 		const token = response.body?.ocs?.data?.url
-		cy.log(`Created direct editing token for ${user}`, token)
+		cy.log(`Created direct editing token for ${user.userId}`, token)
 		return cy.wrap(token)
 	})
 }

--- a/cypress/e2e/files.spec.js
+++ b/cypress/e2e/files.spec.js
@@ -20,17 +20,19 @@
  *
  */
 
+import { User } from '@nextcloud/cypress'
 import { randHash } from '../utils/index.js'
 
-const randUser = randHash()
+const randUser = new User(randHash(), 'password')
 
 describe('Files default view', () => {
 	before(() => {
-		cy.nextcloudCreateUser(randUser, randUser)
+		cy.createUser(randUser)
 	})
 
 	beforeEach(() => {
-		cy.login(randUser, randUser)
+		cy.login(randUser)
+		cy.visit('/apps/files')
 	})
 
 	it('See the default files list', () => {

--- a/cypress/e2e/links.spec.js
+++ b/cypress/e2e/links.spec.js
@@ -1,6 +1,7 @@
+import { User } from '@nextcloud/cypress'
 import { initUserAndFiles, randHash } from '../utils/index.js'
 
-const randUser = randHash()
+const randUser = new User(randHash(), 'password')
 const fileName = 'empty.md'
 
 describe('test link marks', function() {
@@ -9,7 +10,8 @@ describe('test link marks', function() {
 	})
 
 	beforeEach(function() {
-		cy.login(randUser, 'password')
+		cy.login(randUser)
+		cy.visit('/apps/files')
 
 		cy.isolateTest({
 			sourceFile: fileName,

--- a/cypress/e2e/mobile.spec.js
+++ b/cypress/e2e/mobile.spec.js
@@ -20,9 +20,10 @@
  *
  */
 
+import { User } from '@nextcloud/cypress'
 import { randHash } from '../utils/index.js'
 
-const currentUser = randHash()
+const currentUser = new User(randHash(), 'password')
 
 const getRemainItem = (name) => {
 	cy.getActionEntry('remain').click()
@@ -35,11 +36,12 @@ describe('Mobile actions', {
 	viewportHeight: 640,
 }, () => {
 	before(() => {
-		cy.nextcloudCreateUser(currentUser, 'password')
+		cy.createUser(currentUser)
 	})
 
 	beforeEach(function() {
-		cy.login(currentUser, 'password').then(() => {
+		cy.login(currentUser)
+		cy.visit('/apps/files').then(() => {
 			// isolate tests - each happens in its own folder
 			const retry = cy.state('test').currentRetry()
 			const folderName = retry

--- a/cypress/e2e/propfind.spec.js
+++ b/cypress/e2e/propfind.spec.js
@@ -20,18 +20,21 @@
  *
  */
 
+import { User } from '@nextcloud/cypress'
 import { randHash } from '../utils/index.js'
-const randUser = randHash()
+
+const randUser = new User(randHash(), 'password')
 
 describe('Text PROPFIND extension ', function() {
 	const richWorkspace = '{http://nextcloud.org/ns}rich-workspace'
 
 	before(function() {
-		cy.nextcloudCreateUser(randUser, 'password')
+		cy.createUser(randUser)
 	})
 
 	beforeEach(function() {
-		cy.login(randUser, 'password')
+		cy.login(randUser)
+		cy.visit('/apps/files')
 	})
 
 	describe('with workspaces enabled', function() {

--- a/cypress/e2e/sections.spec.js
+++ b/cypress/e2e/sections.spec.js
@@ -1,6 +1,7 @@
+import { User } from '@nextcloud/cypress'
 import { initUserAndFiles, randHash } from '../utils/index.js'
 
-const currentUser = randHash()
+const currentUser = new User(randHash(), 'password')
 const fileName = 'empty.md'
 
 const refresh = () => cy.get('.files-controls .crumb:not(.hidden) a')
@@ -21,12 +22,13 @@ describe('Content Sections', () => {
 	})
 
 	beforeEach(function() {
-		cy.login(currentUser, 'password', {
+		cy.login(currentUser, {
 			onBeforeLoad(win) {
 				cy.stub(win, 'open')
 					.as('winOpen')
 			},
 		})
+		cy.visit('/apps/files')
 
 		cy.isolateTest({
 			sourceFile: fileName,

--- a/cypress/e2e/share.spec.js
+++ b/cypress/e2e/share.spec.js
@@ -21,14 +21,17 @@
  *
  */
 
+import { User } from '@nextcloud/cypress'
 import { randHash } from '../utils/index.js'
-const randUser = randHash()
+
+const randUser = new User(randHash(), 'password')
 
 describe('Open test.md in viewer', function() {
 	before(function() {
 		// Init user
-		cy.nextcloudCreateUser(randUser, 'password')
-		cy.login(randUser, 'password')
+		cy.createUser(randUser)
+		cy.login(randUser)
+		cy.visit('/apps/files')
 
 		// Upload test files
 		cy.createFolder('folder')
@@ -41,7 +44,8 @@ describe('Open test.md in viewer', function() {
 			.should('contain', 'test.md')
 	})
 	beforeEach(function() {
-		cy.login(randUser, 'password')
+		cy.login(randUser)
+		cy.visit('/apps/files')
 	})
 
 	it('Shares the file as a public read only link', function() {

--- a/cypress/e2e/viewer.spec.js
+++ b/cypress/e2e/viewer.spec.js
@@ -20,8 +20,9 @@
  *
  */
 
+import { User } from '@nextcloud/cypress'
 import { initUserAndFiles, randHash } from '../utils/index.js'
-const randUser = randHash()
+const randUser = new User(randHash(), 'password')
 
 describe('Open test.md in viewer', function() {
 	const getViewer = () => cy.get('#viewer')
@@ -31,7 +32,8 @@ describe('Open test.md in viewer', function() {
 	})
 
 	beforeEach(function() {
-		cy.login(randUser, 'password')
+		cy.login(randUser)
+		cy.visit('/apps/files')
 	})
 
 	it('See test.md in the list', function() {

--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -20,18 +20,20 @@
  *
  */
 
+import { User } from '@nextcloud/cypress'
 import { randHash } from '../utils/index.js'
-const randUser = randHash()
+const randUser = new User(randHash(), 'password')
 
 describe('Workspace', function() {
 	let currentFolder
 
 	before(function() {
-		cy.nextcloudCreateUser(randUser, 'password')
+		cy.createUser(randUser, 'password')
 	})
 
 	beforeEach(function() {
-		cy.login(randUser, 'password').then(() => {
+		cy.login(randUser)
+		cy.visit('/apps/files').then(() => {
 			// isolate tests - each happens in its own folder
 			const retry = cy.state('test').currentRetry()
 
@@ -210,10 +212,6 @@ describe('Workspace', function() {
 	describe('callouts', () => {
 		const types = ['info', 'warn', 'error', 'success']
 
-		before(function() {
-			cy.nextcloudCreateUser(randUser, 'password')
-		})
-
 		beforeEach(function() {
 			cy.openWorkspace().type('Callout')
 		})
@@ -273,7 +271,7 @@ describe('Workspace', function() {
 
 	describe('localize', () => {
 		it('takes localized file name into account', function() {
-			cy.nextcloudUpdateUser(randUser, 'password', 'language', 'de_DE')
+			cy.nextcloudUpdateUser(randUser, 'language', 'de_DE')
 			cy.uploadFile('test.md', 'text/markdown', `${Cypress.currentTest.title}/Anleitung.md`)
 			cy.reload()
 			cy.get('.files-fileList').should('contain', 'Anleitung.md')
@@ -282,7 +280,7 @@ describe('Workspace', function() {
 		})
 
 		it('ignores localized file name in other language', function() {
-			cy.nextcloudUpdateUser(randUser, 'password', 'language', 'fr')
+			cy.nextcloudUpdateUser(randUser, 'language', 'fr')
 			cy.uploadFile('test.md', 'text/markdown', `${Cypress.currentTest.title}/Anleitung.md`)
 			cy.reload()
 			cy.get('.files-fileList').should('contain', 'Anleitung.md')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -21,6 +21,7 @@
  */
 
 import axios from '@nextcloud/axios'
+import { login } from '@nextcloud/cypress/commands'
 
 // eslint-disable-next-line no-unused-vars,n/no-extraneous-import
 import regeneratorRuntime from 'regenerator-runtime'
@@ -28,17 +29,11 @@ import regeneratorRuntime from 'regenerator-runtime'
 const url = Cypress.config('baseUrl').replace(/\/index.php\/?$/g, '')
 Cypress.env('baseUrl', url)
 
-Cypress.Commands.add('login', (user, password, { route, onBeforeLoad } = {}) => {
-	route = route || '/apps/files'
+Cypress.Commands.add('loginWithoutVisit', login)
 
-	cy.session(user, function() {
-		cy.visit(route)
-		cy.get('input[name=user]').type(user)
-		cy.get('input[name=password]').type(password)
-		cy.get('form[name=login] button[type=submit]').click()
-		cy.url().should('include', route)
-	})
-	// in case the session already existed but we are on a different route...
+Cypress.Commands.add('login', (userId, password, { route, onBeforeLoad } = {}) => {
+	route = route || '/apps/files'
+	cy.loginWithoutVisit({ userId, password })
 	cy.visit(route, { onBeforeLoad })
 })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -21,7 +21,7 @@
  */
 
 import axios from '@nextcloud/axios'
-import { login } from '@nextcloud/cypress/commands'
+import { addCommands } from '@nextcloud/cypress'
 
 // eslint-disable-next-line no-unused-vars,n/no-extraneous-import
 import regeneratorRuntime from 'regenerator-runtime'
@@ -29,47 +29,15 @@ import regeneratorRuntime from 'regenerator-runtime'
 const url = Cypress.config('baseUrl').replace(/\/index.php\/?$/g, '')
 Cypress.env('baseUrl', url)
 
-Cypress.Commands.add('loginWithoutVisit', login)
+addCommands()
 
-Cypress.Commands.add('login', (userId, password, { route, onBeforeLoad } = {}) => {
-	route = route || '/apps/files'
-	cy.loginWithoutVisit({ userId, password })
-	cy.visit(route, { onBeforeLoad })
-})
-
-Cypress.Commands.add('logout', (route = '/') => {
-	cy.session('_guest', function() {
-	})
-})
-
-Cypress.Commands.add('nextcloudCreateUser', (user, password) => {
-	cy.clearCookies()
-	cy.request({
-		method: 'POST',
-		url: `${Cypress.env('baseUrl')}/ocs/v1.php/cloud/users?format=json`,
-		form: true,
-		body: {
-			userid: user,
-			password,
-			language: 'en', // for tests that rely on the translated text
-		},
-		auth: { user: 'admin', pass: 'admin' },
-		headers: {
-			'OCS-ApiRequest': 'true',
-			'Content-Type': 'application/x-www-form-urlencoded',
-		},
-	}).then(response => {
-		cy.log(`Created user ${user}`, response.status)
-	})
-})
-
-Cypress.Commands.add('nextcloudUpdateUser', (user, password, key, value) => {
+Cypress.Commands.add('nextcloudUpdateUser', (user, key, value) => {
 	cy.request({
 		method: 'PUT',
-		url: `${Cypress.env('baseUrl')}/ocs/v2.php/cloud/users/${user}`,
+		url: `${Cypress.env('baseUrl')}/ocs/v2.php/cloud/users/${user.userId}`,
 		form: true,
 		body: { key, value },
-		auth: { user, pass: password },
+		auth: { user: user.userId, password: user.password },
 		headers: {
 			'OCS-ApiRequest': 'true',
 			'Content-Type': 'application/x-www-form-urlencoded',
@@ -98,21 +66,23 @@ Cypress.Commands.add('nextcloudDeleteUser', (user) => {
 Cypress.Commands.add('uploadFile', (fileName, mimeType, target) => {
 	return cy.fixture(fileName, 'base64')
 		.then(Cypress.Blob.base64StringToBlob)
-		.then(async blob => {
+		.then(blob => {
 			const file = new File([blob], fileName, { type: mimeType })
 			if (typeof target !== 'undefined') {
 				fileName = target
 			}
-			await cy.window().then(async win => {
-				await axios.put(`${Cypress.env('baseUrl')}/remote.php/webdav/${fileName}`, file, {
-					headers: {
-						requesttoken: win.OC.requestToken,
-						'Content-Type': mimeType,
-					},
-				}).then(response => {
-					cy.log(`Uploaded ${fileName}`, response.status)
+			return cy.request('/csrftoken')
+				.then(({ body }) => body.token)
+				.then(requesttoken => {
+					return axios.put(`${Cypress.env('baseUrl')}/remote.php/webdav/${fileName}`, file, {
+						headers: {
+							requesttoken,
+							'Content-Type': mimeType,
+						},
+					}).then(response => {
+						cy.log(`Uploaded ${fileName}`, response.status)
+					})
 				})
-			})
 		})
 })
 
@@ -136,7 +106,7 @@ Cypress.Commands.add('createFile', (target, content, mimeType = 'text/markdown')
 
 })
 
-Cypress.Commands.add('shareFileToUser', (userId, password, path, targetUserId) => {
+Cypress.Commands.add('shareFileToUser', (user, path, targetUser) => {
 	cy.clearCookies()
 	cy.request({
 		method: 'POST',
@@ -145,19 +115,19 @@ Cypress.Commands.add('shareFileToUser', (userId, password, path, targetUserId) =
 		body: {
 			path,
 			shareType: 0,
-			shareWith: targetUserId,
+			shareWith: targetUser.userId,
 		},
-		auth: { user: userId, pass: password },
+		auth: { user: user.userId, password: user.password },
 		headers: {
 			'OCS-ApiRequest': 'true',
 			'Content-Type': 'application/x-www-form-urlencoded',
 		},
 	}).then(response => {
-		cy.log(`${userId} shared ${path} with ${targetUserId}`, response.status)
+		cy.log(`${user.userId} shared ${path} with ${targetUser.userId}`, response.status)
 	})
 })
 
-Cypress.Commands.add('isolateTest', ({ sourceFile = 'text.md', targetFile = null, onBeforeLoad } = {}) => {
+Cypress.Commands.add('isolateTest', ({ sourceFile = 'empty.md', targetFile = null, onBeforeLoad } = {}) => {
 	targetFile = targetFile || sourceFile
 
 	const retry = cy.state('test').currentRetry()
@@ -223,11 +193,11 @@ Cypress.Commands.add('copyFile', (path, destinationPath) => cy.window()
 	.then(win => win.OC.Files.getClient().copy(path, destinationPath))
 )
 
-Cypress.Commands.add('getFileContent', (userId, path) => {
+Cypress.Commands.add('getFileContent', (user, path) => {
 	return cy.request({
 		method: 'GET',
 		url: `${Cypress.env('baseUrl')}/remote.php/webdav/${path}`,
-		auth: { user: userId, pass: 'password' },
+		auth: { user: user.userId, pass: user.password },
 	}).then(response => {
 		cy.wrap(response.body)
 	})
@@ -277,6 +247,7 @@ Cypress.Commands.add('openFile', (fileName, params = {}) => {
 
 Cypress.Commands.add('closeFile', (fileName, params = {}) => {
 	cy.get('#viewer .modal-header button.header-close').click(params)
+	cy.get('#viewer .modal-header').should('not.exist')
 })
 
 Cypress.Commands.add('getFile', fileName => {

--- a/cypress/utils/index.js
+++ b/cypress/utils/index.js
@@ -20,6 +20,8 @@
  *
  */
 
+import { User } from '@nextcloud/cypress'
+
 export const getSearchParams = url => {
 	return url
 		.split(/[?&]/)
@@ -34,13 +36,14 @@ export const getSearchParams = url => {
  * Creates a new user with default passwort `password` and upload one or multiple test files
  * Can be used e.g. for a `before()`
  *
- * @param {string} userName Username of the user to create
+ * @param {User} user - to create
  * @param {...string} files one ore more markdown file names to create
  */
-export function initUserAndFiles(userName, ...files) {
+export function initUserAndFiles(user, ...files) {
 	// Init user
-	cy.nextcloudCreateUser(userName, 'password')
-	cy.login(userName, 'password')
+	cy.createUser(user)
+	cy.login(user)
+	cy.visit('/apps/files')
 
 	// Upload test files
 	;(files || []).forEach(file => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "@cypress/webpack-preprocessor": "^5.15.5",
         "@nextcloud/babel-config": "^1.0.0",
         "@nextcloud/browserslist-config": "^2.3.0",
+        "@nextcloud/cypress": "^1.0.0-beta.1",
         "@nextcloud/eslint-config": "^8.1.4",
         "@nextcloud/stylelint-config": "^2.3.0",
         "@nextcloud/webpack-vue-config": "^5.4.0",
@@ -3117,6 +3118,19 @@
       "integrity": "sha512-2TH2DzJBolYHWfbSovTWkByAIg0gdsyuVfZpf5APnJu/9PixXKbnrVFnaEdxjeP262Gok7ARMFFQeSiuzKRQeQ==",
       "dependencies": {
         "core-js": "^3.6.4"
+      }
+    },
+    "node_modules/@nextcloud/cypress": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/cypress/-/cypress-1.0.0-beta.1.tgz",
+      "integrity": "sha512-2tO8lGaeMLfyNDhqSXN8FVUXV6E6MPJSBdJs7y2jMg2lljtqJFo4ofgPi4bFksAVJK0qiqZInGn3UIzqMycyqQ==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0",
+        "npm": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependencies": {
+        "cypress": "^11.0.1"
       }
     },
     "node_modules/@nextcloud/dialogs": {
@@ -22056,6 +22070,13 @@
           }
         }
       }
+    },
+    "@nextcloud/cypress": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/cypress/-/cypress-1.0.0-beta.1.tgz",
+      "integrity": "sha512-2tO8lGaeMLfyNDhqSXN8FVUXV6E6MPJSBdJs7y2jMg2lljtqJFo4ofgPi4bFksAVJK0qiqZInGn3UIzqMycyqQ==",
+      "dev": true,
+      "requires": {}
     },
     "@nextcloud/dialogs": {
       "version": "4.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@cypress/webpack-preprocessor": "^5.15.5",
     "@nextcloud/babel-config": "^1.0.0",
     "@nextcloud/browserslist-config": "^2.3.0",
+    "@nextcloud/cypress": "^1.0.0-beta.1",
     "@nextcloud/eslint-config": "^8.1.4",
     "@nextcloud/stylelint-config": "^2.3.0",
     "@nextcloud/webpack-vue-config": "^5.4.0",


### PR DESCRIPTION

### 📝 Summary

Use `@nextcloud/cypress` to enable code sharing with other apps.

For now just using the new fast login method.
This reduces the time it takes to login by 6 sec. on my machine.

* See also: #2201

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/master/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
