### PR TITLE
Fix cypress tests after new files app sidebar

### DIFF
--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -59,7 +59,7 @@ describe('Workspace', function() {
 		cy.get('.files-fileList').should('contain', 'README.md')
 		cy.get('#rich-workspace .ProseMirror')
 			.should('contain', 'Hello world')
-		cy.get('.nav-recent')
+		cy.get('a[href*="/apps/files/recent"]')
 			.click()
 		cy.get('#rich-workspace .ProseMirror')
 			.should('not.exist')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -354,12 +354,13 @@ Cypress.Commands.add('configureText', (key, value) => {
 })
 
 Cypress.Commands.add('showHiddenFiles', () => {
-	cy.get('#app-settings-header')
+	cy.get('[data-cy-files-navigation-settings-button]')
 		.click()
-	cy.intercept({ method: 'POST', url: '**/showhidden' }).as('showHidden')
-	cy.get('#app-settings-content label[for=showhiddenfilesToggle]')
-		.click()
+	cy.get('.app-settings__content').should('be.visible')
+	cy.intercept({ method: 'POST', url: '**/show_hidden' }).as('showHidden')
+	cy.get('.app-settings__content').contains('Show hidden files').closest('label').click()
 	cy.wait('@showHidden')
+	cy.get('.modal-container__close').click()
 })
 
 Cypress.on(


### PR DESCRIPTION
### 📝 Summary

Fix cypress tests after https://github.com/nextcloud/server/pull/35772

- ci(cypress): Fix recent files list selector
- ci(cypress): Adapt showHiddenFiles to new settings modal selectors

### Todo

- [x] Remove temporary commit after https://github.com/nextcloud/server/pull/36008 is merged

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/master/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
