### PR TITLE
Don't expect HTML element with ID `mimetype` in public share

### DIFF
--- a/src/public.js
+++ b/src/public.js
@@ -49,7 +49,6 @@ const loadEditor = ({ sharingToken, mimetype, fileId, $el }) => {
 }
 
 documentReady(() => {
-	const mimetype = document.getElementById('mimetype').value
 	const sharingToken = document.getElementById('sharingToken') ? document.getElementById('sharingToken').value : null
 
 	if (!sharingToken) {
@@ -67,7 +66,8 @@ documentReady(() => {
 	}
 
 	// single file share
-	if (openMimetypes.indexOf(mimetype) !== -1) {
+	const mimetype = document.getElementById('mimetype')?.value
+	if (mimetype && openMimetypes.indexOf(mimetype) !== -1) {
 		const $el = document.getElementById('preview')
 		const fileId = loadState('text', 'file_id')
 		loadEditor({ mimetype, sharingToken, fileId, $el })


### PR DESCRIPTION
If the share is password-protected, the authentication page doesn't have the property set yet.

Fixes: #3816
