### PR TITLE
renovate: group cypress and @nextcloud/cypress together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,10 +28,10 @@
   ],
   "packageRules": [
     {
-      "groupName": "tiptap",
-      "matchPackagePrefixes": [
-        "@tiptap/",
-        "prosemirror-"
+      "groupName": "cypress",
+      "matchPackageNames": [
+        "cypress",
+        "@nextcloud/cypress"
       ]
     },
     {
@@ -47,6 +47,13 @@
         "jest",
         "@vue/vue2-jest",
         "jest-environment-jsdom"
+      ]
+    },
+    {
+      "groupName": "tiptap",
+      "matchPackagePrefixes": [
+        "@tiptap/",
+        "prosemirror-"
       ]
     },
     {


### PR DESCRIPTION
cypress is a peer dependency of @nextcloud/cypress. So they need to be updated together.
Updating one without the other fails. See:
* #3538
* #3546 