### PR TITLE
fix: use php 8.1 as that is required now

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: nextcloud/server
-          ref: ${{ matrix.server-versions }}
+          ref: debug/segfault-on-ci
 
       - name: Checkout submodules
         shell: bash

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -71,7 +71,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, zip, gd, apcu
+          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, zip, gd, apcu, imagick
           ini-values:
             apc.enable_cli=on
           coverage: none

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node-version: [16]
         containers: [1, 2, 3, 4]
-        php-versions: [ '7.4' ]
+        php-versions: [ '8.1' ]
         databases: [ 'sqlite' ]
         server-versions: [ 'master' ]
 


### PR DESCRIPTION
### 📝 Summary

* Resolves: CI failures such as https://github.com/nextcloud/text/actions/runs/3785280725
