### PR TITLE
fix: Rename rich workspace to folder description

### DIFF
--- a/src/views/FilesSettings.vue
+++ b/src/views/FilesSettings.vue
@@ -26,7 +26,7 @@
 			class="checkbox"
 			type="checkbox"
 			@change="toggle">
-		<label for="showRichWorkspacesToggle">{{ t('text', 'Show rich workspaces') }}</label>
+		<label for="showRichWorkspacesToggle">{{ t('text', 'Show folder description') }}</label>
 	</div>
 </template>
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/text/issues/2165

This is the only user facing occurence I could find. In the code we will still have it called rich workspace.
