### PR TITLE
fix: Avoid layout jump with rich workspace

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -183,12 +183,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "cb36d570c3b7aae1735599cc4b3614b9ce5c9c79"
+                "reference": "671134b6035f3aa5cd8b51c9e4e1cebf32aafacb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/cb36d570c3b7aae1735599cc4b3614b9ce5c9c79",
-                "reference": "cb36d570c3b7aae1735599cc4b3614b9ce5c9c79",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/671134b6035f3aa5cd8b51c9e4e1cebf32aafacb",
+                "reference": "671134b6035f3aa5cd8b51c9e4e1cebf32aafacb",
                 "shasum": ""
             },
             "require": {
@@ -220,7 +220,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2023-08-26T00:28:49+00:00"
+            "time": "2023-09-08T12:52:53+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2574,5 +2574,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/cypress/e2e/conflict.spec.js
+++ b/cypress/e2e/conflict.spec.js
@@ -32,7 +32,7 @@ const variants = [
 variants.forEach(function({ fixture, mime }) {
 	const fileName = fixture
 	describe(`${mime} (${fileName})`, function() {
-		const getWrapper = () => cy.get('.text-editor__wrapper.has-conflicts')
+		const getWrapper = () => cy.get('.viewer__content .text-editor__wrapper.has-conflicts')
 
 		before(() => {
 			initUserAndFiles(user, fileName)
@@ -56,13 +56,13 @@ variants.forEach(function({ fixture, mime }) {
 			cy.openFile(fileName)
 			cy.get('.text-editor .document-status .icon-error')
 			getWrapper()
-				.get('#read-only-editor')
+				.find('#read-only-editor')
 				.should('contain', 'Hello world')
 			getWrapper()
-				.get('.text-editor__main')
+				.find('.text-editor__main')
 				.should('contain', 'Hello world')
 			getWrapper()
-				.get('.text-editor__main')
+				.find('.text-editor__main')
 				.should('contain', 'cruel conflicting')
 		})
 
@@ -81,7 +81,6 @@ variants.forEach(function({ fixture, mime }) {
 			cy.get('[data-cy="resolveThisVersion"]').click()
 
 			getWrapper()
-				.get('#read-only-editor')
 				.should('not.exist')
 
 			cy.get('[data-cy="resolveThisVersion"]')
@@ -105,12 +104,10 @@ variants.forEach(function({ fixture, mime }) {
 			cy.get('#viewer').should('not.exist')
 			cy.openFile(fileName)
 
-			getWrapper()
-				.get('[data-cy="resolveServerVersion"]')
+			cy.get('[data-cy="resolveServerVersion"]')
 				.click()
 
 			getWrapper()
-				.get('#read-only-editor')
 				.should('not.exist')
 			cy.get('[data-cy="resolveThisVersion"]')
 				.should('not.exist')

--- a/lib/Listeners/FilesLoadAdditionalScriptsListener.php
+++ b/lib/Listeners/FilesLoadAdditionalScriptsListener.php
@@ -45,6 +45,7 @@ class FilesLoadAdditionalScriptsListener implements IEventListener {
 			return;
 		}
 
+		\OCP\Util::addInitScript('text', 'text-init');
 		\OCP\Util::addScript('text', 'text-files');
 
 		$this->initialStateProvider->provideState();

--- a/src/files.js
+++ b/src/files.js
@@ -21,11 +21,10 @@
  */
 import { linkTo } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
-import { registerFileListHeaders, registerDavProperty } from '@nextcloud/files'
 import Vue from 'vue'
 
 import { logger } from './helpers/logger.js'
-import { registerFileActionFallback, FilesWorkspaceHeader } from './helpers/files.js'
+import { registerFileActionFallback } from './helpers/files.js'
 import FilesSettings from './views/FilesSettings.vue'
 import store from './store/index.js'
 
@@ -34,9 +33,6 @@ __webpack_public_path__ = linkTo('text', 'js/') // eslint-disable-line
 
 const workspaceAvailable = loadState('text', 'workspace_available')
 const workspaceEnabled = loadState('text', 'workspace_enabled')
-
-registerDavProperty('nc:rich-workspace', { nc: 'http://nextcloud.org/ns' })
-registerDavProperty('nc:rich-workspace-file', { nc: 'http://nextcloud.org/ns' })
 
 document.addEventListener('DOMContentLoaded', () => {
 	if (typeof OCA.Viewer === 'undefined') {
@@ -59,9 +55,6 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 })
-if (workspaceAvailable) {
-	registerFileListHeaders(FilesWorkspaceHeader)
-}
 
 OCA.Text = {
 	RichWorkspaceEnabled: workspaceEnabled,

--- a/src/files.js
+++ b/src/files.js
@@ -21,7 +21,7 @@
  */
 import { linkTo } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
-import { registerFileListHeaders } from '@nextcloud/files'
+import { registerFileListHeaders, registerDavProperty } from '@nextcloud/files'
 import Vue from 'vue'
 
 import { logger } from './helpers/logger.js'
@@ -34,6 +34,9 @@ __webpack_public_path__ = linkTo('text', 'js/') // eslint-disable-line
 
 const workspaceAvailable = loadState('text', 'workspace_available')
 const workspaceEnabled = loadState('text', 'workspace_enabled')
+
+registerDavProperty('nc:rich-workspace', { nc: 'http://nextcloud.org/ns' })
+registerDavProperty('nc:rich-workspace-file', { nc: 'http://nextcloud.org/ns' })
 
 document.addEventListener('DOMContentLoaded', () => {
 	if (typeof OCA.Viewer === 'undefined') {

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -187,6 +187,7 @@ export const FilesWorkspaceHeader = new Header({
 
 	render(el, folder, view) {
 		addMenuRichWorkspace()
+		const hasRichWorkspace = !!folder.attributes['rich-workspace-file']
 
 		import('vue').then((module) => {
 			el.id = 'files-workspace-wrapper'
@@ -201,6 +202,8 @@ export const FilesWorkspaceHeader = new Header({
 			vm = new View({
 				propsData: {
 					path: folder.path,
+					hasRichWorkspace,
+					content: folder.attributes['rich-workspace'],
 				},
 				store,
 			}).$mount(el)
@@ -208,7 +211,10 @@ export const FilesWorkspaceHeader = new Header({
 	},
 
 	updated(folder, view) {
+		const hasRichWorkspace = !!folder.attributes['rich-workspace-file']
 		vm.path = folder.path
+		vm.hasRichWorkspace = hasRichWorkspace
+		vm.content = folder.attributes['rich-workspace']
 	},
 })
 

--- a/src/init.js
+++ b/src/init.js
@@ -1,0 +1,12 @@
+import { registerFileListHeaders, registerDavProperty } from '@nextcloud/files'
+import { loadState } from '@nextcloud/initial-state'
+import { FilesWorkspaceHeader } from './helpers/files.js'
+
+const workspaceAvailable = loadState('text', 'workspace_available')
+
+registerDavProperty('nc:rich-workspace', { nc: 'http://nextcloud.org/ns' })
+registerDavProperty('nc:rich-workspace-file', { nc: 'http://nextcloud.org/ns' })
+
+if (workspaceAvailable) {
+	registerFileListHeaders(FilesWorkspaceHeader)
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ webpackConfig.entry = {
 	public: path.join(__dirname, 'src', 'public.js'),
 	viewer: path.join(__dirname, 'src', 'viewer.js'),
 	editors: path.join(__dirname, 'src', 'editor.js'),
+	init: path.join(__dirname, 'src', 'init.js'),
 }
 
 webpackConfig.output.chunkFilename = '[id].js?v=[contenthash]'


### PR DESCRIPTION
Alternative approach to #4254 which uses additional dav properties to already know on initial rendering if space for the rich workspace should be preserved.

In addition we can actually use the webdav markdown response to even show the full file content rendered before the text session is even started. As a follow up we could think about only initializing the session if the user clicks the rich workspace which would save us from lots of requests and problems with rich workspace always being locked.