### PR TITLE
fix: Provide file id for single file share links

### DIFF
--- a/cypress/e2e/share.spec.js
+++ b/cypress/e2e/share.spec.js
@@ -135,4 +135,17 @@ describe('Open test.md in viewer', function() {
 		})
 	})
 
+	it('makes use of the file id', function() {
+		cy.intercept({ method: 'PUT', url: '**/apps/text/public/session/create' })
+			.as('create')
+		cy.shareFile('/test2.md', { edit: true })
+			.then((token) => {
+				cy.logout()
+				cy.visit(`/s/${token}`)
+			})
+		cy.wait('@create', { timeout: 10000 })
+			.its('request.body.fileId')
+			.should('be.a', 'Number')
+	})
+
 })

--- a/lib/Listeners/FilesSharingLoadAdditionalScriptsListener.php
+++ b/lib/Listeners/FilesSharingLoadAdditionalScriptsListener.php
@@ -25,13 +25,14 @@ declare(strict_types=1);
 
 namespace OCA\Text\Listeners;
 
+use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
 use OCA\Text\Service\InitialStateProvider;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
 use OCP\Util;
 
-/** @implements IEventListener<Event> */
+/** @implements IEventListener<Event|BeforeTemplateRenderedEvent> */
 class FilesSharingLoadAdditionalScriptsListener implements IEventListener {
 	protected InitialStateProvider $initialStateProvider;
 
@@ -43,5 +44,9 @@ class FilesSharingLoadAdditionalScriptsListener implements IEventListener {
 		Util::addScript('text', 'text-public');
 
 		$this->initialStateProvider->provideState();
+		$node = $event->getShare()->getNode();
+		if ($node instanceof \OCP\Files\File) {
+			$this->initialStateProvider->provideFileId($node->getId());
+		}
 	}
 }

--- a/lib/Service/InitialStateProvider.php
+++ b/lib/Service/InitialStateProvider.php
@@ -36,4 +36,8 @@ class InitialStateProvider {
 			$this->configService->isRichEditingEnabled()
 		);
 	}
+
+	public function provideFileId(int $fileId): void {
+		$this->initialState->provideInitialState('fileId', $fileId);
+	}
 }

--- a/lib/Service/InitialStateProvider.php
+++ b/lib/Service/InitialStateProvider.php
@@ -38,6 +38,6 @@ class InitialStateProvider {
 	}
 
 	public function provideFileId(int $fileId): void {
-		$this->initialState->provideInitialState('fileId', $fileId);
+		$this->initialState->provideInitialState('file_id', $fileId);
 	}
 }

--- a/src/public.js
+++ b/src/public.js
@@ -13,7 +13,7 @@ import store from './store/index.js'
 __webpack_nonce__ = btoa(OC.requestToken) // eslint-disable-line
 __webpack_public_path__ = OC.linkTo('text', 'js/') // eslint-disable-line
 
-const loadEditor = ({ sharingToken, mimetype, $el }) => {
+const loadEditor = ({ sharingToken, mimetype, fileId, $el }) => {
 	const container = document.createElement('div')
 	container.id = 'texteditor'
 
@@ -37,6 +37,7 @@ const loadEditor = ({ sharingToken, mimetype, $el }) => {
 						active: true,
 						shareToken: sharingToken,
 						mime: mimetype,
+						fileId,
 					},
 				}),
 				store,
@@ -67,7 +68,9 @@ documentReady(() => {
 
 	// single file share
 	if (openMimetypes.indexOf(mimetype) !== -1) {
-		loadEditor({ mimetype, sharingToken, $el: document.getElementById('preview') })
+		const $el = document.getElementById('preview')
+		const fileId = loadState('text', 'file_id')
+		loadEditor({ mimetype, sharingToken, fileId, $el })
 	}
 })
 

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -14,6 +14,12 @@ namespace OCA\Viewer\Event {
 	class LoadViewer extends \OCP\EventDispatcher\Event {}
 }
 
+namespace OCA\Files_Sharing\Event {
+	class BeforeTemplateRenderedEvent extends \OCP\EventDispatcher\Event {
+		abstract public function getShare(): \OCP\Share\IShare;
+	}
+}
+
 namespace OC\User {
 	class NoUserException extends \Exception {}
 }


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
