### PR TITLE
Lazy load text-viewer and text-files

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -21,12 +21,9 @@
  */
 import { linkTo } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
-import Vue from 'vue'
+import { registerFileListHeaders } from '@nextcloud/files'
 
 import { logger } from './helpers/logger.js'
-import { registerFileActionFallback } from './helpers/files.js'
-import FilesSettings from './views/FilesSettings.vue'
-import store from './store/index.js'
 
 __webpack_nonce__ = window.btoa(OC.requestToken) // eslint-disable-line
 __webpack_public_path__ = linkTo('text', 'js/') // eslint-disable-line
@@ -34,13 +31,18 @@ __webpack_public_path__ = linkTo('text', 'js/') // eslint-disable-line
 const workspaceAvailable = loadState('text', 'workspace_available')
 const workspaceEnabled = loadState('text', 'workspace_enabled')
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
 	if (typeof OCA.Viewer === 'undefined') {
+		const { registerFileActionFallback } = await import('./helpers/files.js')
 		logger.error('Viewer app is not installed')
 		registerFileActionFallback()
 	}
 
 	if (workspaceAvailable && OCA && OCA?.Files?.Settings) {
+		const { default: Vue } = await import('vue')
+		const { default: FilesSettings } = await import('./views/FilesSettings.vue')
+		const { default: store } = await import('./store/index.js')
+
 		Vue.prototype.t = window.t
 		Vue.prototype.n = window.n
 		Vue.prototype.OCA = window.OCA
@@ -54,6 +56,10 @@ document.addEventListener('DOMContentLoaded', () => {
 		}))
 	}
 
+	if (workspaceAvailable) {
+		const { FilesWorkspaceHeader } = await import('./helpers/files.js')
+		registerFileListHeaders(FilesWorkspaceHeader)
+	}
 })
 
 OCA.Text = {

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -27,7 +27,6 @@ import { loadState } from '@nextcloud/initial-state'
 
 import { getSharingToken } from './token.js'
 import { openMimetypes } from './mime.js'
-import RichWorkspace from '../views/RichWorkspace.vue'
 import store from '../store/index.js'
 import { getCurrentUser } from '@nextcloud/auth'
 import { showSuccess, showError } from '@nextcloud/dialogs'
@@ -211,7 +210,7 @@ export const FilesWorkspaceHeader = new Header({
 		return view.id === 'files'
 	},
 
-	render(el, folder, view) {
+	async render(el, folder, view) {
 		if (vm) {
 			// Enforce destroying of the old rendering and rerender as the FilesListHeader calls render on every folder change
 			vm.$destroy()
@@ -222,6 +221,8 @@ export const FilesWorkspaceHeader = new Header({
 		const content = newWorkspaceCreated ? '' : folder.attributes['rich-workspace']
 
 		newWorkspaceCreated = false
+
+		const { default: RichWorkspace } = await import('./../views/RichWorkspace.vue')
 
 		import('vue').then((module) => {
 			el.id = 'files-workspace-wrapper'

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -20,7 +20,6 @@
  *
  */
 
-import ViewerComponent from './components/ViewerComponent.vue'
 import { logger } from './helpers/logger.js'
 import { openMimetypesMarkdown, openMimetypesPlainText } from './helpers/mime.js'
 
@@ -33,8 +32,7 @@ if (typeof OCA.Viewer === 'undefined') {
 	OCA.Viewer.registerHandler({
 		id: 'text',
 		mimes: [...openMimetypesMarkdown, ...openMimetypesPlainText],
-		// Would be good to be able to lazyload that
-		component: ViewerComponent,
+		component: () => import('./components/ViewerComponent.vue'),
 		group: null,
 		theme: 'default',
 		canCompare: true,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -33,6 +33,7 @@ if (typeof OCA.Viewer === 'undefined') {
 	OCA.Viewer.registerHandler({
 		id: 'text',
 		mimes: [...openMimetypesMarkdown, ...openMimetypesPlainText],
+		// Would be good to be able to lazyload that
 		component: ViewerComponent,
 		group: null,
 		theme: 'default',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,11 +45,6 @@ webpackConfig.optimization.splitChunks.cacheGroups = {
 	}
 }
 
-// webpackConfig.resolve.modules = [
-// 	path.resolve(__dirname, 'node_modules'),
-// 	'node_modules'
-// ]
-
 // Fix Buffer issues
 webpackConfig.plugins.push(new webpack.ProvidePlugin({
 	Buffer: ['buffer', 'Buffer'],
@@ -66,5 +61,16 @@ webpackRules.RULE_RAW_SVGS = {
 }
 
 webpackConfig.module.rules = Object.values(webpackRules)
+
+webpackConfig.optimization.splitChunks.minSize = 102400
+
+webpackConfig.optimization.splitChunks.cacheGroups = {
+	mermaid: {
+		test(module) {
+			return module.resource && module.resource.includes(`${path.sep}node_modules${path.sep}mermaid`)
+		},
+		name: 'mermaid',
+	},
+}
 
 module.exports = webpackConfig

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,14 +36,12 @@ Object.assign(webpackConfig.output, {
 
 webpackConfig.optimization.chunkIds = 'named'
 webpackConfig.optimization.splitChunks.cacheGroups = {
-	defaultVendors: {
-		test(module) {
-			return module.resource && module.resource.includes(`${path.sep}node_modules${path.sep}`) &&
-				!module.resource.includes(`${path.sep}highlight.js${path.sep}`)
-		},
-		name: 'vendors',
-	}
+	mermaid: {
+		test: /[\\/]node_modules[\\/](mermaid)[\\/]/,
+		name: 'mermaid',
+	},
 }
+webpackConfig.optimization.splitChunks.minSize = 102400
 
 // Fix Buffer issues
 webpackConfig.plugins.push(new webpack.ProvidePlugin({
@@ -61,16 +59,5 @@ webpackRules.RULE_RAW_SVGS = {
 }
 
 webpackConfig.module.rules = Object.values(webpackRules)
-
-webpackConfig.optimization.splitChunks.minSize = 102400
-
-webpackConfig.optimization.splitChunks.cacheGroups = {
-	mermaid: {
-		test(module) {
-			return module.resource && module.resource.includes(`${path.sep}node_modules${path.sep}mermaid`)
-		},
-		name: 'mermaid',
-	},
-}
 
 module.exports = webpackConfig


### PR DESCRIPTION
Fixes https://github.com/nextcloud/text/issues/2451
Fixes https://github.com/nextcloud/text/issues/5045

Currently, 5Mb are loaded on the main thread. The idea is to lazy load most of it, and let webpack do a proper chunking.

Also in this PR:
+ Remove vendor bundling
+ Remove chunkIds declaration as it is already the default

Note | Before | After
-- | -- | --
Here, to exacerbate the network gains, it was throttled. The total size is reduced by ~0.15Mb, due to the better chunking. And the DOM loading time is reduced by 30%, because we do not wait for all the scripts before starting the rendering. | ![Screenshot from 2023-08-18 16-45-30](https://github.com/nextcloud/text/assets/6653109/0cebdb49-eca1-4028-a64f-b90a094205a2) | ![Screenshot from 2023-08-18 16-44-23](https://github.com/nextcloud/text/assets/6653109/9dd25580-b32a-4485-a9bf-a30ca4b579e9)
Without throttling, we can still observe a slight gain due to not executing 5Mb of scripts before rendering. The number is more volatile, but repetitions consistently show lower numbers for the lazy loaded build. | ![Screenshot from 2023-08-18 17-13-12](https://github.com/nextcloud/text/assets/6653109/0ca7925e-6dd8-4659-9ba8-268ff818c0fb) | ![Screenshot from 2023-08-18 17-12-00](https://github.com/nextcloud/text/assets/6653109/159c261c-98e3-4696-b322-2189ee67e659)
More request, but the initial ones are smaller, and the remaining are lazy loaded | ![Screenshot from 2023-08-18 15-54-30](https://github.com/nextcloud/text/assets/6653109/612c29f2-a27b-4017-96a3-5b359a26e311) | ![Screenshot from 2023-08-18 16-18-26](https://github.com/nextcloud/text/assets/6653109/bcfe2b24-714f-4dbc-ab3d-34bb481467a1)
Just to show the new build layout | ![Screenshot 2023-08-18 at 16-16-53 @nextcloud_text 18 Aug 2023 at 16 03](https://github.com/nextcloud/text/assets/6653109/4799bf93-61a1-44fe-8138-be737ce8dd2d) | ![Screenshot 2023-08-18 at 16-17-49 @nextcloud_text 18 Aug 2023 at 15 52](https://github.com/nextcloud/text/assets/6653109/402325c6-0e44-4981-a3da-d706e00f6395)

Current webpack config dates from: https://github.com/nextcloud/text/pull/1659