### PR TITLE
Use NcRichText component from `@nextcloud/vue`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@nextcloud/moment": "^1.2.1",
     "@nextcloud/router": "^2.0.1",
     "@nextcloud/vue": "^7.7.1",
-    "@nextcloud/vue-richtext": "^2.1.0-beta.5",
     "@quartzy/markdown-it-mentions": "^0.2.0",
     "@tiptap/core": "^2.0.0-beta.220",
     "@tiptap/extension-blockquote": "^2.0.0-beta.220",

--- a/src/components/Menu/ActionInsertLink.vue
+++ b/src/components/Menu/ActionInsertLink.vue
@@ -79,7 +79,7 @@
 
 <script>
 import { NcActions, NcActionButton, NcActionInput } from '@nextcloud/vue'
-import { getLinkWithPicker } from '@nextcloud/vue-richtext'
+import { getLinkWithPicker } from '@nextcloud/vue/dist/Components/NcRichText.js'
 import { FilePicker, FilePickerType } from '@nextcloud/dialogs'
 
 import { getMarkAttributes, isActive } from '@tiptap/core'

--- a/src/components/Suggestion/LinkPicker/suggestions.js
+++ b/src/components/Suggestion/LinkPicker/suggestions.js
@@ -22,7 +22,7 @@
 import createSuggestions from '../suggestions.js'
 import LinkPickerList from './LinkPickerList.vue'
 
-import { searchProvider, getLinkWithPicker } from '@nextcloud/vue-richtext'
+import { searchProvider, getLinkWithPicker } from '@nextcloud/vue/dist/Components/NcRichText.js'
 
 export default () => createSuggestions({
 	listComponent: LinkPickerList,

--- a/src/nodes/ParagraphView.vue
+++ b/src/nodes/ParagraphView.vue
@@ -23,7 +23,7 @@
 <template>
 	<NodeViewWrapper class="vue-component" as="p">
 		<NodeViewContent class="paragraph-content" />
-		<ReferenceList v-if="text"
+		<NcReferenceList v-if="text"
 			:text="text"
 			:limit="1"
 			contenteditable="false" />
@@ -32,17 +32,15 @@
 
 <script>
 import { NodeViewContent, nodeViewProps, NodeViewWrapper } from '@tiptap/vue-2'
-import { ReferenceList } from '@nextcloud/vue-richtext'
+import { NcReferenceList } from '@nextcloud/vue/dist/Components/NcRichText.js'
 import debounce from 'debounce'
-
-import '@nextcloud/vue-richtext/dist/style.css'
 
 export default {
 	name: 'ParagraphView',
 	components: {
 		NodeViewWrapper,
 		NodeViewContent,
-		ReferenceList,
+		NcReferenceList,
 	},
 	props: nodeViewProps,
 	data() {


### PR DESCRIPTION
:tada: Circular dependency is definitely going down with the next `@nextcloud/vue` release which will includes `NcRichText` and everything needed for the link picker and the reference widgets.

refs https://github.com/nextcloud/nextcloud-vue/pull/3841 https://github.com/nextcloud/nextcloud-vue/issues/3812

I'll update `@nextcloud/vue` and set this to "ready for review" once the new release is out.