### PR TITLE
Fix URL of GitHub workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nextcloud Text
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/nextcloud/text/Node)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/nextcloud/text/node.yml?branch=master)
 [![Start contributing](https://img.shields.io/github/issues/nextcloud/text/good%20first%20issue?color=7057ff&label=Contribute)](https://github.com/nextcloud/text/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22)
 
 


### PR DESCRIPTION
### 📝 Summary

Fix URL of CI workflow status, reference: https://github.com/badges/shields/issues/8671

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![badge broken](https://user-images.githubusercontent.com/1855448/210011874-1d2c1f3b-0774-4c12-94d8-528a7a12b06f.png) | ![badges shows status](https://user-images.githubusercontent.com/1855448/210011897-b0e36343-7974-4d1e-9cea-787ec54c393f.png)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/master/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
