### PR TITLE
fix(postgres): Use a unique index name

### DIFF
--- a/lib/Listeners/AddMissingIndicesListener.php
+++ b/lib/Listeners/AddMissingIndicesListener.php
@@ -38,6 +38,6 @@ class AddMissingIndicesListener implements IEventListener {
 			return;
 		}
 
-		$event->addMissingIndex('text_steps', 'ts_session', ['session_id']);
+		$event->addMissingIndex('text_steps', 'textstep_session', ['session_id']);
 	}
 }

--- a/lib/Migration/Version010000Date20190617184535.php
+++ b/lib/Migration/Version010000Date20190617184535.php
@@ -130,7 +130,7 @@ class Version010000Date20190617184535 extends SimpleMigrationStep {
 			$table->setPrimaryKey(['id']);
 			$table->addIndex(['document_id'], 'rd_steps_did_idx');
 			$table->addIndex(['version'], 'rd_steps_version_idx');
-			$table->addIndex(['session_id'], 'ts_session');
+			$table->addIndex(['session_id'], 'textstep_session');
 		}
 		return $schema;
 	}


### PR DESCRIPTION
ts_session is already used in Talk since Nextcloud 22. Unluckily in Postgres index names have to be unique inside the database, not only per table.

### 📝 Summary

* https://help.nextcloud.com/t/error-with-talk-in-new-installation/166432/2

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
