### PR TITLE
Rework cypress commands

### DIFF
--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -21,7 +21,6 @@
  */
 
 import { initUserAndFiles, randHash, randUser } from '../utils/index.js'
-import 'cypress-file-upload'
 
 const user = randUser()
 const recipient = randUser()
@@ -41,7 +40,12 @@ function attachFile(name, requestAlias = null) {
 	}
 	return cy.getEditor()
 		.find('input[type="file"][data-text-el="attachment-file-input"]')
-		.attachFile(name)
+		.selectFile([
+			{
+				contents: 'cypress/fixtures/' + name,
+				fileName: name,
+			},
+		], { force: true })
 }
 
 /**

--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -410,10 +410,4 @@ describe('Test all attachment insertion methods', () => {
 				}
 			})
 	})
-
-	it('Delete the user', () => {
-		cy.deleteUser(user)
-		cy.deleteUser(recipient)
-	})
-
 })

--- a/cypress/e2e/nodes/ImageView.spec.js
+++ b/cypress/e2e/nodes/ImageView.spec.js
@@ -15,7 +15,6 @@ describe('Image View', () => {
 	before(() => {
 		cy.createUser(user)
 		cy.login(user)
-		cy.visit('/apps/files')
 
 		// Upload test files to user's storage
 		cy.createFolder('child-folder')

--- a/cypress/e2e/nodes/Mentions.spec.js
+++ b/cypress/e2e/nodes/Mentions.spec.js
@@ -1,5 +1,4 @@
 import { initUserAndFiles, randUser } from '../../utils/index.js'
-import 'cypress-file-upload'
 
 const user = randUser()
 const mentionMe = randUser()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,6 +36,9 @@ addCommands()
 // and also to determine paths, urls and the like.
 let auth
 Cypress.Commands.overwrite('login', (login, user) => {
+	cy.window().then((win) => {
+		win.location.href = 'about:blank'
+	})
 	auth = { user: user.userId, password: user.password }
 	login(user)
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -41,43 +41,53 @@ Cypress.Commands.overwrite('login', (login, user) => {
 })
 
 Cypress.Commands.add('ocsRequest', (options) => {
-	return cy.request({
-		form: true,
-		auth,
-		headers: {
-			'OCS-ApiRequest': 'true',
-			'Content-Type': 'application/x-www-form-urlencoded',
-		},
-		...options,
-	})
+	return cy.request('/csrftoken')
+		.then(({ body }) => body.token)
+		.then(requesttoken => {
+			return cy.request({
+				form: true,
+				auth,
+				headers: {
+					'OCS-ApiRequest': 'true',
+					'Content-Type': 'application/x-www-form-urlencoded',
+					requesttoken,
+				},
+				...options,
+			})
+		})
 })
 
 Cypress.Commands.add('uploadFile', (fileName, mimeType, target) => {
-	return cy.fixture(fileName, 'base64')
-		.then(Cypress.Blob.base64StringToBlob)
+	return cy.fixture(fileName, 'binary')
+		.then(Cypress.Blob.binaryStringToBlob)
 		.then(blob => {
-			const file = new File([blob], fileName, { type: mimeType })
 			if (typeof target !== 'undefined') {
 				fileName = target
 			}
-			return cy.request('/csrftoken')
-				.then(({ body }) => body.token)
-				.then(requesttoken => {
-					return axios.put(`${url}/remote.php/webdav/${fileName}`, file, {
+			cy.request('/csrftoken')
+				.then(({ body }) => {
+					return cy.wrap(body.token)
+				})
+				.then(async (requesttoken) => {
+					return cy.request({
+						url: `${url}/remote.php/webdav/${fileName}`,
+						method: 'put',
+						body: blob.size > 0 ? blob : '',
+						auth,
 						headers: {
 							requesttoken,
 							'Content-Type': mimeType,
 						},
-					}).then(response => {
-						const fileId = Number(
-							response.headers['oc-fileid']?.split('oc')?.[0]
-						)
-						cy.log(`Uploaded ${fileName}`,
-							response.status,
-							{ fileId }
-						)
-						return fileId
 					})
+				}).then(response => {
+					const fileId = Number(
+						response.headers['oc-fileid']?.split('oc')?.[0]
+					)
+					cy.log(`Uploaded ${fileName}`,
+						response.status,
+						{ fileId }
+					)
+					return cy.wrap(fileId)
 				})
 		})
 })
@@ -95,27 +105,27 @@ Cypress.Commands.add('downloadFile', (fileName) => {
 })
 
 Cypress.Commands.add('createFile', (target, content, mimeType = 'text/markdown') => {
-	const fileName = target.split('/').pop()
-
 	const blob = new Blob([content], { type: mimeType })
-	const file = new File([blob], fileName, { type: mimeType })
 
-	return cy.window()
-		.then(async win => {
-			const response = await axios.put(`${url}/remote.php/webdav/${target}`, file, {
+	return cy.request('/csrftoken')
+		.then(({ body }) => body.token)
+		.then(requesttoken => {
+			return cy.request({
+				url: `${url}/remote.php/webdav/${target}`,
+				method: 'put',
+				body: blob.size > 0 ? blob : '',
+				auth,
 				headers: {
-					requesttoken: win.OC.requestToken,
 					'Content-Type': mimeType,
+					requesttoken,
 				},
+			}).then((response) => {
+				return cy.log(`Uploaded ${target}`, response.status)
 			})
-
-			return cy.log(`Uploaded ${fileName}`, response.status)
 		})
-
 })
 
 Cypress.Commands.add('shareFileToUser', (path, targetUser, shareData = {}) => {
-	cy.clearCookies()
 	cy.ocsRequest({
 		method: 'POST',
 		url: `${url}/ocs/v2.php/apps/files_sharing/api/v1/shares`,
@@ -212,7 +222,8 @@ Cypress.Commands.add('createFolder', (target) => {
 	return cy.request('/csrftoken')
 		.then(({ body }) => body.token)
 		.then(requesttoken => {
-			return axios.request(`${rootPath}/${dirPath}`, {
+			return cy.request({
+				url: `${rootPath}/${dirPath}`,
 				method: 'MKCOL',
 				auth,
 				headers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,6 @@
         "@vue/test-utils": "^1.3.0 <2",
         "@vue/vue2-jest": "^29.2.4",
         "cypress": "^12.15.0",
-        "cypress-file-upload": "^5.0.8",
         "eslint-plugin-cypress": "^2.13.3",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.5.0",
@@ -7997,18 +7996,6 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
-      }
-    },
-    "node_modules/cypress-file-upload": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
-      "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.2.1"
-      },
-      "peerDependencies": {
-        "cypress": ">3.0.0"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -27784,13 +27771,6 @@
           "dev": true
         }
       }
-    },
-    "cypress-file-upload": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
-      "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
-      "dev": true,
-      "requires": {}
     },
     "dash-ast": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "@vue/test-utils": "^1.3.0 <2",
     "@vue/vue2-jest": "^29.2.4",
     "cypress": "^12.15.0",
-    "cypress-file-upload": "^5.0.8",
     "eslint-plugin-cypress": "^2.13.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.5.0",


### PR DESCRIPTION
This is a set of changes to cypress commands that should increase stability over CI runs. There still seem to be rare failures where some requests return a 401 on the backend which I'm continuing to follow debugging in #4350 however I think this would already be good to get in fast:

- Move from axios usage to cy.request as I suspect that the axios promise was sometimes causing timing issues with requests
- Use cy.selectFile instead of the 3rdparty helper
- Rework recovery after lost connection test to await the session recreation
- Avoid some extra navigation steps