### PR TITLE
feat: Use notify push for sync messages during editing

### DIFF
--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -35,6 +35,7 @@ use Psr\Log\LoggerInterface;
 class ApiService {
 	public function __construct(
 		private IRequest $request,
+		private ConfigService $configService,
 		private SessionService $sessionService,
 		private DocumentService $documentService,
 		private EncodingService $encodingService,
@@ -193,7 +194,7 @@ class ApiService {
 	}
 
 	private function addToPushQueue(Document $document, array $steps): void {
-		if ($this->queue === null) {
+		if ($this->queue === null || !$this->configService->isNotifyPushSyncEnabled()) {
 			return;
 		}
 

--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -12,6 +12,7 @@ namespace OCA\Text\Service;
 use Exception;
 use InvalidArgumentException;
 use OCA\Files_Sharing\SharedStorage;
+use OCA\NotifyPush\Queue\IQueue;
 use OCA\Text\AppInfo\Application;
 use OCA\Text\Db\Document;
 use OCA\Text\Db\Session;
@@ -32,7 +33,6 @@ use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 
 class ApiService {
-
 	public function __construct(
 		private IRequest $request,
 		private SessionService $sessionService,
@@ -41,6 +41,7 @@ class ApiService {
 		private LoggerInterface $logger,
 		private IL10N $l10n,
 		private ?string $userId,
+		private ?IQueue $queue,
 	) {
 	}
 
@@ -181,6 +182,7 @@ class ApiService {
 		}
 		try {
 			$result = $this->documentService->addStep($document, $session, $steps, $version, $token);
+			$this->addToPushQueue($document, [$awareness, ...array_values($steps)]);
 		} catch (InvalidArgumentException $e) {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_UNPROCESSABLE_ENTITY);
 		} catch (DoesNotExistException|NotPermittedException) {
@@ -188,6 +190,27 @@ class ApiService {
 			return new DataResponse(['error' => $this->l10n->t('Editing session has expired. Please reload the page.')], Http::STATUS_PRECONDITION_FAILED);
 		}
 		return new DataResponse($result);
+	}
+
+	private function addToPushQueue(Document $document, array $steps): void {
+		if ($this->queue === null) {
+			return;
+		}
+
+		$sessions = $this->sessionService->getActiveSessions($document->getId());
+		$userIds = array_values(array_filter(array_unique(
+			array_map(fn ($session): ?string => $session['userId'], $sessions)
+		)));
+		foreach ($userIds as $userId) {
+			$this->queue->push('notify_custom', [
+				'user' => $userId,
+				'message' => 'text_steps',
+				'body' => [
+					'documentId' => $document->getId(),
+					'steps' => $steps,
+				],
+			]);
+		}
 	}
 
 	public function sync(Session $session, Document $document, int $version = 0, ?string $shareToken = null): DataResponse {

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -39,4 +39,9 @@ class ConfigService {
 		}
 		return $this->config->getUserValue($userId, Application::APP_NAME, 'workspace_enabled', '1') === '1';
 	}
+
+	public function isNotifyPushSyncEnabled(): bool {
+		return $this->appConfig->getValueBool(Application::APP_NAME, 'notify_push');
+
+	}
 }

--- a/lib/Service/InitialStateProvider.php
+++ b/lib/Service/InitialStateProvider.php
@@ -64,6 +64,11 @@ class InitialStateProvider {
 				];
 			}, $this->textProcessingManager->getAvailableTaskTypes()),
 		);
+
+		$this->initialState->provideInitialState(
+			'notify_push',
+			$this->configService->isNotifyPushSyncEnabled(),
+		);
 	}
 
 	public function provideFileId(int $fileId): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nextcloud/l10n": "^3.1.0",
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/moment": "^1.3.1",
+        "@nextcloud/notify_push": "^1.3.0",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/vue": "^8.14.0",
         "@quartzy/markdown-it-mentions": "^0.2.0",
@@ -4302,6 +4303,16 @@
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"
+      }
+    },
+    "node_modules/@nextcloud/notify_push": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/notify_push/-/notify_push-1.3.0.tgz",
+      "integrity": "sha512-WmyINTP/RynrfrOdyxzcntwV79b88uhXHU3cVJEcMzuh7wt6YT66kitjuQHMGlrG/xlEwk4qUKEM/NpFqVcvJg==",
+      "dependencies": {
+        "@nextcloud/axios": "^2.5.0",
+        "@nextcloud/capabilities": "^1.2.0",
+        "@nextcloud/event-bus": "^3.3.0"
       }
     },
     "node_modules/@nextcloud/paths": {
@@ -31194,6 +31205,16 @@
             "core-js": "^3.6.4"
           }
         }
+      }
+    },
+    "@nextcloud/notify_push": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/notify_push/-/notify_push-1.3.0.tgz",
+      "integrity": "sha512-WmyINTP/RynrfrOdyxzcntwV79b88uhXHU3cVJEcMzuh7wt6YT66kitjuQHMGlrG/xlEwk4qUKEM/NpFqVcvJg==",
+      "requires": {
+        "@nextcloud/axios": "^2.5.0",
+        "@nextcloud/capabilities": "^1.2.0",
+        "@nextcloud/event-bus": "^3.3.0"
       }
     },
     "@nextcloud/paths": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@nextcloud/l10n": "^3.1.0",
     "@nextcloud/logger": "^3.0.2",
     "@nextcloud/moment": "^1.3.1",
+    "@nextcloud/notify_push": "^1.3.0",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/vue": "^8.14.0",
     "@quartzy/markdown-it-mentions": "^0.2.0",

--- a/src/services/NotifyService.js
+++ b/src/services/NotifyService.js
@@ -1,31 +1,19 @@
-/*
- * @copyright Copyright (c) 2023 Julius Härtl <jus@bitgrid.net>
- *
- * @author Julius Härtl <jus@bitgrid.net>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 import mitt from 'mitt'
 import { listen } from '@nextcloud/notify_push'
+import { loadState } from '@nextcloud/initial-state'
 
 if (!window._nc_text_notify) {
-	const useNotifyPush = listen('text_steps', (messageType, messageBody) => {
-		window._nc_text_notify?.emit('notify_push', { messageType, messageBody })
-	})
+	const isPushEnabled = loadState('text', 'notify_push', false)
+	const useNotifyPush = isPushEnabled
+		? listen('text_steps', (messageType, messageBody) => {
+			window._nc_text_notify?.emit('notify_push', { messageType, messageBody })
+		})
+		: undefined
 	window._nc_text_notify = useNotifyPush ? mitt() : null
 }
 

--- a/src/services/NotifyService.js
+++ b/src/services/NotifyService.js
@@ -1,0 +1,34 @@
+/*
+ * @copyright Copyright (c) 2023 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import mitt from 'mitt'
+import { listen } from '@nextcloud/notify_push'
+
+if (!window._nc_text_notify) {
+	const useNotifyPush = listen('text_steps', (messageType, messageBody) => {
+		window._nc_text_notify?.emit('notify_push', { messageType, messageBody })
+	})
+	window._nc_text_notify = useNotifyPush ? mitt() : null
+}
+
+export default () => {
+	return window._nc_text_notify
+}

--- a/tests/stub.php
+++ b/tests/stub.php
@@ -49,3 +49,15 @@ namespace OCA\TpAssistant\Event {
 		abstract public function setNotificationTarget(?string $notificationTarget): void;
 	}
 }
+
+
+namespace OCA\NotifyPush\Queue {
+	interface IQueue {
+		/**
+		 * @param string $channel
+		 * @param mixed $message
+		 * @return void
+		 */
+		public function push(string $channel, $message);
+	}
+}


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>

### 📝 Summary

* Resolves: #1805 

This is a first PoC to make use of notify_push for syncing steps back to other editors instead of regular polling. We still poll every 30 seconds as a fallback and to ensure that the autosave requests are still triggered until https://github.com/nextcloud/text/pull/4424 is there (even with that some fallback sync might still be worth).

Can be manually enabled for now with

```
occ config:app:set text notify_push --type boolean --value=1
```

### 🚧 TODO

- [x] More manual testing in different scenarios
  - [x] Check what happens with the base doc changing externally (did we use the sync to detect the conflict?)

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
