### PR TITLE
Revert "ci: Skip some heading tests for now due to #4895"

### DIFF
--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -90,7 +90,7 @@ describe('Workspace', function() {
 		cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
 		cy.openWorkspace(currentFolder).type('Heading')
 		cy.getContent().type('{selectall}')
-		;['h1', 'h2', 'h3'].forEach((heading) => {
+		;['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].forEach((heading) => {
 			const actionName = `headings-${heading}`
 
 			cy.getSubmenuEntry('headings', actionName).click()


### PR DESCRIPTION
This reverts commit 2fd9f5d3318ba81d75c61bbcf537a378329a01cd.

Was fixed with https://github.com/nextcloud/server/pull/41093 already