### PR TITLE
Prevent cumulative layout shift when rich workspace is loading

### DIFF
--- a/src/views/RichWorkspace.vue
+++ b/src/views/RichWorkspace.vue
@@ -259,11 +259,13 @@ export default {
 	}
 
 	#rich-workspace.focus {
+		min-height: 25vh;
 		max-height: 50vh;
 	}
 
-	#rich-workspace:not(.focus) {
-		max-height: 30vh;
+	#rich-workspace:not(.focus), #rich-workspace.icon-loading {
+		min-height: 25vh;
+		max-height: 25vh;
 		position: relative;
 		overflow: hidden;
 	}

--- a/src/views/RichWorkspace.vue
+++ b/src/views/RichWorkspace.vue
@@ -203,7 +203,7 @@ export default {
 		z-index: 61;
 		position: relative;
 		&.creatable {
-			min-height: 100px;
+			min-height: 150px;
 		}
 	}
 
@@ -259,15 +259,19 @@ export default {
 	}
 
 	#rich-workspace.focus {
-		min-height: 25vh;
+		min-height: 150px;
 		max-height: 50vh;
 	}
 
 	#rich-workspace:not(.focus), #rich-workspace.icon-loading {
-		min-height: 25vh;
-		max-height: 25vh;
+		min-height: 150px;
+		max-height: 150px;
 		position: relative;
 		overflow: hidden;
+
+		:deep([data-text-el="menubar"]) {
+			display: none;
+		}
 	}
 
 	#rich-workspace:not(.focus):not(.icon-loading):not(.empty):after {
@@ -284,11 +288,5 @@ export default {
 
 	#rich-workspace.dark:not(.focus):not(.icon-loading):after {
 		background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), var(--color-main-background));
-	}
-
-	@media only screen and (max-width: 1024px) {
-		#rich-workspace:not(.focus) {
-			max-height: 30vh;
-		}
 	}
 </style>


### PR DESCRIPTION
### 📝 Summary

Instead of only increasing editor height with growing document length, let's stick to a fixed height (25vh) and use that one already while loading the document.
    
The editor height still increases when it gets focused.

* Fixes: #2834
* Fixes: #2803

#### 🖼️ Screencasts

🏚️ Before | 🏡 After
---|---
[recording1.webm](https://github.com/nextcloud/text/assets/3582805/0cdd5427-3bd0-42e3-af6b-e71c6939fc71) | [recording2.webm](https://github.com/nextcloud/text/assets/3582805/7f060f9a-a7f6-42d7-893f-24ca2459afba)



### 🚧 TODO

- [ ] Wait for feedback by @nextcloud/designers

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
