### PR TITLE
fix(sync): Save even if versions match

### DIFF
--- a/cypress/e2e/directediting.spec.js
+++ b/cypress/e2e/directediting.spec.js
@@ -61,15 +61,10 @@ describe('direct editing', function() {
 			})
 		const closeRequestAlias = 'closeRequest'
 		cy.intercept({ method: 'POST', url: '**/session/close' }).as(closeRequestAlias)
-		cy.intercept({ method: 'POST', url: '**/apps/text/session/sync' }).as('sync')
 		cy.getContent().type('# This is a headline')
 		cy.getContent().type('{enter}')
 		cy.getContent().type('Some text')
 		cy.getContent().type('{enter}')
-
-		// ensure we have received our own steps
-		cy.wait('@sync', { timeout: 7000 })
-		cy.wait('@sync', { timeout: 7000 })
 
 		cy.get('button.icon-close').click()
 		cy.wait(`@${closeRequestAlias}`).then(() => {
@@ -87,16 +82,11 @@ describe('direct editing', function() {
 			})
 		const closeRequestAlias = 'closeRequest'
 		cy.intercept({ method: 'POST', url: '**/session/close' }).as(closeRequestAlias)
-		cy.intercept({ method: 'POST', url: '**/apps/text/session/sync' }).as('sync')
 
 		cy.getContent().type('# This is a headline')
 		cy.getContent().type('{enter}')
 		cy.getContent().type('Some text')
 		cy.getContent().type('{enter}')
-
-		// ensure we have received our own steps
-		cy.wait('@sync', { timeout: 7000 })
-		cy.wait('@sync', { timeout: 7000 })
 
 		cy.get('button.icon-close').click()
 		cy.wait(`@${closeRequestAlias}`).then(() => {
@@ -114,16 +104,11 @@ describe('direct editing', function() {
 			})
 		const closeRequestAlias = 'closeRequest'
 		cy.intercept({ method: 'POST', url: '**/session/close' }).as(closeRequestAlias)
-		cy.intercept({ method: 'POST', url: '**/apps/text/session/sync' }).as('sync')
 
 		cy.getContent().type('# This is a headline')
 		cy.getContent().type('{enter}')
 		cy.getContent().type('Some text')
 		cy.getContent().type('{enter}')
-
-		// ensure we have received our own steps
-		cy.wait('@sync', { timeout: 7000 })
-		cy.wait('@sync', { timeout: 7000 })
 
 		cy.get('button.icon-close').click()
 		cy.wait(`@${closeRequestAlias}`).then(() => {

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -339,9 +339,13 @@ class DocumentService {
 		if ($autoSaveDocument === null) {
 			return $document;
 		}
-		// Do not save if version already saved
+		// Do not save if newer version already saved
+		// Note that $version is the version of the steps the client has fetched.
+		// It may have added steps on top of that - so if the versions match we still save.
 		$stepsVersion = $this->stepMapper->getLatestVersion($documentId);
-		if (!$force && ($version <= (string)$document->getLastSavedVersion() || $version > (string)$stepsVersion)) {
+		$savedVersion = $document->getLastSavedVersion();
+		$outdated = $savedVersion > 0 && $savedVersion > $version;
+		if (!$force && ($outdated || $version > (string)$stepsVersion)) {
 			return $document;
 		}
 


### PR DESCRIPTION
### 📝 Summary

Fixes #3404.

Apply saves even if the client and server version match.

The client version only reflects the steps which the client has received back from the server.
It may leave out the steps the client just send itself.

So if the versions match - save the file to be sure to include changes from the client.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
