### PR TITLE
Feat/read only setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ The rich workspaces in the file list can be disabled either by the users in the 
 occ config:app:set text workspace_available --value=0
 ```
 
+The app can be configured to open files read-only by default. This setting is globally valid and can be set by the admin with the following command:
+
+```bash
+occ config:app:set text open_read_only_enabled --value=1
+```
 
 ## 🏗 Development setup
 

--- a/cypress/e2e/openreadonly.spec.js
+++ b/cypress/e2e/openreadonly.spec.js
@@ -1,0 +1,104 @@
+import { User } from '@nextcloud/cypress'
+import { randUser } from '../utils/index.js'
+
+const admin = new User('admin', 'admin')
+const user = randUser()
+
+describe('Open read-only mode', function () {
+
+	const setReadOnlyMode = function (mode) {
+		cy.login(admin)
+		cy.ocsRequest({
+			method: 'POST',
+			url: 'http://localhost/ocs/v2.php/apps/testing/api/v1/app/text/open_read_only_enabled',
+			body: { value: mode }
+		}).then(response => {
+			cy.log(response.status)
+		})
+		cy.logout()
+	}
+
+	describe('Disabled', function () {
+		const checkMenubar = function () {
+			cy.get('.text-editor--readonly-bar').should('not.exist')
+			cy.get('.text-menubar').getActionEntry('done').should('not.exist')
+		}
+
+		beforeEach(function () {
+			setReadOnlyMode(0)
+
+			cy.createUser(user)
+			cy.login(user)
+
+			cy.uploadFile('test.md', 'text/markdown')
+			cy.uploadFile('test.md', 'text/markdown', 'test.txt')
+
+			cy.visit('/apps/files')
+		})
+
+		it('Test writable markdown file', function () {
+			cy.openFile('test.md')
+			checkMenubar()
+		})
+
+		it('Test writable text file', function () {
+			cy.openFile('test.txt')
+			checkMenubar()
+		})
+	})
+
+	describe('Enabled', function () {
+		const requireReadOnlyBar = function () {
+			cy.get('.text-editor--readonly-bar').should('exist')
+			cy.get('.text-editor--readonly-bar').getActionEntry('edit').should('exist')
+		}
+
+		const requireMenubar = function () {
+			cy.get('.text-editor--readonly-bar').should('not.exist')
+			cy.get('.text-menubar').getActionEntry('done').should('exist')
+		}
+
+		beforeEach(function () {
+			setReadOnlyMode(1)
+
+			cy.createUser(user)
+			cy.login(user)
+
+			cy.removeFile('test.md')
+			cy.removeFile('test.txt')
+
+			cy.uploadFile('test.md', 'text/markdown')
+			cy.uploadFile('test.md', 'text/plain', 'test.txt')
+
+			cy.visit('/apps/files')
+		})
+
+		it('Test read-only markdown file', function () {
+			cy.openFile('test.md')
+
+			requireReadOnlyBar()
+
+			// Switch to edit-mode
+			cy.get('.text-editor--readonly-bar').getActionEntry('edit').click()
+
+			requireMenubar()
+
+			// Switch to read-only mode
+			cy.get('.text-menubar').getActionEntry('done').click()
+
+			requireReadOnlyBar()
+		})
+
+		it('Test read-only text file', function () {
+			cy.openFile('test.txt')
+
+			requireReadOnlyBar()
+
+			// Switch to edit-mode
+			cy.get('.text-editor--readonly-bar').getActionEntry('edit').click()
+
+			// Check that read-only bar does not exist
+			cy.get('.text-editor--readonly-bar').should('not.exist')
+		})
+	})
+})

--- a/cypress/e2e/openreadonly.spec.js
+++ b/cypress/e2e/openreadonly.spec.js
@@ -4,9 +4,9 @@ import { randUser } from '../utils/index.js'
 const admin = new User('admin', 'admin')
 const user = randUser()
 
-describe('Open read-only mode', function () {
+describe('Open read-only mode', function() {
 
-	const setReadOnlyMode = function (mode) {
+	const setReadOnlyMode = function(mode) {
 		cy.login(admin)
 		cy.ocsRequest({
 			method: 'POST',
@@ -18,13 +18,13 @@ describe('Open read-only mode', function () {
 		cy.logout()
 	}
 
-	describe('Disabled', function () {
-		const checkMenubar = function () {
+	describe('Disabled', function() {
+		const checkMenubar = function() {
 			cy.get('.text-editor--readonly-bar').should('not.exist')
 			cy.get('.text-menubar').getActionEntry('done').should('not.exist')
 		}
 
-		beforeEach(function () {
+		beforeEach(function() {
 			setReadOnlyMode(0)
 
 			cy.createUser(user)
@@ -36,29 +36,29 @@ describe('Open read-only mode', function () {
 			cy.visit('/apps/files')
 		})
 
-		it('Test writable markdown file', function () {
+		it('Test writable markdown file', function() {
 			cy.openFile('test.md')
 			checkMenubar()
 		})
 
-		it('Test writable text file', function () {
+		it('Test writable text file', function() {
 			cy.openFile('test.txt')
 			checkMenubar()
 		})
 	})
 
-	describe('Enabled', function () {
-		const requireReadOnlyBar = function () {
+	describe('Enabled', function() {
+		const requireReadOnlyBar = function() {
 			cy.get('.text-editor--readonly-bar').should('exist')
 			cy.get('.text-editor--readonly-bar').getActionEntry('edit').should('exist')
 		}
 
-		const requireMenubar = function () {
+		const requireMenubar = function() {
 			cy.get('.text-editor--readonly-bar').should('not.exist')
 			cy.get('.text-menubar').getActionEntry('done').should('exist')
 		}
 
-		beforeEach(function () {
+		beforeEach(function() {
 			setReadOnlyMode(1)
 
 			cy.createUser(user)
@@ -73,7 +73,7 @@ describe('Open read-only mode', function () {
 			cy.visit('/apps/files')
 		})
 
-		it('Test read-only markdown file', function () {
+		it('Test read-only markdown file', function() {
 			cy.openFile('test.md')
 
 			requireReadOnlyBar()
@@ -89,7 +89,7 @@ describe('Open read-only mode', function () {
 			requireReadOnlyBar()
 		})
 
-		it('Test read-only text file', function () {
+		it('Test read-only text file', function() {
 			cy.openFile('test.txt')
 
 			requireReadOnlyBar()

--- a/cypress/e2e/openreadonly.spec.js
+++ b/cypress/e2e/openreadonly.spec.js
@@ -10,8 +10,8 @@ describe('Open read-only mode', function () {
 		cy.login(admin)
 		cy.ocsRequest({
 			method: 'POST',
-			url: 'http://localhost/ocs/v2.php/apps/testing/api/v1/app/text/open_read_only_enabled',
-			body: { value: mode }
+			url: `${Cypress.env('baseUrl')}/ocs/v2.php/apps/testing/api/v1/app/text/open_read_only_enabled`,
+			body: { value: mode },
 		}).then(response => {
 			cy.log(response.status)
 		})

--- a/cypress/e2e/openreadonly.spec.js
+++ b/cypress/e2e/openreadonly.spec.js
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 import { User } from '@nextcloud/cypress'
 import { randUser } from '../utils/index.js'
 

--- a/cypress/e2e/openreadonly.spec.js
+++ b/cypress/e2e/openreadonly.spec.js
@@ -11,27 +11,31 @@ const user = randUser()
 
 describe('Open read-only mode', function() {
 
+	before(function() {
+		cy.createUser(user)
+		cy.login(user)
+		cy.uploadFile('test.md', 'text/markdown')
+		cy.uploadFile('test.md', 'text/plain', 'test.txt')
+	})
+
 	const setReadOnlyMode = function(mode) {
 		cy.login(admin)
 		cy.setAppConfig('open_read_only_enabled', mode)
-		cy.logout()
 	}
 
 	describe('Disabled', function() {
 		const checkMenubar = function() {
 			cy.get('.text-editor--readonly-bar').should('not.exist')
-			cy.get('.text-menubar').getActionEntry('done').should('not.exist')
+			cy.get('.text-menubar', { timeout: 10000 })
+				.getActionEntry('done').should('not.exist')
 		}
 
-		beforeEach(function() {
+		before(function() {
 			setReadOnlyMode(0)
+		})
 
-			cy.createUser(user)
+		beforeEach(function() {
 			cy.login(user)
-
-			cy.uploadFile('test.md', 'text/markdown')
-			cy.uploadFile('test.md', 'text/markdown', 'test.txt')
-
 			cy.visit('/apps/files')
 		})
 
@@ -57,18 +61,12 @@ describe('Open read-only mode', function() {
 			cy.get('.text-menubar').getActionEntry('done').should('exist')
 		}
 
-		beforeEach(function() {
+		before(function() {
 			setReadOnlyMode(1)
+		})
 
-			cy.createUser(user)
+		beforeEach(function() {
 			cy.login(user)
-
-			cy.removeFile('test.md')
-			cy.removeFile('test.txt')
-
-			cy.uploadFile('test.md', 'text/markdown')
-			cy.uploadFile('test.md', 'text/plain', 'test.txt')
-
 			cy.visit('/apps/files')
 		})
 

--- a/cypress/e2e/openreadonly.spec.js
+++ b/cypress/e2e/openreadonly.spec.js
@@ -13,13 +13,7 @@ describe('Open read-only mode', function() {
 
 	const setReadOnlyMode = function(mode) {
 		cy.login(admin)
-		cy.ocsRequest({
-			method: 'POST',
-			url: `${Cypress.env('baseUrl')}/ocs/v2.php/apps/testing/api/v1/app/text/open_read_only_enabled`,
-			body: { value: mode },
-		}).then(response => {
-			cy.log(response.status)
-		})
+		cy.setAppConfig('open_read_only_enabled', mode)
 		cy.logout()
 	}
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -401,6 +401,14 @@ Cypress.Commands.add('showHiddenFiles', (value = true) => {
 	)
 })
 
+Cypress.Commands.add('setAppConfig', (key, value) => {
+	Cypress.log()
+	return axios.post(
+		`${url}/ocs/v2.php/apps/testing/api/v1/app/text/${key}`,
+		{ value },
+	)
+})
+
 Cypress.Commands.add('createDescription', (buttonLabel = 'Add folder description') => {
 	const url = '**/remote.php/dav/files/**'
 	cy.intercept({ method: 'PUT', url })

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -22,6 +22,10 @@ class ConfigService {
 		return $this->appConfig->getValueString(Application::APP_NAME, 'default_file_extension', 'md');
 	}
 
+	public function isOpenReadOnlyEnabled(): bool {
+		return $this->appConfig->getValueString(Application::APP_NAME, 'open_read_only_enabled', '0') === '1';
+	}
+
 	public function isRichEditingEnabled(): bool {
 		return ($this->appConfig->getValueString(Application::APP_NAME, 'rich_editing_enabled', '1') === '1');
 	}

--- a/lib/Service/InitialStateProvider.php
+++ b/lib/Service/InitialStateProvider.php
@@ -43,6 +43,11 @@ class InitialStateProvider {
 		);
 
 		$this->initialState->provideInitialState(
+			'open_read_only_enabled',
+			$this->configService->isOpenReadOnlyEnabled()
+		);
+
+		$this->initialState->provideInitialState(
 			'default_file_extension',
 			$this->configService->getDefaultFileExtension()
 		);

--- a/src/components/Editor/Wrapper.provider.js
+++ b/src/components/Editor/Wrapper.provider.js
@@ -5,6 +5,7 @@
 
 export const OUTLINE_STATE = Symbol('wrapper:outline-state')
 export const OUTLINE_ACTIONS = Symbol('wrapper:outline-actions')
+export const READ_ONLY_ACTIONS = Symbol('wrapper:read-only-actions')
 
 export const useOutlineStateMixin = {
 	inject: {
@@ -22,6 +23,17 @@ export const useOutlineActions = {
 	inject: {
 		$outlineActions: {
 			from: OUTLINE_ACTIONS,
+			default: {
+				toggle: () => {},
+			},
+		},
+	},
+}
+
+export const useReadOnlyActions = {
+	inject: {
+		$readOnlyActions: {
+			from: READ_ONLY_ACTIONS,
 			default: {
 				toggle: () => {},
 			},

--- a/src/components/Editor/Wrapper.vue
+++ b/src/components/Editor/Wrapper.vue
@@ -16,7 +16,7 @@
 
 <script>
 import { useIsRichEditorMixin, useIsRichWorkspaceMixin } from './../Editor.provider.js'
-import { OUTLINE_STATE, OUTLINE_ACTIONS } from './Wrapper.provider.js'
+import { OUTLINE_STATE, OUTLINE_ACTIONS, READ_ONLY_ACTIONS } from './Wrapper.provider.js'
 import useStore from '../../mixins/store.js'
 import { mapState } from 'vuex'
 
@@ -33,6 +33,11 @@ export default {
 			[OUTLINE_ACTIONS]: {
 				get: () => ({
 					toggle: this.outlineToggle,
+				}),
+			},
+			[READ_ONLY_ACTIONS]: {
+				get: () => ({
+					toggle: this.readOnlyToggle,
 				}),
 			},
 		})
@@ -115,6 +120,9 @@ export default {
 			if (event.ctrlKey && event.altKey && event.key === 'h') {
 				this.outlineToggle()
 			}
+		},
+		readOnlyToggle() {
+			this.$emit('read-only-toggled')
 		},
 	},
 

--- a/src/components/Menu/BaseActionEntry.js
+++ b/src/components/Menu/BaseActionEntry.js
@@ -8,7 +8,7 @@
 import debounce from 'debounce'
 
 import { useEditorMixin, useIsMobileMixin } from '../Editor.provider.js'
-import { useOutlineActions, useOutlineStateMixin } from '../Editor/Wrapper.provider.js'
+import { useOutlineActions, useOutlineStateMixin, useReadOnlyActions } from '../Editor/Wrapper.provider.js'
 import { getActionState, getKeys, getKeyshortcuts } from './utils.js'
 import useStore from '../../mixins/store.js'
 
@@ -18,7 +18,14 @@ import './ActionEntry.scss'
  * @type {import("vue").ComponentOptions} BaseActionEntry
  */
 const BaseActionEntry = {
-	mixins: [useEditorMixin, useIsMobileMixin, useStore, useOutlineActions, useOutlineStateMixin],
+	mixins: [
+		useEditorMixin,
+		useIsMobileMixin,
+		useStore,
+		useOutlineActions,
+		useOutlineStateMixin,
+		useReadOnlyActions,
+	],
 	props: {
 		actionEntry: {
 			type: Object,

--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -71,7 +71,7 @@ import ActionSingle from './ActionSingle.vue'
 import CharacterCount from './CharacterCount.vue'
 import HelpModal from '../HelpModal.vue'
 import ToolBarLogic from './ToolBarLogic.js'
-import actionsFullEntries from './entries.js'
+import { ReadOnlyDoneEntries, MenuEntries } from './entries.js'
 import { MENU_ID } from './MenuBar.provider.js'
 import { DotsHorizontal, TranslateVariant } from '../icons.js'
 import {
@@ -116,6 +116,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		openReadOnly: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	setup() {
@@ -126,7 +130,7 @@ export default {
 
 	data() {
 		return {
-			entries: [...actionsFullEntries],
+			entries: this.openReadOnly ? [...ReadOnlyDoneEntries, ...MenuEntries] : [...MenuEntries],
 			randomID: `menu-bar-${(Math.ceil((Math.random() * 10000) + 500)).toString(16)}`,
 			displayHelp: false,
 			isReady: false,

--- a/src/components/Menu/ReadonlyBar.vue
+++ b/src/components/Menu/ReadonlyBar.vue
@@ -25,7 +25,7 @@
 
 <script>
 import { defineComponent } from 'vue'
-import { ReadonlyEntries as entries } from './entries.js'
+import { ReadOnlyEditEntries, OutlineEntries } from './entries.js'
 
 import ActionList from './ActionList.vue'
 import ActionSingle from './ActionSingle.vue'
@@ -38,9 +38,15 @@ export default defineComponent({
 		ActionSingle,
 	},
 	extends: ToolBarLogic,
+	props: {
+		openReadOnly: {
+			type: Boolean,
+			default: false,
+		},
+	},
 	data() {
 		return {
-			entries,
+			entries: this.openReadOnly ? [...ReadOnlyEditEntries, ...OutlineEntries] : [...OutlineEntries],
 		}
 	},
 })

--- a/src/components/Menu/entries.js
+++ b/src/components/Menu/entries.js
@@ -30,6 +30,8 @@ import {
 	Info,
 	LinkIcon,
 	Paperclip,
+	Pencil,
+	PencilOff,
 	Positive,
 	Table,
 	UnfoldMoreHorizontal,
@@ -41,7 +43,7 @@ import ActionInsertLink from './ActionInsertLink.vue'
 
 import { MODIFIERS } from './keys.js'
 
-export const ReadonlyEntries = [{
+export const OutlineEntries = [{
 	key: 'outline',
 	forceLabel: true,
 	icon: FormatListBulleted,
@@ -53,7 +55,23 @@ export const ReadonlyEntries = [{
 	},
 }]
 
-export default [
+export const ReadOnlyEditEntries = [{
+	key: 'edit',
+	label: t('text', 'Edit'),
+	forceLabel: true,
+	icon: Pencil,
+	click: ({ $readOnlyActions }) => $readOnlyActions.toggle(),
+}]
+
+export const ReadOnlyDoneEntries = [{
+	key: 'done',
+	label: t('text', 'Done'),
+	keyChar: 'esc',
+	icon: PencilOff,
+	click: ({ $readOnlyActions }) => $readOnlyActions.toggle(),
+}]
+
+export const MenuEntries = [
 	{
 		key: 'undo',
 		label: t('text', 'Undo'),

--- a/src/components/Menu/entries.js
+++ b/src/components/Menu/entries.js
@@ -66,7 +66,6 @@ export const ReadOnlyEditEntries = [{
 export const ReadOnlyDoneEntries = [{
 	key: 'done',
 	label: t('text', 'Done'),
-	keyChar: 'esc',
 	icon: PencilOff,
 	click: ({ $readOnlyActions }) => $readOnlyActions.toggle(),
 }]

--- a/src/components/Suggestion/LinkPicker/suggestions.js
+++ b/src/components/Suggestion/LinkPicker/suggestions.js
@@ -6,7 +6,7 @@
 import createSuggestions from '../suggestions.js'
 import LinkPickerList from './LinkPickerList.vue'
 import { searchProvider, getLinkWithPicker } from '@nextcloud/vue/dist/Components/NcRichText.js'
-import menuEntries from './../../Menu/entries.js'
+import { MenuEntries } from './../../Menu/entries.js'
 import { getIsActive } from '../../Menu/utils.js'
 import markdownit from '../../../markdownit/index.js'
 import shouldInterpretAsMarkdown from '../../../markdownit/shouldInterpretAsMarkdown.js'
@@ -38,12 +38,12 @@ const sortImportantFirst = (list) => {
 const formattingSuggestions = (query) => {
 	return sortImportantFirst(
 		[
-			...menuEntries.find(e => e.key === 'headings').children,
-			...menuEntries.find(e => e.key === 'lists').children,
-			...menuEntries.filter(e => e.action && !filterOut(e)),
-			...menuEntries.find(e => e.key === 'blocks').children,
+			...MenuEntries.find(e => e.key === 'headings').children,
+			...MenuEntries.find(e => e.key === 'lists').children,
+			...MenuEntries.filter(e => e.action && !filterOut(e)),
+			...MenuEntries.find(e => e.key === 'blocks').children,
 			{
-				...menuEntries.find(e => e.key === 'emoji-picker'),
+				...MenuEntries.find(e => e.key === 'emoji-picker'),
 				action: (command) => command.insertContent(':'),
 			},
 		].filter(e => e?.label?.toLowerCase?.()?.includes(query.toLowerCase()))

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -46,6 +46,8 @@ import MDI_LinkVariantPlus from 'vue-material-design-icons/LinkVariantPlus.vue'
 import MDI_Loading from 'vue-material-design-icons/Loading.vue'
 import MDI_Lock from 'vue-material-design-icons/Lock.vue'
 import MDI_Paperclip from 'vue-material-design-icons/Paperclip.vue'
+import MDI_Pencil from 'vue-material-design-icons/Pencil.vue'
+import MDI_PencilOff from 'vue-material-design-icons/PencilOff.vue'
 import MDI_Positive from 'vue-material-design-icons/CheckboxMarkedCircle.vue'
 import MDI_Redo from 'vue-material-design-icons/ArrowURightTop.vue'
 import MDI_Shape from 'vue-material-design-icons/Shape.vue'
@@ -128,6 +130,8 @@ export const LinkOff = makeIcon(MDI_LinkOff)
 export const LinkVariantPlus = makeIcon(MDI_LinkVariantPlus)
 export const Lock = makeIcon(MDI_Lock)
 export const Paperclip = makeIcon(MDI_Paperclip)
+export const Pencil = makeIcon(MDI_Pencil)
+export const PencilOff = makeIcon(MDI_PencilOff)
 export const Positive = makeIcon(MDI_Positive)
 export const Redo = makeIcon(MDI_Redo)
 export const Shape = makeIcon(MDI_Shape)

--- a/src/files.js
+++ b/src/files.js
@@ -10,6 +10,7 @@ import 'vite/modulepreload-polyfill'
 
 const workspaceAvailable = loadState('text', 'workspace_available')
 const workspaceEnabled = loadState('text', 'workspace_enabled')
+const openReadOnlyEnabled = loadState('text', 'open_read_only_enabled')
 
 document.addEventListener('DOMContentLoaded', async () => {
 	if (typeof OCA.Viewer === 'undefined') {
@@ -39,4 +40,5 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 OCA.Text = {
 	RichWorkspaceEnabled: workspaceEnabled,
+	OpenReadOnlyEnabled: openReadOnlyEnabled,
 }

--- a/src/public.js
+++ b/src/public.js
@@ -162,4 +162,5 @@ documentReady(() => {
 
 OCA.Text = {
 	RichWorkspaceEnabled: loadState('text', 'workspace_available'),
+	OpenReadOnlyEnabled: loadState('text', 'open_read_only_enabled'),
 }


### PR DESCRIPTION
### 📝 Summary

* Resolves: #3923

Hi everybody,

So far the following is implemented:
- A global setting `open_read_only_enabled` has been added, which can be toggled in the same way as `workspace_available` via command line. Thus, the original functionality remains untouched.
- With `open_read_only_enabled=true` text/markdown files are opened in read-only mode by default and an edit button is shown next to the "Show Outline" button. Clicking on the button makes the file editable, the edit button is replaced by a "Save document" button and the formatting menu bar is shown as in normal mode beneath the button.

While playing around with that new mode, we figured it would be useful to have a possibility to prevent the file from being auto-saved on exit if the user changed the file. Instead, we thought of showing a confirmation dialog in case of unsaved changes asking whether the user wants to save them. 
I tried to add such a dialog to the `Editor.vue` component, but as far as as I understand it, the editor is destroyed by the parent `Viewer` component and in the editor's `beforeDestroy` life hook, where the auto-save is performed, I am not able to launch a modal that waits for the user input, because the remaining life hooks are executed immediately after `beforeDestroy`. 
The `ImageEditor.vue` component of the `Viewer` app does exactly this, but it uses the `FilerobotImageEditor` which can be provided with an `onClose` callback.
Is there any other way we could achieve the same functionality?

I am new to web development and I know that many of the changes I propose here can be improved. I happy about your feedback.

#### 🖼️ Screenshots

##### Read-only
![read-only-mode-01](https://github.com/nextcloud/text/assets/22923069/baf58483-b14b-4c95-8593-4b87d6e65d54)

##### Editable
![read-only-mode-02](https://github.com/nextcloud/text/assets/22923069/b5ba9765-123f-4ca8-8baf-b1692828da31)




### 🚧 TODO

- [ ] Menu bar appearance in rich workspaces
- [ ] Menu bar appearance in text files
- [ ] SCSS / layout for mobile devices

### 🏁 Checklist

- [X] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [X] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [X] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
