### PR TITLE
[stable26] fix(cypress): show hidden files request now uses PUT

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -389,7 +389,7 @@ Cypress.Commands.add('showHiddenFiles', () => {
 	cy.get('[data-cy-files-navigation-settings-button]')
 		.click()
 	cy.get('.app-settings__content').should('be.visible')
-	cy.intercept({ method: 'POST', url: '**/show_hidden' }).as('showHidden')
+	cy.intercept({ method: 'PUT', url: '**/show_hidden' }).as('showHidden')
 	cy.get('.app-settings__content').contains('Show hidden files').closest('label').click()
 	cy.wait('@showHidden')
 	cy.get('.modal-container__close').click()


### PR DESCRIPTION
### 📝 Summary

* Backports: #4073 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
