### PR TITLE
chore(renovate): update nextcloud packages separately

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,12 +33,6 @@
       ]
     },
     {
-      "groupName": "nextcloud",
-      "matchPackagePrefixes": [
-        "@nextcloud/"
-      ]
-    },
-    {
       "groupName": "cypress",
       "matchPackageNames": [
         "cypress",


### PR DESCRIPTION
They do not really depend on each other
and are more likely to cause CI failures than others.

If we combine the upgrades one upgrade failing will also block the others.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
