### PR TITLE
test: open different mimetypes

### DIFF
--- a/cypress/e2e/files.spec.js
+++ b/cypress/e2e/files.spec.js
@@ -24,21 +24,29 @@ import { randUser } from '../utils/index.js'
 
 const user = randUser()
 
-describe('Files default view', () => {
+describe('Text and server mimetypes', () => {
 	before(() => {
 		cy.createUser(user)
 	})
 
 	beforeEach(() => {
 		cy.login(user)
+	})
+
+	it('handle plaintext in a pre tag', () => {
+		cy.uploadFile('empty.md', 'text/plain', 'textfile.txt')
 		cy.visit('/apps/files')
+		cy.get('#app-content-files table tr').should('contain', 'textfile.txt')
+		cy.openFile('textfile.txt')
+		cy.getContent().find('pre').should('exist')
 	})
 
-	it('See the default files list', () => {
-		cy.get('#app-content-files table tr').should('contain', 'welcome.txt')
+	it('handle markdown with richtext editor', () => {
+		cy.uploadFile('test.md', 'text/markdown', 'markdown.md')
+		cy.visit('/apps/files')
+		cy.get('#app-content-files table tr').should('contain', 'markdown.md')
+		cy.openFile('markdown.md')
+		cy.getContent().find('h2').should('contain', 'Hello world')
 	})
 
-	it('Take screenshot', () => {
-		cy.screenshot()
-	})
 })


### PR DESCRIPTION
Just `text/plain` and `text/markdown` for now.
Also provide some docs how to add more mimetypes to text. (taken from #394)

### 📝 Summary

* Prepares: testing more mimetypes in additions such as in #3535 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/master/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
