### PR TITLE
fix: Rework attachment tests

### DIFF
--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -149,6 +149,8 @@ describe('Test all attachment insertion methods', () => {
 	before(() => {
 		initUserAndFiles(user, 'test.md', 'empty.md')
 
+		cy.createFolder('.hidden')
+
 		cy.createFolder('sub')
 		cy.createFolder('sub/a')
 		cy.createFolder('sub/b')
@@ -162,17 +164,19 @@ describe('Test all attachment insertion methods', () => {
 	})
 
 	beforeEach(() => {
+		cy.showHiddenFiles()
 		cy.login(currentUser)
-		cy.visit('/apps/files')
 	})
 
 	it('See test files in the list and display hidden files', () => {
+		cy.visit('/apps/files')
 		cy.getFile('test.md')
 		cy.getFile('github.png')
-		cy.showHiddenFiles()
+		cy.getFile('.hidden')
 	})
 
 	it('Insert an image file from Files', () => {
+		cy.visit('/apps/files')
 		cy.openFile('test.md')
 
 		clickOnAttachmentAction(ACTION_INSERT_FROM_FILES)
@@ -227,6 +231,7 @@ describe('Test all attachment insertion methods', () => {
 	})
 
 	it('Upload a local image file (table.png)', () => {
+		cy.visit('/apps/files')
 		cy.openFile('test.md')
 		// in this case we almost could just attach the file to the input
 		// BUT we still need to click on the action because otherwise the command
@@ -244,6 +249,7 @@ describe('Test all attachment insertion methods', () => {
 	})
 
 	it('Upload a local media file (file.txt.gz)', () => {
+		cy.visit('/apps/files')
 		cy.openFile('test.md')
 		// in this case we almost could just attach the file to the input
 		// BUT we still need to click on the action because otherwise the command
@@ -265,7 +271,7 @@ describe('Test all attachment insertion methods', () => {
 		const filename = randHash() + '.md'
 
 		cy.uploadFile('empty.md', 'text/markdown', filename)
-		cy.reloadFileList()
+		cy.visit('/apps/files')
 		cy.openFile(filename)
 
 		const assertImage = index => {
@@ -292,7 +298,7 @@ describe('Test all attachment insertion methods', () => {
 	})
 
 	it('test if attachment files are in the attachment folder', () => {
-		// check we stored the attachment names/ids
+		cy.visit('/apps/files')
 
 		cy.getFile('test.md')
 			.should('have.attr', 'data-cy-files-list-row-fileid')
@@ -312,7 +318,7 @@ describe('Test all attachment insertion methods', () => {
 
 	it('test if attachment folder is moved with the markdown file', () => {
 		cy.createFolder('subFolder')
-		cy.reloadFileList()
+		cy.visit('/apps/files')
 		cy.moveFile('test.md', 'subFolder/test.md')
 		cy.openFolder('subFolder')
 		cy.getFile('test.md')
@@ -332,7 +338,7 @@ describe('Test all attachment insertion methods', () => {
 
 	it('test if attachment folder is copied when copying a markdown file', () => {
 		cy.copyFile('subFolder/test.md', 'testCopied.md')
-		cy.reloadFileList()
+		cy.visit('/apps/files')
 
 		cy.getFile('testCopied.md')
 			.should('exist')
@@ -353,6 +359,8 @@ describe('Test all attachment insertion methods', () => {
 	})
 
 	it('test if attachment folder is deleted after having deleted a markdown file', () => {
+		cy.copyFile('subFolder/test.md', 'testCopied.md')
+		cy.visit('/apps/files')
 		cy.getFile('testCopied.md')
 			.should('exist')
 			.should('have.attr', 'data-cy-files-list-row-fileid')
@@ -367,6 +375,7 @@ describe('Test all attachment insertion methods', () => {
 	})
 
 	it('[share] check everything behaves correctly on the share target user side', () => {
+		cy.visit('/apps/files')
 		// check the file list
 		cy.getFile('test.md')
 			.should('exist')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -405,14 +405,24 @@ Cypress.Commands.add('configureText', (key, value) => {
 	})
 })
 
-Cypress.Commands.add('showHiddenFiles', () => {
-	cy.get('[data-cy-files-navigation-settings-button]')
-		.click()
-	cy.get('.app-settings__content').should('be.visible')
-	cy.intercept({ method: 'PUT', url: '**/show_hidden' }).as('showHidden')
-	cy.get('.app-settings__content').contains('Show hidden files').closest('label').click()
-	cy.wait('@showHidden')
-	cy.get('.modal-container__close').click()
+Cypress.Commands.add('showHiddenFiles', (value = true) => {
+	return cy.request('/csrftoken')
+		.then(({ body }) => body.token)
+		.then(requesttoken => {
+			return cy.request({
+				url: `${url}/index.php/apps/files/api/v1/config/show_hidden`,
+				method: 'put',
+				body: {
+					value,
+				},
+				auth,
+				headers: {
+					requesttoken,
+				},
+			}).then((response) => {
+				return cy.log(`Set hidden files to ${value}`, response.status)
+			})
+		})
 })
 
 Cypress.Commands.add('createDescription', () => {


### PR DESCRIPTION
One local failure remaining which seems related to recent getParent changes:

```
{
  "reqId": "9fD20dHDE2aTMruVxttA",
  "level": 3,
  "time": "2023-09-06T17:10:52+00:00",
  "remoteAddr": "192.168.21.1",
  "user": "yztziuuoda",
  "app": "no app in context",
  "method": "MOVE",
  "url": "/remote.php/dav/files/yztziuuoda/test.md",
  "message": "",
  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36",
  "version": "28.0.0.2",
  "exception": {
    "Exception": "OCP\\Files\\NotFoundException",
    "Message": "",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/html/lib/private/Files/Node/Node.php",
        "line": 303,
        "function": "getFileInfo",
        "class": "OC\\Files\\Node\\Node",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/apps/text/lib/Service/AttachmentService.php",
        "line": 630,
        "function": "getParent",
        "class": "OC\\Files\\Node\\Node",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/apps/text/lib/Listeners/BeforeNodeRenamedListener.php",
        "line": 54,
        "function": "moveAttachments",
        "class": "OCA\\Text\\Service\\AttachmentService",
        "type": "->",
        "args": [
          [
            "OC\\Files\\Node\\File"
          ],
          [
            "OC\\Files\\Node\\NonExistingFile"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 86,
        "function": "handle",
        "class": "OCA\\Text\\Listeners\\BeforeNodeRenamedListener",
        "type": "->",
        "args": [
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeRenamedEvent"
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 230,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->",
        "args": [
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeRenamedEvent"
          ],
          "OCP\\Files\\Events\\Node\\BeforeNodeRenamedEvent",
          [
            "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 59,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            [
              "Closure"
            ],
            [
              "Closure"
            ]
          ],
          "OCP\\Files\\Events\\Node\\BeforeNodeRenamedEvent",
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeRenamedEvent"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 94,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeRenamedEvent"
          ],
          "OCP\\Files\\Events\\Node\\BeforeNodeRenamedEvent"
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 106,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          "OCP\\Files\\Events\\Node\\BeforeNodeRenamedEvent",
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeRenamedEvent"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Node/HookConnector.php",
        "line": 175,
        "function": "dispatchTyped",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeRenamedEvent"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/legacy/OC_Hook.php",
        "line": 105,
        "function": "rename",
        "class": "OC\\Files\\Node\\HookConnector",
        "type": "->",
        "args": [
          [
            "/test.md",
            "/testMoved.md",
            true
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/View.php",
        "line": 755,
        "function": "emit",
        "class": "OC_Hook",
        "type": "::",
        "args": [
          "OC_Filesystem",
          "rename",
          [
            "/test.md",
            "/testMoved.md",
            true
          ]
        ]
      },
      {
        "file": "/var/www/html/apps/dav/lib/Connector/Sabre/Node.php",
        "line": 159,
        "function": "rename",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "/test.md",
          "/testMoved.md"
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Tree.php",
        "line": 153,
        "function": "setName",
        "class": "OCA\\DAV\\Connector\\Sabre\\Node",
        "type": "->",
        "args": [
          "testMoved.md"
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
        "line": 612,
        "function": "move",
        "class": "Sabre\\DAV\\Tree",
        "type": "->",
        "args": [
          "files/yztziuuoda/test.md",
          "files/yztziuuoda/testMoved.md"
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
        "line": 89,
        "function": "httpMove",
        "class": "Sabre\\DAV\\CorePlugin",
        "type": "->",
        "args": [
          [
            "Sabre\\HTTP\\Request"
          ],
          [
            "Sabre\\HTTP\\Response"
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 472,
        "function": "emit",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "method:MOVE",
          [
            [
              "Sabre\\HTTP\\Request"
            ],
            [
              "Sabre\\HTTP\\Response"
            ]
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 253,
        "function": "invokeMethod",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          [
            "Sabre\\HTTP\\Request"
          ],
          [
            "Sabre\\HTTP\\Response"
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 321,
        "function": "start",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/apps/dav/lib/Server.php",
        "line": 366,
        "function": "exec",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/apps/dav/appinfo/v2/remote.php",
        "line": 35,
        "function": "exec",
        "class": "OCA\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/remote.php",
        "line": 172,
        "args": [
          "/var/www/html/apps/dav/appinfo/v2/remote.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/html/lib/private/Files/Node/Node.php",
    "Line": 112,
    "CustomMessage": "--"
  }
}

```