### PR TITLE
Only scroll images into view when they're added

### DIFF
--- a/src/components/EditorWrapper.vue
+++ b/src/components/EditorWrapper.vue
@@ -528,6 +528,8 @@ export default {
 			} else {
 				this.$editor.chain().setImage({ src, alt }).insertContent('<br />').focus().run()
 			}
+			// Scroll image into view
+			this.$editor.commands.scrollIntoView()
 		},
 
 		onOpened({ document, session }) {

--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -309,9 +309,6 @@ export default {
 		},
 		onLoaded() {
 			this.loaded = true
-			this.$nextTick(() => {
-				this.editor.commands.scrollIntoView()
-			})
 		},
 		getTextApiUrl(imageFileName) {
 			const documentId = this.currentSession?.documentId


### PR DESCRIPTION
Instead of scrolling each image into view after it's been loaded, only scroll images into view when they got added to the document.

Fixes: #3531
Backports: #3532 
