### PR TITLE
Fix double readme files getting created on case-insensitive storages

### DIFF
--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -12,8 +12,8 @@ class WorkspaceService {
 	private IL10N $l10n;
 
 	private const SUPPORTED_STATIC_FILENAMES = [
-		'README.md',
 		'Readme.md',
+		'README.md',
 		'readme.md'
 	];
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/text/issues/3348

Apparently this got missing from https://github.com/nextcloud/text/pull/834 when the rebase was done.

See https://github.com/nextcloud/text/compare/1e600fb26111f0c850f134cf17aad96b1c8c59d3..7d6569cdf4c01e3467fe4b066a5f80bb56c48d9e

But actually @max-nextcloud and me tested a bit and this only seems to fix when creating new readme files from the workspace. The rootcase would probably need to be fixed somewhere in getFileInfo in View.php in server but we don't know much about that so adding this change here seems like a quick win.