### PR TITLE
[stable27] Flaky CI fixes

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -75,10 +75,20 @@ jobs:
         node-version: [16]
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
         php-versions: [ '8.1' ]
-        databases: [ 'sqlite' ]
         server-versions: ['stable27']
 
     name: runner ${{ matrix.containers }}
+
+    services:
+      postgres:
+        image: ghcr.io/nextcloud/continuous-integration-postgres-14:latest
+        ports:
+          - 4444:5432/tcp
+        env:
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: rootpassword
+          POSTGRES_DB: nextcloud
+        options: --health-cmd pg_isready --health-interval 5s --health-timeout 2s --health-retries 5
 
     steps:
       - name: Restore context
@@ -101,7 +111,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, zip, gd, apcu
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
           ini-values:
             apc.enable_cli=on
           coverage: none
@@ -113,7 +123,7 @@ jobs:
         run: |
           mkdir data
           echo '<?php $CONFIG=["memcache.local"=>"\OC\Memcache\APCu","hashing_default_password"=>true];' > config/config.php
-          php occ maintenance:install --verbose --database=${{ matrix.databases }} --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
+          php occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
           php -f index.php
           php -S 0.0.0.0:8081 &
           export OC_PASS=1234561

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -56,11 +56,6 @@ jobs:
           # Split and keep last
           echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
 
-      - name: Enable ONLY_FULL_GROUP_BY MySQL option
-        run: |
-          echo "SET GLOBAL sql_mode=(SELECT CONCAT(@@sql_mode,',ONLY_FULL_GROUP_BY'));" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
-          echo "SELECT @@sql_mode;" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
-
       - name: Checkout server
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
@@ -72,6 +67,11 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           path: apps/${{ env.APP_NAME }}
+
+      - name: Enable ONLY_FULL_GROUP_BY MySQL option
+        run: |
+          echo "SET GLOBAL sql_mode=(SELECT CONCAT(@@sql_mode,',ONLY_FULL_GROUP_BY'));" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
+          echo "SELECT @@sql_mode;" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
 
       - name: Set up php ${{ matrix.php-versions }}
         uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d # v2

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   phpunit-oci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -21,7 +21,6 @@
  */
 
 import { initUserAndFiles, randHash, randUser } from '../utils/index.js'
-import 'cypress-file-upload'
 
 const user = randUser()
 const recipient = randUser()
@@ -41,7 +40,12 @@ function attachFile(name, requestAlias = null) {
 	}
 	return cy.getEditor()
 		.find('input[type="file"][data-text-el="attachment-file-input"]')
-		.attachFile(name)
+		.selectFile([
+			{
+				contents: 'cypress/fixtures/' + name,
+				fileName: name,
+			},
+		], { force: true })
 }
 
 /**

--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -410,10 +410,4 @@ describe('Test all attachment insertion methods', () => {
 				}
 			})
 	})
-
-	it('Delete the user', () => {
-		cy.deleteUser(user)
-		cy.deleteUser(recipient)
-	})
-
 })

--- a/cypress/e2e/nodes/ImageView.spec.js
+++ b/cypress/e2e/nodes/ImageView.spec.js
@@ -15,7 +15,6 @@ describe('Image View', () => {
 	before(() => {
 		cy.createUser(user)
 		cy.login(user)
-		cy.visit('/apps/files')
 
 		// Upload test files to user's storage
 		cy.createFolder('child-folder')

--- a/cypress/e2e/nodes/Mentions.spec.js
+++ b/cypress/e2e/nodes/Mentions.spec.js
@@ -1,5 +1,4 @@
 import { initUserAndFiles, randUser } from '../../utils/index.js'
-import 'cypress-file-upload'
 
 const user = randUser()
 const mentionMe = randUser()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,6 +36,9 @@ addCommands()
 // and also to determine paths, urls and the like.
 let auth
 Cypress.Commands.overwrite('login', (login, user) => {
+	cy.window().then((win) => {
+		win.location.href = 'about:blank'
+	})
 	auth = { user: user.userId, password: user.password }
 	login(user)
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -41,43 +41,53 @@ Cypress.Commands.overwrite('login', (login, user) => {
 })
 
 Cypress.Commands.add('ocsRequest', (options) => {
-	return cy.request({
-		form: true,
-		auth,
-		headers: {
-			'OCS-ApiRequest': 'true',
-			'Content-Type': 'application/x-www-form-urlencoded',
-		},
-		...options,
-	})
+	return cy.request('/csrftoken')
+		.then(({ body }) => body.token)
+		.then(requesttoken => {
+			return cy.request({
+				form: true,
+				auth,
+				headers: {
+					'OCS-ApiRequest': 'true',
+					'Content-Type': 'application/x-www-form-urlencoded',
+					requesttoken,
+				},
+				...options,
+			})
+		})
 })
 
 Cypress.Commands.add('uploadFile', (fileName, mimeType, target) => {
-	return cy.fixture(fileName, 'base64')
-		.then(Cypress.Blob.base64StringToBlob)
+	return cy.fixture(fileName, 'binary')
+		.then(Cypress.Blob.binaryStringToBlob)
 		.then(blob => {
-			const file = new File([blob], fileName, { type: mimeType })
 			if (typeof target !== 'undefined') {
 				fileName = target
 			}
-			return cy.request('/csrftoken')
-				.then(({ body }) => body.token)
-				.then(requesttoken => {
-					return axios.put(`${url}/remote.php/webdav/${fileName}`, file, {
+			cy.request('/csrftoken')
+				.then(({ body }) => {
+					return cy.wrap(body.token)
+				})
+				.then(async (requesttoken) => {
+					return cy.request({
+						url: `${url}/remote.php/webdav/${fileName}`,
+						method: 'put',
+						body: blob.size > 0 ? blob : '',
+						auth,
 						headers: {
 							requesttoken,
 							'Content-Type': mimeType,
 						},
-					}).then(response => {
-						const fileId = Number(
-							response.headers['oc-fileid']?.split('oc')?.[0]
-						)
-						cy.log(`Uploaded ${fileName}`,
-							response.status,
-							{ fileId }
-						)
-						return fileId
 					})
+				}).then(response => {
+					const fileId = Number(
+						response.headers['oc-fileid']?.split('oc')?.[0]
+					)
+					cy.log(`Uploaded ${fileName}`,
+						response.status,
+						{ fileId }
+					)
+					return cy.wrap(fileId)
 				})
 		})
 })
@@ -95,27 +105,27 @@ Cypress.Commands.add('downloadFile', (fileName) => {
 })
 
 Cypress.Commands.add('createFile', (target, content, mimeType = 'text/markdown') => {
-	const fileName = target.split('/').pop()
-
 	const blob = new Blob([content], { type: mimeType })
-	const file = new File([blob], fileName, { type: mimeType })
 
-	return cy.window()
-		.then(async win => {
-			const response = await axios.put(`${url}/remote.php/webdav/${target}`, file, {
+	return cy.request('/csrftoken')
+		.then(({ body }) => body.token)
+		.then(requesttoken => {
+			return cy.request({
+				url: `${url}/remote.php/webdav/${target}`,
+				method: 'put',
+				body: blob.size > 0 ? blob : '',
+				auth,
 				headers: {
-					requesttoken: win.OC.requestToken,
 					'Content-Type': mimeType,
+					requesttoken,
 				},
+			}).then((response) => {
+				return cy.log(`Uploaded ${target}`, response.status)
 			})
-
-			return cy.log(`Uploaded ${fileName}`, response.status)
 		})
-
 })
 
 Cypress.Commands.add('shareFileToUser', (path, targetUser, shareData = {}) => {
-	cy.clearCookies()
 	cy.ocsRequest({
 		method: 'POST',
 		url: `${url}/ocs/v2.php/apps/files_sharing/api/v1/shares`,
@@ -212,7 +222,8 @@ Cypress.Commands.add('createFolder', (target) => {
 	return cy.request('/csrftoken')
 		.then(({ body }) => body.token)
 		.then(requesttoken => {
-			return axios.request(`${rootPath}/${dirPath}`, {
+			return cy.request({
+				url: `${rootPath}/${dirPath}`,
 				method: 'MKCOL',
 				auth,
 				headers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,6 @@
         "@vue/test-utils": "^1.3.0 <2",
         "@vue/vue2-jest": "^29.2.4",
         "cypress": "^12.16.0",
-        "cypress-file-upload": "^5.0.8",
         "eslint-plugin-cypress": "^2.13.3",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.5.0",
@@ -7994,18 +7993,6 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
-      }
-    },
-    "node_modules/cypress-file-upload": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
-      "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.2.1"
-      },
-      "peerDependencies": {
-        "cypress": ">3.0.0"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -27782,13 +27769,6 @@
           "dev": true
         }
       }
-    },
-    "cypress-file-upload": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
-      "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
-      "dev": true,
-      "requires": {}
     },
     "dash-ast": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "@vue/test-utils": "^1.3.0 <2",
     "@vue/vue2-jest": "^29.2.4",
     "cypress": "^12.16.0",
-    "cypress-file-upload": "^5.0.8",
     "eslint-plugin-cypress": "^2.13.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.5.0",


### PR DESCRIPTION
Combined backport of #4357 and #4364 

- use proper database for cypress
- ci(phpunit): Work around flaky self hosted runners
- ci(cypress): Use cy.request instead of axios
- ci(cypress): Use cypress select file
- ci(cypress): Attempt to fix flaky recovery test
- ci(cypress): Avoid unneeded user removal
- ci(cypress): Clear page to avoid issues when switching sessions while requests are still being fired

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
