### PR TITLE
fix(menubar): Add aria-selected and aria-activedescendant to menu bar items (fix #3911)

### DIFF
--- a/src/components/Menu/ActionList.vue
+++ b/src/components/Menu/ActionList.vue
@@ -27,6 +27,7 @@
 		v-bind="state"
 		:container="menuIDSelector"
 		:aria-label="actionEntry.label"
+		:aria-activedescendant="currentChild ? `${$menuID}-child-${currentChild.key}` : null"
 		:force-menu="true"
 		:name="actionEntry.label"
 		:data-text-action-entry="actionEntry.key"
@@ -37,6 +38,7 @@
 		</template>
 		<ActionSingle v-for="child in children"
 			:key="`child-${child.key}`"
+			:id="`${$menuID}-child-${child.key}`"
 			is-item
 			:action-entry="child"
 			v-on="$listeners"

--- a/src/components/Menu/utils.js
+++ b/src/components/Menu/utils.js
@@ -75,6 +75,7 @@ const getActionState = (actionEntry, $editor) => {
 		disabled: isDisabled(actionEntry, $editor),
 		class: getEntryClasses(actionEntry, active),
 		active,
+		'aria-selected': active,
 	}
 }
 


### PR DESCRIPTION
### 📝 Summary

Fixes https://github.com/nextcloud/text/issues/3911

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
