### PR TITLE
fix: Fetch attachment share permissions

### DIFF
--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\Text\Service;
 
 use OC\User\NoUserException;
+use OCA\Files_Sharing\SharedStorage;
 use OCA\Text\Controller\AttachmentController;
 use OCP\Constants;
 use OCP\Files\File;
@@ -155,7 +156,7 @@ class AttachmentService {
 	private function getMediaFullFile(string $mediaFileName, File $textFile): ?File {
 		$attachmentFolder = $this->getAttachmentDirectoryForFile($textFile, true);
 		$mediaFile = $attachmentFolder->get($mediaFileName);
-		if ($mediaFile instanceof File) {
+		if ($mediaFile instanceof File && !$this->isDownloadDisabled($mediaFile)) {
 			return $mediaFile;
 		}
 		return null;
@@ -192,7 +193,7 @@ class AttachmentService {
 	private function getMediaFilePreviewFile(string $mediaFileName, File $textFile): ?array {
 		$attachmentFolder = $this->getAttachmentDirectoryForFile($textFile, true);
 		$mediaFile = $attachmentFolder->get($mediaFileName);
-		if ($mediaFile instanceof File) {
+		if ($mediaFile instanceof File && !$this->isDownloadDisabled($mediaFile)) {
 			if ($this->previewManager->isMimeSupported($mediaFile->getMimeType())) {
 				try {
 					return [
@@ -453,11 +454,25 @@ class AttachmentService {
 		$userFolder = $this->rootFolder->getUserFolder($userId);
 		if ($userFolder->nodeExists($filePath)) {
 			$file = $userFolder->get($filePath);
-			if ($file instanceof File) {
+			if ($file instanceof File && !$this->isDownloadDisabled($file)) {
 				return $file;
 			}
 		}
 		return null;
+	}
+
+	private function isDownloadDisabled(File $file): bool {
+		$storage = $file->getStorage();
+		if ($storage->instanceOfStorage(SharedStorage::class)) {
+			/** @var SharedStorage $storage */
+			$share = $storage->getShare();
+			$attributes = $share->getAttributes();
+			if ($attributes !== null && $attributes->getAttribute('permissions', 'download') === false) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -472,9 +487,10 @@ class AttachmentService {
 	 */
 	private function getTextFile(int $documentId, string $userId): File {
 		$userFolder = $this->rootFolder->getUserFolder($userId);
-		$textFile = $userFolder->getById($documentId);
-		if (count($textFile) > 0 && $textFile[0] instanceof File) {
-			return $textFile[0];
+		$files = $userFolder->getById($documentId);
+		$file = array_shift($files);
+		if ($file instanceof File && !$this->isDownloadDisabled($file)) {
+			return $file;
 		}
 		throw new NotFoundException('Text file with id=' . $documentId . ' was not found in storage of ' . $userId);
 	}
@@ -495,15 +511,16 @@ class AttachmentService {
 				// shared file or folder?
 				if ($share->getNodeType() === 'file') {
 					$textFile = $share->getNode();
-					if ($textFile instanceof File) {
+					if ($textFile instanceof File && !$this->isDownloadDisabled($textFile)) {
 						return $textFile;
 					}
 				} elseif ($documentId !== null && $share->getNodeType() === 'folder') {
 					$folder = $share->getNode();
 					if ($folder instanceof Folder) {
 						$textFile = $folder->getById($documentId);
-						if (count($textFile) > 0 && $textFile[0] instanceof File) {
-							return $textFile[0];
+						$textFile = array_shift($textFile);
+						if ($textFile instanceof File && !$this->isDownloadDisabled($textFile)) {
+							return $textFile;
 						}
 					}
 				}


### PR DESCRIPTION
Opening files without download permission is blocked early anyways but better to safeguard this.

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
