### PR TITLE
fix(cypress): shortcut test retry

### DIFF
--- a/cypress/e2e/shortcuts.spec.js
+++ b/cypress/e2e/shortcuts.spec.js
@@ -46,14 +46,9 @@ describe('keyboard shortcuts', () => {
 
 	beforeEach(() => {
 		cy.login(user)
+		cy.uploadTestFile()
 		cy.visit('/apps/files')
-		const path = `/${Cypress.currentTest.title}.md`
-		cy.uploadFile(
-			'empty.md',
-			'text/markdown',
-			path
-		)
-		cy.window().then(win => win.OCA.Viewer.open({ path }))
+		cy.openTestFile()
 	    cy.getContent().type(Cypress.currentTest.title)
 		cy.getContent().type('{selectall}')
 	})


### PR DESCRIPTION
### 📝 Summary

Use the `uploadTestFile` and `openTestFile` functions to make sure retries use different file names
and prevent conflicts.

Fixes #3436.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- Documentation is not required
