### PR TITLE
fix(Viewer): remove outdated fix from stable16.

### DIFF
--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -68,12 +68,6 @@ export default {
 			default: false,
 		},
 	},
-	beforeMount() {
-		// FIXME Dirty fix to avoid recreating the component on stable16
-		if (typeof this.$parent.$parent !== 'undefined' && this.$parent.$parent.onResize) {
-			window.removeEventListener('resize', this.$parent.$parent.onResize)
-		}
-	},
 }
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
### 📝 Summary

This broke the viewer resize and is not needed anymore.

In order to confirm this is not needed
i replaced the `beforeMount` handler with a `console.info` call opened a text in the viewer and resized the window a few times. The provided info only showed up once.
So the `ViewerComponent` was only mounted once as well.

Fixes #4099.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Changes are not covered with tests as it's hard to test for the absence of UI glitches.
- [x] Documentation is not required
