### PR TITLE
Fix bug when session not found

### DIFF
--- a/lib/Controller/SessionController.php
+++ b/lib/Controller/SessionController.php
@@ -113,9 +113,11 @@ class SessionController extends Controller {
 
 	private function loginSessionUser(int $documentId, int $sessionId, string $sessionToken) {
 		$currentSession = $this->sessionService->getSession($documentId, $sessionId, $sessionToken);
-		$user = $this->userManager->get($currentSession->getUserId());
-		if ($user !== null) {
-			$this->userSession->setUser($user);
+		if ($currentSession !== false) {
+			$user = $this->userManager->get($currentSession->getUserId());
+			if ($user !== null) {
+				$this->userSession->setUser($user);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fix potential crash when trying to use the document session's user when the session is not found.

Maybe there's a better way to fix this if we identify the reason it happens and fix stuff in an upper level :grin:.

I don't know when, but this is what happens:

```
{"reqId":"XXXXX","level":3,"time":"2023-01-27T09:47:02+00:00","remoteAddr":"XXXXX","user":"XXXXX","app":"index","method":"POST","url":"/apps/text/session/sync","message":"Call to a member function getUserId() on bool in file 'XXXXX/apps/text/lib/Controller/SessionController.php' line 116","userAgent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Edg/108.0.1462.76","version":"25.0.3.2","exception":{"Exception":"Exception","Message":"Call to a member function getUserId() on bool in file 'XXXXX/apps/text/lib/Controller/SessionController.php' line 116","Code":0,"Trace":[{"file":"XXXXX/lib/private/AppFramework/App.php","line":172,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[{"__class__":"OCA\\Text\\Controller\\SessionController"},"sync"]},{"file":"XXXXX/lib/private/Route/Router.php","line":298,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OCA\\Text\\Controller\\SessionController","sync",{"__class__":"OC\\AppFramework\\DependencyInjection\\DIContainer"},["text.Session.sync"]]},{"file":"XXXXX/lib/base.php","line":1047,"function":"match","class":"OC\\Route\\Router","type":"->","args":["/apps/text/session/sync"]},{"file":"XXXXX/index.php","line":36,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"XXXXX/lib/private/AppFramework/Http/Dispatcher.php","Line":165,"Previous":{"Exception":"Error","Message":"Call to a member function getUserId() on bool","Code":0,"Trace":[{"file":"XXXXX/nextcloud/apps/text/lib/Controller/SessionController.php","line":91,"function":"loginSessionUser","class":"OCA\\Text\\Controller\\SessionController","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"XXXXX/lib/private/AppFramework/Http/Dispatcher.php","line":225,"function":"sync","class":"OCA\\Text\\Controller\\SessionController","type":"->","args":["*** sensitive parameters replaced ***","*** sensitive parameters replaced ***","*** sensitive parameters replaced ***",8,null,false,false]},{"file":"XXXXX/nextcloud/lib/private/AppFramework/Http/Dispatcher.php","line":133,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[{"__class__":"OCA\\Text\\Controller\\SessionController"},"sync"]},{"file":"XXXXX/lib/private/AppFramework/App.php","line":172,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[{"__class__":"OCA\\Text\\Controller\\SessionController"},"sync"]},{"file":"XXXXX/lib/private/Route/Router.php","line":298,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OCA\\Text\\Controller\\SessionController","sync",{"__class__":"OC\\AppFramework\\DependencyInjection\\DIContainer"},["text.Session.sync"]]},{"file":"XXXXX/lib/base.php","line":1047,"function":"match","class":"OC\\Route\\Router","type":"->","args":["/apps/text/session/sync"]},{"file":"XXXXX/index.php","line":36,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"XXXXX/apps/text/lib/Controller/SessionController.php","Line":116},"CustomMessage":"--"},"id":"63d39fcecf173"}
```
