### PR TITLE
Adding explanatory comments to the Cypress configuration file

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,29 +1,55 @@
+// Importing the defineConfig function from the 'cypress' package.
 const { defineConfig } = require('cypress')
 
+// Exporting a configuration object for Cypress tests.
 module.exports = defineConfig({
-	projectId: 'hx9gqy',
-	viewportWidth: 1280,
-	viewportHeight: 900,
-	e2e: {
-		setupNodeEvents(on, config) {
-			const browserify = require('@cypress/browserify-preprocessor')
-			const webpack = require('@cypress/webpack-preprocessor')
-			const webpackOptions = require('@nextcloud/webpack-vue-config')
+  // Unique identifier for the project.
+  projectId: 'hx9gqy',
 
-			webpackOptions.module.rules.push({ test: /\.md/, type: 'asset/source' })
+  // Default viewport width for the tests.
+  viewportWidth: 1280,
 
-			on('file:preprocessor', browserify())
-			on('file:preprocessor', webpack({ webpackOptions }))
-		},
+  // Default viewport height for the tests.
+  viewportHeight: 900,
 
-		baseUrl: 'http://localhost:8081/index.php/',
-		experimentalSessionAndOrigin: true,
-		specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
-	},
-	retries: {
-		runMode: 2,
-		// do not retry in `cypress open`
-		openMode: 0,
-	},
-	"numTestsKeptInMemory": 5,
+  // Configuration specific to end-to-end (E2E) tests.
+  e2e: {
+
+    // Setting up custom Node events.
+    setupNodeEvents(on, config) {
+      const browserify = require('@cypress/browserify-preprocessor')
+      const webpack = require('@cypress/webpack-preprocessor')
+      const webpackOptions = require('@nextcloud/webpack-vue-config')
+
+      // Adding a rule to handle Markdown files.
+      webpackOptions.module.rules.push({ test: /\.md/, type: 'asset/source' })
+
+      // Applying Browserify preprocessor.
+      on('file:preprocessor', browserify())
+
+      // Applying Webpack preprocessor with specified options.
+      on('file:preprocessor', webpack({ webpackOptions }))
+    },
+
+    // Base URL for the application under test.
+    baseUrl: 'http://localhost:8081/index.php/',
+
+    // Enabling experimental session and origin features.
+    experimentalSessionAndOrigin: true,
+
+    // Pattern for locating test files (JavaScript and TypeScript).
+    specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
+  },
+
+  // Configuration for test retries.
+  retries: {
+    // Number of retries in run mode.
+    runMode: 2,
+
+    // Disabling retries in 'cypress open' mode.
+    openMode: 0,
+  },
+
+  // Number of tests to keep in memory.
+  "numTestsKeptInMemory": 5,
 })


### PR DESCRIPTION
In this commit, I added comments to explain the functionality of the Cypress configuration file. Each section of the code was properly documented to facilitate understanding and future maintenance of the code. Detailed explanations for each part of the file are available in the code comments.

Main Changes:

Added explanatory comments to the Cypress configuration file (cypress.json). Documented the purpose of each section in the file, including projectId, viewportWidth, viewportHeight, e2e, retries, and numTestsKeptInMemory. Justification:

This change is important to make the code more readable and understandable for other project collaborators. Proper documentation is essential for easy maintenance and future expansion of the system.

Related Tasks:

 Review other configuration files for adding explanatory comments if needed.
 Ensure that comments are clear and concise.
Additional Notes:

Make sure to keep the comments updated as the code changes in the future. Consider performing a code review for additional feedback on the quality of the documentation. This commit has been reviewed and is ready to be merged into the main branch.

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
