### PR TITLE
fix: flaky cypress test in workspace test

### DIFF
--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -90,13 +90,13 @@ describe('Workspace', function() {
 			['strikethrough', 's'],
 		].forEach(([button, tag]) => {
 			cy.getMenuEntry(button)
-				.click({ force: true })
+				.click()
 				.should('have.class', 'is-active')
 			cy.getContent()
 				.find(`${tag}`)
 				.should('contain', 'Format me')
 			cy.getMenuEntry(button)
-				.click({ force: true })
+				.click()
 				.should('not.have.class', 'is-active')
 		})
 	})
@@ -134,14 +134,14 @@ describe('Workspace', function() {
 			['task-list', 'ul[data-type="taskList"]'],
 		].forEach(([button, tag]) => {
 			cy.getMenuEntry(button)
-				.click({ force: true })
+				.click()
 				.should('have.class', 'is-active')
 
 			cy.getContent()
 				.find(`${tag}`).should('contain', 'List me')
 
 			cy.getMenuEntry(button)
-				.click({ force: true })
+				.click()
 				.should('not.have.class', 'is-active')
 		})
 	})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -295,7 +295,7 @@ Cypress.Commands.add('getMenu', { prevSubject: 'optional' }, (subject) => {
 // Get menu entry even if moved into overflow menu
 Cypress.Commands.add('getMenuEntry', (name) => {
 	cy.getMenu().then(($body) => {
-		if ($body.find(`[data-text-action-entry="${name}"]`).length) {
+		if ($body.find(`div.text-menubar__entries > [data-text-action-entry="${name}"]`).length) {
 			return cy.getActionEntry(name)
 		}
 		return cy.getSubmenuEntry('remain', name)


### PR DESCRIPTION
Fix the selector for main menu entries
to exclude entries of dangling submenus.

Whenever the strikethrough action was inside the remaining actions the `formats text` test would fail.

`getMenuEntry` always returned main menu entries directly. For entries of submenus it should open that submenu and then return the entry in question.

When attempting to click the strikethrough action
it would detect the action-entry in the remain actions drop down menu as if it was inside the main menu.
It would then return it without opening the remain menu.

The dangling menu with the action was hidden.
But since `click` was called with `force: true`
it would still happen.
However it had no impact.
The click just happened in the text field itself
where the detached menu was located but not clickable.

Fixing the selector to distinguish
between main menu actions and remaining actions
also allows us to drop some other `force` options.

