### PR TITLE
fix(cypress): close attachments file before proceeding

### DIFF
--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -103,6 +103,9 @@ const checkAttachment = (documentId, fileName, fileId, index, isImage = true) =>
 			const srcPathEnd = isImage ? 'image' : 'mediaPreview'
 			const srcFileNameParam = isImage ? 'imageFileName' : 'mediaFileName'
 
+			// ensure the image is not hidden behind the menu bar.
+			cy.wrap($el).scrollIntoView({ offset: { top: -50, left: 0 } })
+
 			cy.wrap($el)
 				.should('be.visible')
 				.find('img')
@@ -220,6 +223,7 @@ describe('Test all attachment insertion methods', () => {
 
 				return waitForRequestAndCheckAttachment(requestAlias)
 			})
+		cy.closeFile()
 	})
 
 	it('Upload a local image file (table.png)', () => {
@@ -236,6 +240,7 @@ describe('Test all attachment insertion methods', () => {
 
 				return waitForRequestAndCheckAttachment(requestAlias)
 			})
+		cy.closeFile()
 	})
 
 	it('Upload a local media file (file.txt.gz)', () => {
@@ -252,6 +257,7 @@ describe('Test all attachment insertion methods', () => {
 
 				return waitForRequestAndCheckAttachment(requestAlias, undefined, false)
 			})
+		cy.closeFile()
 	})
 
 	it('Upload image files with the same name', () => {
@@ -280,8 +286,9 @@ describe('Test all attachment insertion methods', () => {
 					assertImage(index).then(resolve, reject)
 				})
 			})
-		return cy.getEditor().find('[data-component="image-view"]')
+		cy.getEditor().find('[data-component="image-view"]')
 			.should('have.length', 3)
+		cy.closeFile()
 	})
 
 	it('test if attachment files are in the attachment folder', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -321,7 +321,7 @@ Cypress.Commands.add('getFile', fileName => {
 
 Cypress.Commands.add('deleteFile', fileName => {
 	cy.get(`[data-cy-files-list] tr[data-cy-files-list-row-name="${fileName}"] .files-list__row-actions button`).click()
-	cy.get('.files-list__row-action-delete button').click()
+	cy.get('.files-list__row-action-delete:visible button').click()
 	cy.get(`[data-cy-files-list] tr[data-cy-files-list-row-name="${fileName}"]`).should('not.exist')
 })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -306,7 +306,7 @@ Cypress.Commands.add('openFileInShare', fileName => {
 	cy.wait(250)
 })
 
-Cypress.Commands.add('closeFile', (fileName, params = {}) => {
+Cypress.Commands.add('closeFile', (params = {}) => {
 	cy.intercept({ method: 'POST', url: '**/apps/text/session/close' })
 		.as('close')
 	cy.get('#viewer .modal-header button.header-close').click(params)


### PR DESCRIPTION
### 📝 Summary

Deleting the file later on failed because the file still was locked.

* Resolves: failing test runs such as https://github.com/nextcloud/text/actions/runs/5995152778/job/16257869213

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Test all attachment insertion methods -- test if attachment folder is deleted after having deleted a markdown file (failed)](https://github.com/nextcloud/text/assets/97337118/1ace64c4-b0c6-4d8c-9fa3-285b4b1b468b)
 | A


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] this PR fixes tests.
- [x] Documentation is not required
