### PR TITLE
chore(ci): Set server branch to `stable26` in Cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -77,7 +77,7 @@ jobs:
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
         php-versions: [ '8.1' ]
         databases: [ 'sqlite' ]
-        server-versions: [ 'master' ]
+        server-versions: [ 'stable26' ]
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
### 📝 Summary

