### PR TITLE
chore(ci): Run cypress against proper stable branch

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,6 +22,10 @@ jobs:
     outputs:
       nodeVersion: ${{ steps.versions.outputs.nodeVersion }}
       npmVersion: ${{ steps.versions.outputs.npmVersion }}
+    strategy:
+      fail-fast: false
+      matrix:
+        server-versions: ['stable26']
 
     steps:
       - name: Checkout server
@@ -72,10 +76,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16]
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
         php-versions: [ '8.1' ]
-        server-versions: ['stable26']
 
     name: runner ${{ matrix.containers }}
 


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
