### PR TITLE
Avoid cleanup on close to not run into race conditions with other sessions on the same document

### DIFF
--- a/cypress/e2e/SessionApi.spec.js
+++ b/cypress/e2e/SessionApi.spec.js
@@ -350,7 +350,8 @@ describe('The session Api', function() {
 		})
 
 		// Failed with a probability of ~ 50% initially
-		it('ignores steps stored after close cleaned up', function() {
+		// Skipped for now since the behaviour chanced by not cleaning up the state on close/create
+		it.skip('ignores steps stored after close cleaned up', function() {
 			cy.pushAndClose({ connection, steps: [messages.update], version })
 			cy.createTextSession(undefined, { filePath: '', shareToken })
 				.then(con => {

--- a/cypress/e2e/sync.spec.js
+++ b/cypress/e2e/sync.spec.js
@@ -95,14 +95,14 @@ describe('Sync', () => {
 			.should('include', 'after the lost connection')
 	})
 
-	it('passes the doc content from one session to the next', () => {
+	it.only('passes the doc content from one session to the next', () => {
 		cy.closeFile()
 		cy.intercept({ method: 'PUT', url: '**/apps/text/session/create' })
 			.as('create')
 		cy.openTestFile()
 		cy.wait('@create', { timeout: 10000 })
 			.its('response.body')
-			.should('have.property', 'content')
+			.should('have.property', 'documentState')
 			.should('not.be.empty')
 		cy.getContent().find('h2').should('contain', 'Hello world')
 		cy.getContent().find('li').should('contain', 'Saving the doc saves the doc state')

--- a/lib/Controller/PublicSessionController.php
+++ b/lib/Controller/PublicSessionController.php
@@ -66,8 +66,8 @@ class PublicSessionController extends PublicShareController {
 	 * @NoAdminRequired
 	 * @PublicPage
 	 */
-	public function create(string $token, string $file = null, $guestName = null, bool $forceRecreate = false): DataResponse {
-		return $this->apiService->create(null, $file, $token, $guestName, $forceRecreate);
+	public function create(string $token, string $file = null, $guestName = null): DataResponse {
+		return $this->apiService->create(null, $file, $token, $guestName);
 	}
 
 	/**

--- a/lib/Controller/SessionController.php
+++ b/lib/Controller/SessionController.php
@@ -53,8 +53,8 @@ class SessionController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	public function create(int $fileId = null, string $file = null, bool $forceRecreate = false): DataResponse {
-		return $this->apiService->create($fileId, $file, null, null, $forceRecreate);
+	public function create(int $fileId = null, string $file = null): DataResponse {
+		return $this->apiService->create($fileId, $file, null, null);
 	}
 
 	/**

--- a/lib/Cron/Cleanup.php
+++ b/lib/Cron/Cleanup.php
@@ -79,7 +79,7 @@ class Cleanup extends TimedJob {
 				$this->logger->error('Document ' . $session->getDocumentId() . ' has not been reset, as an error occured', ['exception' => $e]);
 			}
 		}
-		$removedSessions = $this->sessionService->removeInactiveSessions(null);
+		$removedSessions = $this->sessionService->removeInactiveSessionsWithoutSteps(null);
 		$this->logger->debug('Removed ' . $removedSessions . ' inactive sessions');
 	}
 }

--- a/lib/Cron/Cleanup.php
+++ b/lib/Cron/Cleanup.php
@@ -28,8 +28,6 @@ declare(strict_types=1);
 
 namespace OCA\Text\Cron;
 
-use OCA\Text\Db\Session;
-use OCA\Text\Exception\DocumentHasUnsavedChangesException;
 use OCA\Text\Service\DocumentService;
 use OCA\Text\Service\AttachmentService;
 use OCA\Text\Service\SessionService;
@@ -57,28 +55,24 @@ class Cleanup extends TimedJob {
 	}
 
 	protected function run($argument) {
-		$this->logger->debug('Run cleanup job for text sessions');
-		$inactive = $this->sessionService->findAllInactive();
-		/** @var Session $session */
-		foreach ($inactive as $session) {
-			$activeSessions = $this->sessionService->getActiveSessions($session->getDocumentId());
-			if (count($activeSessions) > 0) {
+		$this->logger->debug('Run cleanup job for text documents');
+		$documents = $this->documentService->getAll();
+		foreach ($documents as $document) {
+			$allSessions = $this->sessionService->getAllSessions($document->getId());
+			if (count($allSessions) > 0) {
+				// Do not reset if there are any sessions left
+				// Inactive sessions will get removed further down and will trigger a reset next time
 				continue;
 			}
 
-			$this->documentService->unlock($session->getDocumentId());
-
-			try {
-				$this->logger->debug('Resetting document ' . $session->getDocumentId() . '');
-				$this->documentService->resetDocument($session->getDocumentId());
-				$this->attachmentService->cleanupAttachments($session->getDocumentId());
-				$this->logger->debug('Resetting document ' . $session->getDocumentId() . '');
-			} catch (DocumentHasUnsavedChangesException $e) {
-				$this->logger->info('Document ' . $session->getDocumentId() . ' has not been reset, as it has unsaved changes');
-			} catch (\Throwable $e) {
-				$this->logger->error('Document ' . $session->getDocumentId() . ' has not been reset, as an error occured', ['exception' => $e]);
+			if ($this->documentService->hasUnsavedChanges($document)) {
+				continue;
 			}
+
+			$this->documentService->resetDocument($document->getId());
 		}
+
+		$this->logger->debug('Run cleanup job for text sessions');
 		$removedSessions = $this->sessionService->removeInactiveSessionsWithoutSteps(null);
 		$this->logger->debug('Removed ' . $removedSessions . ' inactive sessions');
 	}

--- a/lib/Db/DocumentMapper.php
+++ b/lib/Db/DocumentMapper.php
@@ -54,4 +54,13 @@ class DocumentMapper extends QBMapper {
 		}
 		return Document::fromRow($data);
 	}
+
+	public function findAll(): array {
+		$qb = $this->db->getQueryBuilder();
+		$result = $qb->select('*')
+			->from($this->getTableName())
+			->execute();
+
+		return $this->findEntities($qb);
+	}
 }

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -99,7 +99,7 @@ class SessionMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
-	public function deleteInactive($documentId = -1) {
+	public function deleteInactiveWithoutSteps($documentId = -1) {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('session_id')
 			->from('text_steps');

--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -120,6 +120,7 @@ class ApiService {
 				try {
 					$this->logger->info('Attempt to reset document during session create for ' . $file->getId());
 					$this->documentService->resetDocument($file->getId(), $forceRecreate);
+					$this->attachmentService->cleanupAttachments($file->getId());
 				} catch (DocumentHasUnsavedChangesException $e) {
 					$this->logger->debug('Failed to reset document during session create for ' . $file->getId(), [
 						'remainingSessions' => $remainingSessions,

--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -185,6 +185,10 @@ class ApiService {
 	public function close($documentId, $sessionId, $sessionToken): DataResponse {
 		$this->sessionService->closeSession($documentId, $sessionId, $sessionToken);
 		$this->sessionService->removeInactiveSessionsWithoutSteps($documentId);
+		$activeSessions = $this->sessionService->getActiveSessions($documentId);
+		if (count($activeSessions) === 0) {
+			$this->documentService->unlock($documentId);
+		}
 		return new DataResponse([]);
 	}
 

--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -112,7 +112,7 @@ class ApiService {
 
 			$readOnly = $this->documentService->isReadOnly($file, $token);
 
-			$this->sessionService->removeInactiveSessions($file->getId());
+			$this->sessionService->removeInactiveSessionsWithoutSteps($file->getId());
 			$remainingSessions = $this->sessionService->getAllSessions($file->getId());
 			$freshSession = false;
 			if ($forceRecreate || count($remainingSessions) === 0) {
@@ -183,17 +183,7 @@ class ApiService {
 
 	public function close($documentId, $sessionId, $sessionToken): DataResponse {
 		$this->sessionService->closeSession($documentId, $sessionId, $sessionToken);
-		$this->sessionService->removeInactiveSessions($documentId);
-		$activeSessions = $this->sessionService->getActiveSessions($documentId);
-		if (count($activeSessions) === 0) {
-			try {
-				$this->documentService->resetDocument($documentId);
-				$this->attachmentService->cleanupAttachments($documentId);
-				$this->logger->info('Reset unsaved changes of ' . $documentId);
-			} catch (DocumentHasUnsavedChangesException $e) {
-				$this->logger->error('Did not reset unsaved changes during close of ' . $documentId, ['exception' => $e]);
-			}
-		}
+		$this->sessionService->removeInactiveSessionsWithoutSteps($documentId);
 		return new DataResponse([]);
 	}
 

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -332,6 +332,22 @@ class DocumentService {
 			return $document;
 		}
 
+		if (empty($autoaveDocument)) {
+			$this->logger->debug('Saving empty document', [
+				'requestVersion' => $version,
+				'requestAutosaveDocument' => $autoaveDocument,
+				'requestDocumentState' => $documentState,
+				'document' => $document->jsonSerialize(),
+				'fileSizeBeforeSave' => $file->getSize(),
+				'steps' => array_map(function (Step $step) {
+					return $step->jsonSerialize();
+				}, $this->stepMapper->find($documentId, 0)),
+				'sessions' => array_map(function (Session $session) {
+					return $session->jsonSerialize();
+				}, $this->sessionMapper->findAll($documentId))
+			]);
+		}
+
 		$this->cache->set('document-save-lock-' . $documentId, true, 10);
 		try {
 			$this->lockManager->runInScope(new LockContext(

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -127,7 +127,7 @@ class DocumentService {
 			// This way the user can still resolve conflicts in the editor view
 			$stepsVersion = $this->stepMapper->getLatestVersion($document->getId());
 			if ($stepsVersion && ($document->getLastSavedVersion() !== $stepsVersion)) {
-				$this->logger->debug('Unsaved steps but collission with file, continue collaborative editing');
+				$this->logger->debug('Unsaved steps, continue collaborative editing');
 				return $document;
 			}
 			return $document;
@@ -258,6 +258,7 @@ class DocumentService {
 			}
 			$stepsVersion = $this->stepMapper->getLatestVersion($document->getId());
 			$newVersion = $stepsVersion + count($steps);
+			$this->logger->debug("Adding steps to $documentId: bumping version from $stepsVersion to $newVersion");
 			$this->cache->set('document-version-' . $document->getId(), $newVersion);
 			$step = new Step();
 			$step->setData($stepsJson);

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -112,6 +112,14 @@ class DocumentService {
 		}
 	}
 
+	public function getDocument(File $file): ?Document {
+		try {
+			return $this->documentMapper->find($file->getId());
+		} catch (DoesNotExistException|NotFoundException $e) {
+			return null;
+		}
+	}
+
 	/**
 	 * @param File $file
 	 * @return Entity
@@ -383,6 +391,7 @@ class DocumentService {
 		try {
 			$document = $this->documentMapper->find($documentId);
 			if (!$force && $this->hasUnsavedChanges($document)) {
+				$this->logger->debug('did not reset document for ' . $documentId);
 				throw new DocumentHasUnsavedChangesException('Did not reset document, as it has unsaved changes');
 			}
 
@@ -393,6 +402,7 @@ class DocumentService {
 			$this->documentMapper->delete($document);
 
 			$this->getStateFile($documentId)->delete();
+			$this->logger->debug('document reset for ' . $documentId);
 		} catch (DoesNotExistException|NotFoundException $e) {
 			// Ignore if document not found or state file not found
 		}

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -408,6 +408,10 @@ class DocumentService {
 		}
 	}
 
+	public function getAll() {
+		return $this->documentMapper->findAll();
+	}
+
 	/**
 	 * @param Session $session
 	 * @param $shareToken

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -360,15 +360,16 @@ class DocumentService {
 					$this->writeDocumentState($file->getId(), $documentState);
 				}
 			});
+			$document->setLastSavedVersion($stepsVersion);
+			$document->setLastSavedVersionTime(time());
+			$document->setLastSavedVersionEtag($file->getEtag());
+			$this->documentMapper->update($document);
 		} catch (LockedException $e) {
 			// Ignore lock since it might occur when multiple people save at the same time
 			return $document;
+		} finally {
+			$this->cache->remove('document-save-lock-' . $documentId);
 		}
-		$document->setLastSavedVersion($stepsVersion);
-		$document->setLastSavedVersionTime(time());
-		$document->setLastSavedVersionEtag($file->getEtag());
-		$this->documentMapper->update($document);
-		$this->cache->remove('document-save-lock-' . $documentId);
 		return $document;
 	}
 

--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -146,9 +146,9 @@ class SessionService {
 		return $this->sessionMapper->findAllInactive();
 	}
 
-	public function removeInactiveSessions($documentId = -1) {
+	public function removeInactiveSessionsWithoutSteps($documentId = -1) {
 		// No need to clear the cache here as we already set a TTL
-		return $this->sessionMapper->deleteInactive($documentId);
+		return $this->sessionMapper->deleteInactiveWithoutSteps($documentId);
 	}
 
 	/**


### PR DESCRIPTION
- Add more debug logging around document handling
- Add logging for saving empty files (replaces #3872)
- fix: Rework save locking
- fix: Avoid document cleanup when closing sessions
- fix: Make sure to still cleanup attachments on document reset


## Follow up

- The database showed some leftovers which I cleaned up manually but we should tackle that with https://github.com/nextcloud/text/issues/3915 at some point
- https://github.com/nextcloud/text/issues/3916