### PR TITLE
fix(cypress): Create callouts without leaving menu open.

### DIFF
--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -210,17 +210,16 @@ describe('Workspace', function() {
 
 				// enable callout
 				cy.getSubmenuEntry('callouts', actionName).click()
-				cy.getSubmenuEntry('callouts', actionName).then(() => {
-					// check content
-					cy.getContent()
-						.find(`.callout.callout--${type}`)
-						.should('contain', 'Callout')
 
-					// disable
-					return cy.getSubmenuEntry('callouts', actionName)
-						.should('have.class', 'is-active')
-						.click()
-				})
+				// check content
+				cy.getContent()
+					.find(`.callout.callout--${type}`)
+					.should('contain', 'Callout')
+
+				// disable
+				cy.getSubmenuEntry('callouts', actionName)
+					.should('have.class', 'is-active')
+					.click()
 			})
 		})
 


### PR DESCRIPTION
### 📝 Summary

Remove unnecessary `cy.getSubmenuEntry`.
As it will open the parent menu.

This is a leftover from e9f54d00445c26b513fefb9bb84787f573bef9c7.

Fixes failing cy runs such as https://cloud.cypress.io/projects/hx9gqy/runs/9579/test-results/cc56b5cc-d502-4f28-a0ea-b83af102daed

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
