### PR TITLE
fix: Use prefilter for delete with subquery

### DIFF
--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -111,8 +111,13 @@ class SessionMapper extends QBMapper {
 		}
 
 		$qb = $this->db->getQueryBuilder();
-		$qb->delete($this->getTableName())
-			->where($qb->expr()->in('id', $qb->createFunction($selectSubQuery->getSQL())));
+		$qb->delete($this->getTableName());
+		if ($documentId !== null) {
+			$qb->where($selectSubQuery->expr()->eq('document_id', $selectSubQuery->createParameter('documentId')));
+			$qb->andWhere($qb->expr()->in('id', $qb->createFunction($selectSubQuery->getSQL())));
+		} else {
+			$qb->where($qb->expr()->in('id', $qb->createFunction($selectSubQuery->getSQL())));
+		}
 		$qb->setParameters([
 			'lastContact' => time() - SessionService::SESSION_VALID_TIME,
 			'documentId' => $documentId,


### PR DESCRIPTION
It seems that MySQL is badly optimizing `DELETE FROM .. WHERE IN` with subqueries as in that a full table scan and row locks are done when the subquery returns no result. In most cases we have a document id so we can apply it to the delete query itself to reduce the amount of rows to scan.


## Before

```
MariaDB [oc]> EXPLAIN DELETE FROM `oc_text_sessions` WHERE `id` IN (SELECT `s`.`id` FROM `oc_text_sessions` `s` LEFT JOIN `oc_text_steps` `st` ON `st`.`session_id` = `s`.`id` WHERE (`last_contact` < '1689576710') AND (`st`.`id` IS NULL)
AND (`s`.`document_id` = '7197220'));
+------+--------------------+------------------+-------+---------------------------------------------+----------------------+---------+---------+------+--------------------------------------+
| id   | select_type        | table            | type  | possible_keys                               | key                  | key_len | ref     | rows | Extra                                |
+------+--------------------+------------------+-------+---------------------------------------------+----------------------+---------+---------+------+--------------------------------------+
|    1 | PRIMARY            | oc_text_sessions | ALL   | NULL                                        | NULL                 | NULL    | NULL    | 1364 | Using where                          |
|    2 | DEPENDENT SUBQUERY | s                | range | PRIMARY,ts_docid_lastcontact,ts_lastcontact | ts_docid_lastcontact | 16      | NULL    | 1    | Using where; Using index             |
|    2 | DEPENDENT SUBQUERY | st               | ref   | ts_session                                  | ts_session           | 8       | oc.s.id | 3    | Using where; Using index; Not exists |
+------+--------------------+------------------+-------+---------------------------------------------+----------------------+---------+---------+------+--------------------------------------+
```

### After

```
MariaDB [oc]> EXPLAIN DELETE FROM `oc_text_sessions` WHERE document_id = '7197220' AND `id` IN (SELECT `s`.`id` FROM `oc_text_sessions` `s` LEFT JOIN `oc_text_steps` `st` ON `st`.`session_id` = `s`.`id` WHERE (`last_contact` < '168957671
0') AND (`st`.`id` IS NULL)
+------+--------------------+------------------+-------+---------------------------------------------+----------------------+---------+---------+------+--------------------------------------+
| id   | select_type        | table            | type  | possible_keys                               | key                  | key_len | ref     | rows | Extra                                |
+------+--------------------+------------------+-------+---------------------------------------------+----------------------+---------+---------+------+--------------------------------------+
|    1 | PRIMARY            | oc_text_sessions | range | ts_docid_lastcontact                        | ts_docid_lastcontact | 8       | NULL    | 4    | Using where                          |
|    2 | DEPENDENT SUBQUERY | s                | range | PRIMARY,ts_docid_lastcontact,ts_lastcontact | ts_docid_lastcontact | 16      | NULL    | 1    | Using where; Using index             |
|    2 | DEPENDENT SUBQUERY | st               | ref   | ts_session                                  | ts_session           | 8       | oc.s.id | 3    | Using where; Using index; Not exists |
+------+--------------------+------------------+-------+---------------------------------------------+----------------------+---------+---------+------+--------------------------------------+
```