### PR TITLE
rename: master branch to main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,4 +20,4 @@ B | A
 - [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
 - [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
 - [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
-- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/master/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
+- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - master
       - stable*
 

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ["master", "stable25", "stable24"]
+        branches: ["main", "stable25", "stable24"]
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nextcloud Text
 
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/nextcloud/text/node.yml?branch=master)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/nextcloud/text/node.yml?branch=main)
 [![Start contributing](https://img.shields.io/github/issues/nextcloud/text/good%20first%20issue?color=7057ff&label=Contribute)](https://github.com/nextcloud/text/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22)
 
 
@@ -28,7 +28,7 @@ occ config:app:set text workspace_available --value=0
 
 ## 🏗 Development setup
 
-Currently this app requires the master branch of the [Viewer app](https://github.com/nextcloud/viewer).
+Currently this app requires the main branch of the [Viewer app](https://github.com/nextcloud/viewer).
 
 1. ☁ Clone this app into the `apps` folder of your Nextcloud: `git clone https://github.com/nextcloud/text.git`
 2. 👩‍💻 In the folder of the app, run the command `make` to install dependencies and build the Javascript.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,9 +23,9 @@
 	<website>https://github.com/nextcloud/text</website>
 	<bugs>https://github.com/nextcloud/text/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/text.git</repository>
-	<screenshot>https://raw.githubusercontent.com/nextcloud/text/master/img/screenshots/screenshot1.png</screenshot>
-	<screenshot>https://raw.githubusercontent.com/nextcloud/text/master/img/screenshots/screenshot2.png</screenshot>
-	<screenshot>https://raw.githubusercontent.com/nextcloud/text/master/img/screenshots/screenshot3.gif</screenshot>
+	<screenshot>https://raw.githubusercontent.com/nextcloud/text/main/img/screenshots/screenshot1.png</screenshot>
+	<screenshot>https://raw.githubusercontent.com/nextcloud/text/main/img/screenshots/screenshot2.png</screenshot>
+	<screenshot>https://raw.githubusercontent.com/nextcloud/text/main/img/screenshots/screenshot3.gif</screenshot>
 	<dependencies>
 		<nextcloud min-version="26" max-version="26" />
 	</dependencies>

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
   "rebaseWhen": "conflicted",
   "ignoreUnstable": false,
   "baseBranches": [
-    "master",
+    "main",
     "stable25",
     "stable24",
     "stable23"


### PR DESCRIPTION
Rename `master` branch to `main` to avoid using terms associated with slavery and exploitation.