### PR TITLE
[stable26] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -608,12 +608,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "8ad3d190cc7fa4210e5121c36d40d0de9dcc343f"
+                "reference": "37923c381f59247ae6a4049561454f5d3cc2fa01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8ad3d190cc7fa4210e5121c36d40d0de9dcc343f",
-                "reference": "8ad3d190cc7fa4210e5121c36d40d0de9dcc343f",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/37923c381f59247ae6a4049561454f5d3cc2fa01",
+                "reference": "37923c381f59247ae6a4049561454f5d3cc2fa01",
                 "shasum": ""
             },
             "require": {
@@ -643,7 +643,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable26"
             },
-            "time": "2023-04-04T00:35:10+00:00"
+            "time": "2023-05-05T00:32:37+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency