### PR TITLE
enh(SyncService): Throw error on save failure

### DIFF
--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -268,6 +268,7 @@ class SyncService {
 			this.autosave.clear()
 		} catch (e) {
 			logger.error('Failed to save document.', { error: e })
+			throw e
 		}
 	}
 


### PR DESCRIPTION
This allows to detect errors when saving via the editor API.

Outsourced from #4780:

> I had a look at all occasions of .save(), .autosave() and .forceSave(). Seems to be mostly places where throwing an error should be save. But maybe it's better to remove this potentially dangerous change from this PR that is supposed to be backported and move it to a seperate PR that doesn't get backported.