### PR TITLE
Always provide original GIF file

### DIFF
--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -121,6 +121,10 @@ class AttachmentService {
 		$attachmentFolder = $this->getAttachmentDirectoryForFile($textFile, true);
 		$imageFile = $attachmentFolder->get($imageFileName);
 		if ($imageFile instanceof File && in_array($imageFile->getMimetype(), AttachmentController::IMAGE_MIME_TYPES)) {
+			// previews of gifs are static images, always provide the real gif
+			if ($imageFile->getMimetype() === 'image/gif') {
+				return $imageFile;
+			}
 			// we might prefer the raw image
 			if ($preferRawImage && in_array($imageFile->getMimetype(), AttachmentController::BROWSER_SUPPORTED_IMAGE_MIME_TYPES)) {
 				return $imageFile;


### PR DESCRIPTION
Previews of GIF files are static images so we might prefer to always provide the raw file to the editor.