### PR TITLE
chore(dependencies): Skip tiptap/prosemirror updates for 25

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,15 @@
       "enabled": false
     },
     {
+      "groupName": "tiptap",
+      "matchBaseBranches": ["stable25"],
+      "matchPackagePrefixes": [
+        "@tiptap/",
+        "prosemirror-"
+      ],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["vue"],
       "allowedVersions": "<3"
     },


### PR DESCRIPTION
As discussed with @max-nextcloud recently and to avoid reopening of https://github.com/nextcloud/text/pull/3752