### PR TITLE
fix(mermaid): Only switch back on failure if in preview mode

### DIFF
--- a/src/nodes/CodeBlockView.vue
+++ b/src/nodes/CodeBlockView.vue
@@ -150,7 +150,9 @@ export default {
 				this.$refs.preview.innerHTML = svg
 			} catch (e) {
 				console.debug('Invalid mermaid source', e)
-				this.viewMode = this.isEditable ? 'side-by-side' : 'code'
+				if (this.viewMode === 'preview') {
+					this.viewMode = this.isEditable ? 'side-by-side' : 'code'
+				}
 			}
 		}, 250)
 


### PR DESCRIPTION
### 📝 Summary

* Resolves: https://github.com/nextcloud/text/issues/4815


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
