### PR TITLE
test: fix flaky cypress section test (again)

### DIFF
--- a/cypress/e2e/sections.spec.js
+++ b/cypress/e2e/sections.spec.js
@@ -88,7 +88,7 @@ describe('Content Sections', () => {
 				.should('not.be.inViewport')
 			cy.getContent()
 				.find('a[href="#bottom"]:not(.heading-anchor)')
-				.click({ force: true })
+				.click()
 			cy.getContent()
 				.get('h2[id="bottom"]')
 				.should('be.inViewport')


### PR DESCRIPTION
Wait for the link to load before clicking it.
Fixes flaky tests such as this one: https://cloud.cypress.io/projects/hx9gqy/runs/7903/test-results/fa066929-47a6-4878-bb58-08041fa52f7a