### PR TITLE
fix(makefile): Disable parallel execution of targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # later. See the COPYING file.
 app_name=$(notdir $(CURDIR))
 
+.NOTPARALLEL:
+
 all: dev-setup lint build-js-production
 
 # Dev env management


### PR DESCRIPTION
### 📝 Summary

I have `export MAKEFLAGS="-j$(nproc)"` in my environment which allows make to spawn multiple jobs at the same time. This breaks running `make` because installing dependencies and compiling happens at the same time which ultimate fails.
Adding this line disables any parallel execution of any targets. See https://www.gnu.org/software/make/manual/html_node/Parallel-Disable.html

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
