### PR TITLE
ci(cypress): Revert show_hidden method for cypress interception

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -400,7 +400,7 @@ Cypress.Commands.add('showHiddenFiles', () => {
 	cy.get('[data-cy-files-navigation-settings-button]')
 		.click()
 	cy.get('.app-settings__content').should('be.visible')
-	cy.intercept({ method: 'PUT', url: '**/show_hidden' }).as('showHidden')
+	cy.intercept({ method: 'POST', url: '**/show_hidden' }).as('showHidden')
 	cy.get('.app-settings__content').contains('Show hidden files').closest('label').click()
 	cy.wait('@showHidden')
 	cy.get('.modal-container__close').click()


### PR DESCRIPTION
After #4410 this was failing as we backported a test adjustment with the api url that was not there in 26
