### PR TITLE
enh(log): use level warning for saving empty docs

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -342,7 +342,7 @@ class DocumentService {
 		}
 
 		if (empty($autoSaveDocument)) {
-			$this->logger->debug('Saving empty document', [
+			$this->logger->warning('Saving empty document', [
 				'requestVersion' => $version,
 				'requestAutosaveDocument' => $autoSaveDocument,
 				'requestDocumentState' => $documentState,


### PR DESCRIPTION
### 📝 Summary

Saving an empty document can happen from time to time but if it happens to often it may indicate some problem. Keep an eye on these without needing to log all debug things in text.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests - we don't test our logging.
- [x] Documentation is not required
