### PR TITLE
Limit cypress to github runners

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       nodeVersion: ${{ steps.versions.outputs.nodeVersion }}
       npmVersion: ${{ steps.versions.outputs.npmVersion }}
@@ -66,7 +66,7 @@ jobs:
           path: ./
 
   cypress:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: init
 
     strategy:


### PR DESCRIPTION
Until we know how to make it work this should bring back more reliable cypress runs 