### PR TITLE
Fix background color of tables

### DIFF
--- a/css/prosemirror.scss
+++ b/css/prosemirror.scss
@@ -226,14 +226,12 @@ div.ProseMirror {
 	}
 
 	// table variables
-	@at-root :root {
-		--table-color-border: var(--color-border);
-		--table-color-heading: var(--color-text-maxcontrast);
-		--table-color-heading-border: var(--color-border-dark);
-		--table-color-background: var(--color-main-background);
-		--table-color-background-hover: var(--color-primary-light);
-		--table-border-radius: var(--border-radius);
-	}
+	--table-color-border: var(--color-border);
+	--table-color-heading: var(--color-text-maxcontrast);
+	--table-color-heading-border: var(--color-border-dark);
+	--table-color-background: var(--color-main-background);
+	--table-color-background-hover: var(--color-primary-light);
+	--table-border-radius: var(--border-radius);
 
 	table {
 		border-spacing: 0;


### PR DESCRIPTION
### 📝 Summary

* Resolves: #3369

The server css variables are set on the body tag currently, so if we use those variables, e.g. for aliasing them as done here, they need to be evaluated on the same or a child node. This means we can not define aliases on the `:root` element.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![black background on bright theme, unreadable](https://user-images.githubusercontent.com/1855448/216052064-52f223e8-1051-4b88-903a-078a43b4d895.png) | ![white background, good readable](https://user-images.githubusercontent.com/1855448/216052086-6e2d201a-a0d1-4325-a652-1390c2f39cef.png)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
