### PR TITLE
fix: Call to a member function getUserId() on bool

### DIFF
--- a/lib/Controller/SessionController.php
+++ b/lib/Controller/SessionController.php
@@ -117,11 +117,14 @@ class SessionController extends Controller {
 	private function loginSessionUser(int $documentId, int $sessionId, string $sessionToken) {
 		$currentSession = $this->sessionService->getSession($documentId, $sessionId, $sessionToken);
 		if ($currentSession !== false && !$this->userSession->isLoggedIn()) {
-			$user = $this->userManager->get($currentSession->getUserId());
-			if ($user !== null) {
-				$this->restoreUser = true;
-				$this->userToRestore = $this->userSession->getUser();
-				$this->userSession->setUser($user);
+			$userId = $currentSession->getUserId();
+			if ($userId !== false) {
+				$user = $this->userManager->get($userId);
+				if ($user !== null) {
+					$this->restoreUser = true;
+					$this->userToRestore = $this->userSession->getUser();
+					$this->userSession->setUser($user);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### 📝 Summary

Check that `$currentSession` is not false before trying to retrieve the user.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
