### PR TITLE
Fix/cypress flaky sections test

### DIFF
--- a/cypress/e2e/Table.spec.js
+++ b/cypress/e2e/Table.spec.js
@@ -18,7 +18,6 @@ describe('table plugin', () => {
 
 	beforeEach(() => {
 		cy.login(user)
-		cy.visit('/apps/files')
 
 		cy.isolateTest({
 			sourceFile: fileName,

--- a/cypress/e2e/links.spec.js
+++ b/cypress/e2e/links.spec.js
@@ -10,8 +10,6 @@ describe('test link marks', function() {
 
 	beforeEach(function() {
 		cy.login(user)
-		cy.visit('/apps/files')
-
 		cy.isolateTest({
 			sourceFile: fileName,
 			onBeforeLoad(win) {
@@ -19,9 +17,7 @@ describe('test link marks', function() {
 					.as('winOpen')
 			},
 		})
-
 		cy.openFile(fileName, { force: true })
-		return cy.clearContent()
 	})
 
 	describe('link preview', function() {

--- a/cypress/e2e/sections.spec.js
+++ b/cypress/e2e/sections.spec.js
@@ -21,16 +21,8 @@ describe('Content Sections', () => {
 	})
 
 	beforeEach(function() {
-		cy.login(user, {
-			onBeforeLoad(win) {
-				cy.stub(win, 'open')
-					.as('winOpen')
-			},
-		})
-		cy.visit('/apps/files')
-
+		cy.login(user)
 		cy.isolateTest({
-			sourceFile: fileName,
 			onBeforeLoad(win) {
 				cy.stub(win, 'open')
 					.as('winOpen')
@@ -38,7 +30,6 @@ describe('Content Sections', () => {
 		})
 
 		cy.openFile(fileName, { force: true })
-		return cy.clearContent()
 	})
 
 	describe('Heading anchors', () => {
@@ -58,7 +49,7 @@ describe('Content Sections', () => {
 		})
 
 		it('Anchor ID is updated', () => {
-			cy.clearContent()
+			cy.getContent()
 				.type('# Heading 1{enter}')
 				.then(() => {
 					cy.getContent()
@@ -88,7 +79,7 @@ describe('Content Sections', () => {
 
 		it('Anchor scrolls into view', () => {
 			// Create link to top heading
-			cy.clearContent()
+			cy.getContent()
 				.type('{selectAll}{backspace}move top\n{selectAll}')
 				.then(() => {
 					cy.getSubmenuEntry('insert-link', 'insert-link-website')

--- a/cypress/fixtures/anchors.md
+++ b/cypress/fixtures/anchors.md
@@ -1,0 +1,57 @@
+# top 
+
+[move to bottom](#bottom)
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+lorem ipsum 
+
+[move to top](#top)
+
+## Bottom


### PR DESCRIPTION
Upload the file with anchors instead of typing it in.

The typing failed in various ways.
Most of the time it would not close the heading
and instead type a lot of `lorem ipsum` headings.

This is based upon #3561 - please review that one first.