### PR TITLE
fix: CSP issue on loading RichWorkspace component

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -1,6 +1,10 @@
 import { registerFileListHeaders, registerDavProperty } from '@nextcloud/files'
 import { loadState } from '@nextcloud/initial-state'
 import { FilesWorkspaceHeader } from './helpers/files.js'
+import { linkTo } from '@nextcloud/router'
+
+__webpack_nonce__ = window.btoa(OC.requestToken) // eslint-disable-line
+__webpack_public_path__ = linkTo('text', 'js/') // eslint-disable-line
 
 const workspaceAvailable = loadState('text', 'workspace_available')
 


### PR DESCRIPTION
### 📝 Summary

* Resolves: Fix CSP issue on loading RichWorkspace component


#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/text/assets/89908051/f90fd4b1-9d76-4440-9209-53432ca65205)
 | A


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
