### PR TITLE
Update cypress to use php 8.1

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -75,7 +75,7 @@ jobs:
       matrix:
         node-version: [16]
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
-        php-versions: [ '7.4' ]
+        php-versions: [ '8.1' ]
         databases: [ 'sqlite' ]
         server-versions: [ 'master' ]
 


### PR DESCRIPTION
Server now requires at least php 8.0
