### PR TITLE
Use cypress helpers from `@nextcloud/cypress`

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -10,8 +10,6 @@ cy.getContent()
 ### Available custom commands
 | Command              | Function               | Parameters                          |
 | -------------------- | ---------------------- | ----------------------------------- |
-| `nextcloudUpdateUser`| Update user setting    | `user`, `password`, `key`, `value`  |
-| `nextcloudDeleteUser`| Delete user            | `user`                              |
 | `uploadFile`         | Upload file            | `fileName`, `mimeType`, `target`    |
 | `createFile`         | Create file            | `target`, `content`, `mimeType`     |
 | `moveFile`           | Move a file            | `path`, `destinationPath`           |
@@ -33,12 +31,4 @@ cy.getContent()
 | `getActionSubEntry`  | Get submenu entry (after menu clicked) | `name`              |
 | `openWorkspace`      | Open workspace and return Editor content |                   |
 
-### Commands from `@nextcloud/cypress`
-
-We also use some commands from `@nextcloud/cypress`:
-* `login(user)`
-* `logout()`
-* `createRandomUser().then(user => login(user))`
-* `createUser(user)`
-
-see https://github.com/nextcloud/nextcloud-cypress
+We also use some commands from the [`@nextcloud/cypress`](https://github.com/nextcloud/nextcloud-cypress) package.

--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -413,8 +413,8 @@ describe('Test all attachment insertion methods', () => {
 	})
 
 	it('Delete the user', () => {
-		cy.nextcloudDeleteUser(user)
-		cy.nextcloudDeleteUser(recipient)
+		cy.deleteUser(user)
+		cy.deleteUser(recipient)
 	})
 
 })

--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -273,7 +273,7 @@ describe('Workspace', function() {
 
 	describe('localize', () => {
 		it('takes localized file name into account', function() {
-			cy.updateUserSetting('language', 'de_DE')
+			cy.modifyUser(user, 'language', 'de_DE')
 			cy.uploadFile('test.md', 'text/markdown', `${Cypress.currentTest.title}/Anleitung.md`)
 			cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
 			cy.get('.files-fileList').should('contain', 'Anleitung.md')
@@ -282,7 +282,7 @@ describe('Workspace', function() {
 		})
 
 		it('ignores localized file name in other language', function() {
-			cy.updateUserSetting('language', 'fr')
+			cy.modifyUser(user, 'language', 'fr')
 			cy.uploadFile('test.md', 'text/markdown', `${Cypress.currentTest.title}/Anleitung.md`)
 			cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
 			cy.get('.files-fileList').should('contain', 'Anleitung.md')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -52,27 +52,6 @@ Cypress.Commands.add('ocsRequest', (options) => {
 	})
 })
 
-Cypress.Commands.add('updateUserSetting', (key, value) => {
-	cy.ocsRequest({
-		method: 'PUT',
-		url: `${url}/ocs/v2.php/cloud/users/${auth.user}`,
-		body: { key, value },
-	}).then(response => {
-		cy.log(`Updated ${auth.user} ${key} to ${value}`, response.status)
-	})
-})
-
-Cypress.Commands.add('nextcloudDeleteUser', (user) => {
-	cy.clearCookies()
-	cy.ocsRequest({
-		method: 'DELETE',
-		url: `${url}/ocs/v1.php/cloud/users/${user}`,
-		auth: { user: 'admin', pass: 'admin' },
-	}).then(response => {
-		cy.log(`Deleted user ${user}`, response.status)
-	})
-})
-
 Cypress.Commands.add('uploadFile', (fileName, mimeType, target) => {
 	return cy.fixture(fileName, 'base64')
 		.then(Cypress.Blob.base64StringToBlob)


### PR DESCRIPTION
### 📝 Summary
* Resolves only partly #2201 

Use user management commands from `@nextcloud/cypress` instead maintaining them by our self.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/master/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
