### PR TITLE
No more deprecated API usages

### DIFF
--- a/lib/Db/DocumentMapper.php
+++ b/lib/Db/DocumentMapper.php
@@ -45,7 +45,7 @@ class DocumentMapper extends QBMapper {
 		$result = $qb->select('*')
 			->from($this->getTableName())
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($documentId)))
-			->execute();
+			->executeQuery();
 
 		$data = $result->fetch();
 		$result->closeCursor();
@@ -59,7 +59,7 @@ class DocumentMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$result = $qb->select('*')
 			->from($this->getTableName())
-			->execute();
+			->executeQuery();
 
 		return $this->findEntities($qb);
 	}

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -61,7 +61,7 @@ class SessionMapper extends QBMapper {
 			->where($qb->expr()->eq('document_id', $qb->createNamedParameter($documentId)))
 			->andWhere($qb->expr()->eq('id', $qb->createNamedParameter($sessionId)))
 			->andWhere($qb->expr()->eq('token', $qb->createNamedParameter($token)))
-			->execute();
+			->executeQuery();
 
 		$data = $result->fetch();
 		$result->closeCursor();
@@ -108,7 +108,7 @@ class SessionMapper extends QBMapper {
 		}
 		$result = $qb
 			->groupBy('session_id')
-			->execute();
+			->executeQuery();
 		$activeSessions = $result->fetchAll(\PDO::FETCH_COLUMN);
 		$result->closeCursor();
 
@@ -119,14 +119,14 @@ class SessionMapper extends QBMapper {
 			$qb->andWhere($qb->expr()->eq('document_id', $qb->createNamedParameter($documentId)));
 		}
 		$qb->andWhere($qb->expr()->notIn('id', $qb->createNamedParameter($activeSessions, IQueryBuilder::PARAM_INT_ARRAY)));
-		return $qb->execute();
+		return $qb->executeStatement();
 	}
 
 	public function deleteByDocumentId($documentId) {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->getTableName())
 			->where($qb->expr()->eq('document_id', $qb->createNamedParameter($documentId)));
-		return $qb->execute();
+		return $qb->executeStatement();
 	}
 
 	public function isUserInDocument($documentId, $userId): bool {

--- a/lib/Db/StepMapper.php
+++ b/lib/Db/StepMapper.php
@@ -59,7 +59,7 @@ class StepMapper extends QBMapper {
 			->where($qb->expr()->eq('document_id', $qb->createNamedParameter($documentId)))
 			->setMaxResults(1)
 			->orderBy('version', 'DESC')
-			->execute();
+			->executeQuery();
 
 		$data = $result->fetch();
 		if ($data === false) {

--- a/lib/DirectEditing/TextDirectEditor.php
+++ b/lib/DirectEditing/TextDirectEditor.php
@@ -28,12 +28,12 @@ use OCA\Text\Service\ApiService;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\DirectEditing\IEditor;
 use OCP\DirectEditing\IToken;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
-use OCP\IInitialStateService;
 use OCP\IL10N;
 use OCP\Util;
 
@@ -42,13 +42,13 @@ class TextDirectEditor implements IEditor {
 	/** @var IL10N */
 	private $l10n;
 
-	/** @var IInitialStateService */
+	/** @var IInitialState */
 	private $initialStateService;
 
 	/** @var ApiService */
 	private $apiService;
 
-	public function __construct(IL10N $l10n, IInitialStateService $initialStateService, ApiService $apiService) {
+	public function __construct(IL10N $l10n, IInitialState $initialStateService, ApiService $apiService) {
 		$this->l10n = $l10n;
 		$this->initialStateService = $initialStateService;
 		$this->apiService = $apiService;
@@ -153,12 +153,12 @@ class TextDirectEditor implements IEditor {
 		$token->useTokenScope();
 		try {
 			$session = $this->apiService->create($token->getFile()->getId());
-			$this->initialStateService->provideInitialState('text', 'file', [
+			$this->initialStateService->provideInitialState('file', [
 				'fileId' => $token->getFile()->getId(),
 				'mimetype' => $token->getFile()->getMimeType(),
 				'session' => \json_encode($session->getData())
 			]);
-			$this->initialStateService->provideInitialState('text', 'directEditingToken', $token->getToken());
+			$this->initialStateService->provideInitialState('directEditingToken', $token->getToken());
 			Util::addScript('text', 'text-text');
 			return new TemplateResponse('text', 'main', [], 'base');
 		} catch (InvalidPathException $e) {

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -49,7 +49,7 @@ class NotificationService {
 		;
 
 		if ($this->manager->getCount($notification) === 0) {
-			$notification->setDateTime($this->timeFactory->getDateTime());
+			$notification->setDateTime(\DateTime::createFromImmutable($this->timeFactory->now()));
 			$this->manager->notify($notification);
 			return true;
 		}

--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -95,7 +95,7 @@ class SessionService {
 		if ($this->userId === null) {
 			$session->setGuestName($guestName);
 		}
-		$session->setLastContact($this->timeFactory->getTime());
+		$session->setLastContact($this->timeFactory->now()->getTimestamp());
 
 		$session = $this->sessionMapper->insert($session);
 		$this->cache->set($session->getToken(), json_encode($session), self::SESSION_VALID_TIME);
@@ -192,7 +192,7 @@ class SessionService {
 			return false;
 		}
 
-		$currentTime = $this->timeFactory->getTime();
+		$currentTime = $this->timeFactory->now()->getTimestamp();
 		if (($currentTime - $session->getLastContact()) >= 30) {
 			/*
 			 * We need to update the timestamp.
@@ -205,7 +205,7 @@ class SessionService {
 				$this->cache->remove($token);
 				return false;
 			}
-			$session->setLastContact($this->timeFactory->getTime());
+			$session->setLastContact($this->timeFactory->now()->getTimestamp());
 			$this->sessionMapper->update($session);
 			$this->cache->set($token, json_encode($session), self::SESSION_VALID_TIME - 30);
 		}

--- a/psalm.xml
+++ b/psalm.xml
@@ -15,7 +15,10 @@
     <extraFiles>
         <directory name="vendor/nextcloud/ocp" />
     </extraFiles>
-    	<issueHandlers>
+	<issueHandlers>
+		<DeprecatedMethod>
+			<errorLevel type="error" />
+		</DeprecatedMethod>
 		<UndefinedClass>
 			<errorLevel type="suppress">
 				<referencedClass name="OC" />


### PR DESCRIPTION
### 📝 Summary

- chore: Move away from deprecated backend APIs
- ci(paslm): Consider deprecated methods as errors

Since now all deprecated API usages are fixed I added the DeprecatedMethod as an error case to the psalm config as long as we cannot increase the psalm level (which might be a bit more work, but should be done)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
