### PR TITLE
fix(readme): Clarify the dependency on the viewer app

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ occ config:app:set text workspace_available --value=0
 
 ## 🏗 Development setup
 
-Currently, this app requires the main branch of the [Viewer app](https://github.com/nextcloud/viewer).
+This app requires the main branch of the [Viewer app](https://github.com/nextcloud/viewer) to be installed and enabled.
+Follow its development setup and then continue here.
 
 1. ☁ Clone this app into the `apps` folder of your Nextcloud: `git clone https://github.com/nextcloud/text.git`
 2. 👩‍💻 In the folder of the app, run the command `make` to install dependencies and build the Javascript.


### PR DESCRIPTION
### 📝 Summary

When I setup this app it wasn't immediately clear what I had to do regarding the viewer app. I clarified it a bit which should help other people with the setup.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
