### PR TITLE
ci(cypress): Fix failing cypress spec by more specific selector

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -321,7 +321,7 @@ Cypress.Commands.add('getFile', fileName => {
 })
 
 Cypress.Commands.add('deleteFile', fileName => {
-	cy.get(`[data-cy-files-list] tr[data-cy-files-list-row-name="${fileName}"] .files-list__row-actions button`).click()
+	cy.get(`[data-cy-files-list] tr[data-cy-files-list-row-name="${fileName}"] .files-list__row-actions .action-item__menutoggle`).click()
 	cy.get('.files-list__row-action-delete:visible button').click()
 	cy.get(`[data-cy-files-list] tr[data-cy-files-list-row-name="${fileName}"]`).should('not.exist')
 })


### PR DESCRIPTION
Brings back green CI at least locally