### PR TITLE
fix(UserApiController): Fix warning during test run with PHP 8.2

### DIFF
--- a/lib/Controller/UserApiController.php
+++ b/lib/Controller/UserApiController.php
@@ -41,7 +41,7 @@ class UserApiController extends ApiController {
 			$sessionUserId = $session['userId'];
 			if ($sessionUserId !== null && !isset($users[$sessionUserId])) {
 				$displayName = $this->userManager->getDisplayName($sessionUserId);
-				if (stripos($displayName, $filter) !== false || stripos($sessionUserId, $filter) !== false) {
+				if ($displayName && stripos($displayName, $filter) !== false || stripos($sessionUserId, $filter) !== false) {
 					$users[$sessionUserId] = $displayName;
 				}
 			}

--- a/tests/unit/Controller/UserApiControllerTest.php
+++ b/tests/unit/Controller/UserApiControllerTest.php
@@ -69,6 +69,9 @@ class UserApiControllerTest extends TestCase {
 				'userId' => 'admin',
 				'displayName' => 'admin',
 			]]);
+		$this->userManager->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('Administrator');
 		$this->sessionService
 			->expects($this->once())
 			->method('getSession')->willReturn($session);


### PR DESCRIPTION
Fix test failure that only happens on PHP8.2

> stripos(): Passing null to parameter #1 ($haystack) of type string is deprecated