### PR TITLE
ci(audit): Do not create pull requests if npm audit fix fails

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ["main", "master", "stable27", "stable26", "stable25", "stable24"]
-  
+        branches: ["main", "stable27", "stable26", "stable25", "stable24"]
+
     name: npm-audit-fix-${{ matrix.branches }}
 
     steps:

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -48,13 +48,11 @@ jobs:
           npm audit fix
 
       - name: Run npm ci and npm run build
-        if: always()
         run: |
           npm ci
           npm run build --if-present
 
       - name: Create Pull Request
-        if: always()
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}


### PR DESCRIPTION
Otherwise this leads to weird pull requests that only update the map file for some reason:

https://github.com/nextcloud/text/actions/runs/5497724813/jobs/10018684048
