### PR TITLE
Fix 403 on close

### DIFF
--- a/cypress/e2e/api/SessionApi.spec.js
+++ b/cypress/e2e/api/SessionApi.spec.js
@@ -301,6 +301,19 @@ describe('The session Api', function() {
 			})
 		})
 
+		it('signals closing connection', function() {
+			cy.then(() => {
+				return new Promise((resolve, reject) => {
+					connection.close()
+					connection.push({ steps: [messages.update], version, awareness: '' })
+						.then(
+							() => reject(new Error('Push should have thrown ConnectionClosed()')),
+							resolve,
+						)
+				})
+			})
+		})
+
 		it('sends initial content if other session is alive but did not push any steps', function() {
 			let joining
 			cy.createTextSession(undefined, { filePath: '', shareToken })

--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -157,16 +157,16 @@ class SyncService {
 		return new Promise((resolve, reject) => {
 			this.#sendIntervalId = setInterval(() => {
 				if (this.connection && !this.sending) {
-					clearInterval(this.#sendIntervalId)
-					this.#sendIntervalId = null
-					this._sendSteps(getSendable).then(resolve).catch(reject)
+					this.sendStepsNow(getSendable).then(resolve).catch(reject)
 				}
 			}, 200)
 		})
 	}
 
-	_sendSteps(getSendable) {
+	sendStepsNow(getSendable) {
 		this.sending = true
+		clearInterval(this.#sendIntervalId)
+		this.#sendIntervalId = null
 		const data = getSendable()
 		if (data.steps.length > 0) {
 			this.emit('stateChange', { dirty: true })


### PR DESCRIPTION
### 📝 Summary

* Resolves: #4823
* Prevent sending requests with closed session - raise an exception instead.
* Send remaining steps before closing connection so last yjs awareness update gets through.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required