### PR TITLE
[stable27] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -183,12 +183,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "ec5cfc7f39f99e877f7c585866b006ca08dc7556"
+                "reference": "10d5e8430930a2f18e4c3a2053fb32348853bb78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ec5cfc7f39f99e877f7c585866b006ca08dc7556",
-                "reference": "ec5cfc7f39f99e877f7c585866b006ca08dc7556",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/10d5e8430930a2f18e4c3a2053fb32348853bb78",
+                "reference": "10d5e8430930a2f18e4c3a2053fb32348853bb78",
                 "shasum": ""
             },
             "require": {
@@ -219,7 +219,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable27"
             },
-            "time": "2023-08-30T00:30:24+00:00"
+            "time": "2023-09-07T00:30:04+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency