### PR TITLE
Add repair step to reset all sessions before Yjs migration

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 - **💾 Open format:** Files are saved as [Markdown](https://en.wikipedia.org/wiki/Markdown), so you can edit them from any other text app too.
 - **✊ Strong foundation:** We use [🐈 tiptap](https://tiptap.scrumpy.io) which is based on [🦉 ProseMirror](https://prosemirror.net) – huge thanks to them!
 	]]></description>
-	<version>3.7.1</version>
+	<version>3.7.2</version>
 	<licence>agpl</licence>
 	<author mail="jus@bitgrid.net">Julius Härtl</author>
 	<namespace>Text</namespace>
@@ -40,4 +40,9 @@
 			<plugin>OCA\Text\DAV\WorkspacePlugin</plugin>
 		</plugins>
 	</sabre>
+	<repair-steps>
+		<post-migration>
+			<step>OCA\Text\Migration\ResetSessionsBeforeYjs</step>
+		</post-migration>
+	</repair-steps>
 </info>

--- a/composer/composer/autoload_classmap.php
+++ b/composer/composer/autoload_classmap.php
@@ -39,6 +39,7 @@ return array(
     'OCA\\Text\\Listeners\\LoadViewerListener' => $baseDir . '/../lib/Listeners/LoadViewerListener.php',
     'OCA\\Text\\Listeners\\NodeCopiedListener' => $baseDir . '/../lib/Listeners/NodeCopiedListener.php',
     'OCA\\Text\\Listeners\\RegisterDirectEditorEventListener' => $baseDir . '/../lib/Listeners/RegisterDirectEditorEventListener.php',
+    'OCA\\Text\\Migration\\ResetSessionsBeforeYjs' => $baseDir . '/../lib/Migration/ResetSessionsBeforeYjs.php',
     'OCA\\Text\\Migration\\Version010000Date20190617184535' => $baseDir . '/../lib/Migration/Version010000Date20190617184535.php',
     'OCA\\Text\\Migration\\Version030001Date20200402075029' => $baseDir . '/../lib/Migration/Version030001Date20200402075029.php',
     'OCA\\Text\\Migration\\Version030201Date20201116110353' => $baseDir . '/../lib/Migration/Version030201Date20201116110353.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -54,6 +54,7 @@ class ComposerStaticInitText
         'OCA\\Text\\Listeners\\LoadViewerListener' => __DIR__ . '/..' . '/../lib/Listeners/LoadViewerListener.php',
         'OCA\\Text\\Listeners\\NodeCopiedListener' => __DIR__ . '/..' . '/../lib/Listeners/NodeCopiedListener.php',
         'OCA\\Text\\Listeners\\RegisterDirectEditorEventListener' => __DIR__ . '/..' . '/../lib/Listeners/RegisterDirectEditorEventListener.php',
+        'OCA\\Text\\Migration\\ResetSessionsBeforeYjs' => __DIR__ . '/..' . '/../lib/Migration/ResetSessionsBeforeYjs.php',
         'OCA\\Text\\Migration\\Version010000Date20190617184535' => __DIR__ . '/..' . '/../lib/Migration/Version010000Date20190617184535.php',
         'OCA\\Text\\Migration\\Version030001Date20200402075029' => __DIR__ . '/..' . '/../lib/Migration/Version030001Date20200402075029.php',
         'OCA\\Text\\Migration\\Version030201Date20201116110353' => __DIR__ . '/..' . '/../lib/Migration/Version030201Date20201116110353.php',

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -36,6 +36,17 @@ class SessionMapper extends QBMapper {
 	}
 
 	/**
+	 * @return array
+	 */
+	public function findAllDocuments(): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName());
+
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * @param $documentId
 	 * @param $sessionId
 	 * @param $token

--- a/lib/Migration/ResetSessionsBeforeYjs.php
+++ b/lib/Migration/ResetSessionsBeforeYjs.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace OCA\Text\Migration;
+
+use OCA\Text\Db\SessionMapper;
+use OCA\Text\Service\DocumentService;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class ResetSessionsBeforeYjs implements IRepairStep {
+	private IConfig $config;
+	private SessionMapper $sessionMapper;
+	private DocumentService $documentService;
+
+	public function __construct(IConfig $config,
+								SessionMapper $sessionMapper,
+								DocumentService $documentService) {
+		$this->config = $config;
+		$this->sessionMapper = $sessionMapper;
+		$this->documentService = $documentService;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName(): string {
+		return 'Force-reset all Text sessions before Yjs migration';
+	}
+
+	/**
+	 * @param IOutput $output
+	 *
+	 * @return void
+	 */
+	public function run(IOutput $output): void {
+		$appVersion = $this->config->getAppValue('text', 'installed_version');
+
+		if (!$appVersion || version_compare($appVersion, '3.7.2') !== -1) {
+			return;
+		}
+
+		$sessions = $this->sessionMapper->findAllDocuments();
+		if (!$sessions) {
+			return;
+		}
+
+		$output->startProgress(count($sessions));
+		foreach ($sessions as $session) {
+			$documentId = $session->getDocumentId();
+			$this->documentService->unlock($documentId);
+			$this->documentService->resetDocument($documentId, true);
+			$output->advance();
+		}
+		$output->finishProgress();
+	}
+}

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -339,7 +339,7 @@ class DocumentService {
 	 * @param bool $force
 	 * @throws DocumentHasUnsavedChangesException
 	 */
-	public function resetDocument(int $documentId, $force = false): void {
+	public function resetDocument(int $documentId, bool $force = false): void {
 		try {
 			$this->unlock($documentId);
 


### PR DESCRIPTION
Text sessions with data from our old collaboration backend cause issues after the upgrade to Text with the new Yjs backend. Therefore let's force-reset all sessions when upgrading from a Text version smaller than 3.7.1.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
