### PR TITLE
fix: Use simple query and chunk in PHP to delete inactive sessions

### DIFF
--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -100,30 +100,36 @@ class SessionMapper extends QBMapper {
 	}
 
 	public function deleteInactiveWithoutSteps(?int $documentId = null): int {
-		$selectSubQuery = $this->db->getQueryBuilder();
-		$selectSubQuery->select('s.id')
+		$lastContact = time() - SessionService::SESSION_VALID_TIME;
+
+		$inactiveSessionBuilder = $this->db->getQueryBuilder();
+		$inactiveSessionBuilder->select('s.id')
 			->from('text_sessions', 's')
-			->leftJoin('s', 'text_steps', 'st', $selectSubQuery->expr()->eq('st.session_id', 's.id'))
-			->where($selectSubQuery->expr()->lt('last_contact', $selectSubQuery->createParameter('lastContact')))
-			->andWhere($selectSubQuery->expr()->isNull('st.id'));
+			->leftJoin('s', 'text_steps', 'st', $inactiveSessionBuilder->expr()->eq('st.session_id', 's.id'))
+			->where($inactiveSessionBuilder->expr()->lt('last_contact', $inactiveSessionBuilder->createNamedParameter($lastContact)))
+			->andWhere($inactiveSessionBuilder->expr()->isNull('st.id'));
 		if ($documentId !== null) {
-			$selectSubQuery->andWhere($selectSubQuery->expr()->eq('s.document_id', $selectSubQuery->createParameter('documentId')));
+			$inactiveSessionBuilder->andWhere($inactiveSessionBuilder->expr()->eq('s.document_id', $inactiveSessionBuilder->createNamedParameter($documentId)));
 		}
+		$result = $inactiveSessionBuilder->executeQuery();
+		$documentIds = array_map(function ($row) {
+			return (int)$row['id'];
+		}, $result->fetchAll());
+		$result->closeCursor();
 
-		$qb = $this->db->getQueryBuilder();
-		$qb->delete($this->getTableName());
-		if ($documentId !== null) {
-			$qb->where($selectSubQuery->expr()->eq('document_id', $selectSubQuery->createParameter('documentId')));
-			$qb->andWhere($qb->expr()->in('id', $qb->createFunction($selectSubQuery->getSQL())));
-		} else {
-			$qb->where($qb->expr()->in('id', $qb->createFunction($selectSubQuery->getSQL())));
+		$chunks = array_chunk($documentIds, 500);
+
+		$deleteBuilder = $this->db->getQueryBuilder();
+		$deleteBuilder->delete($this->getTableName())
+			->where($deleteBuilder->expr()->in('id', $deleteBuilder->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY));
+
+		$deletedCount = 0;
+		foreach ($chunks as $ids) {
+			$deleteBuilder->setParameter('ids', $ids, IQueryBuilder::PARAM_INT_ARRAY);
+
+			$deletedCount += $deleteBuilder->executeStatement();
 		}
-		$qb->setParameters([
-			'lastContact' => time() - SessionService::SESSION_VALID_TIME,
-			'documentId' => $documentId,
-		]);
-
-		return $qb->executeStatement();
+		return $deletedCount;
 	}
 
 	public function deleteByDocumentId($documentId): int {


### PR DESCRIPTION
reverts #4339 and #4539 except for the added tests and moves to plain PHP chunking to avoid issues with MySQL 8

Easiest to review in split mode https://github.com/nextcloud/text/pull/4549/files?diff=split

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
