### PR TITLE
fix: solve publicly shared document with hide download issue

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -517,10 +517,6 @@ class DocumentService {
 		if (($share->getPermissions() & $permission) === 0) {
 			throw new NotFoundException();
 		}
-
-		if ($share->getHideDownload()) {
-			throw new NotPermittedException();
-		}
 	}
 
 	public function hasUnsavedChanges(Document $document) {


### PR DESCRIPTION
Signed-off-by: Luka Trovic <luka@nextcloud.com>

### 📝 Summary

* Resolves: #3704

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
