### PR TITLE
Revert "tmp: skip known attachment failures"

### DIFF
--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -336,7 +336,7 @@ describe('Test all attachment insertion methods', () => {
 			})
 	})
 
-	it.skip('test if attachment folder is copied when copying a markdown file', () => {
+	it('test if attachment folder is copied when copying a markdown file', () => {
 		cy.copyFile('subFolder/test.md', 'testCopied.md')
 		cy.visit('/apps/files')
 
@@ -358,7 +358,7 @@ describe('Test all attachment insertion methods', () => {
 			})
 	})
 
-	it.skip('test if attachment folder is deleted after having deleted a markdown file', () => {
+	it('test if attachment folder is deleted after having deleted a markdown file', () => {
 		cy.copyFile('subFolder/test.md', 'testCopied.md')
 		cy.visit('/apps/files')
 		cy.getFile('testCopied.md')
@@ -374,7 +374,7 @@ describe('Test all attachment insertion methods', () => {
 		currentUser = recipient
 	})
 
-	it.skip('[share] check everything behaves correctly on the share target user side', () => {
+	it('[share] check everything behaves correctly on the share target user side', () => {
 		cy.visit('/apps/files')
 		// check the file list
 		cy.getFile('test.md')

--- a/cypress/e2e/nodes/ImageView.spec.js
+++ b/cypress/e2e/nodes/ImageView.spec.js
@@ -2,11 +2,6 @@ import { randUser } from '../../utils/index.js'
 
 const user = randUser()
 
-const createMarkdown = (fileName, content) => {
-	return cy.createFile(fileName, content, 'text/markdown')
-		.then(cy.reload)
-}
-
 describe('Image View', () => {
 	before(() => {
 		cy.createUser(user)
@@ -27,7 +22,7 @@ describe('Image View', () => {
 		it('from root', () => {
 			const fileName = `${Cypress.currentTest.title}.md`
 
-			createMarkdown(fileName, '# from root\n\n ![git](/github.png)')
+			cy.createMarkdown(fileName, '# from root\n\n ![git](/github.png)')
 
 			cy.openFile(fileName)
 
@@ -45,7 +40,7 @@ describe('Image View', () => {
 		it('from child folder', () => {
 			const fileName = `${Cypress.currentTest.title}.md`
 
-			createMarkdown(fileName, '# from child\n\n ![git](child-folder/github.png)')
+			cy.createMarkdown(fileName, '# from child\n\n ![git](child-folder/github.png)')
 
 			cy.openFile(fileName)
 
@@ -65,7 +60,7 @@ describe('Image View', () => {
 
 			const fileName = `${Cypress.currentTest.title}.md`
 
-			createMarkdown(`/child-folder/${fileName}`, '# from parent\n\n ![git](../github.png)')
+			cy.createMarkdown(`/child-folder/${fileName}`, '# from parent\n\n ![git](../github.png)')
 
 			cy.openFile(fileName, { force: true })
 
@@ -85,7 +80,7 @@ describe('Image View', () => {
 		it('direct access', () => {
 			const fileName = `${Cypress.currentTest.title}.md`
 
-			createMarkdown(fileName, '# from root\n\n ![yaha](/yaha.png)')
+			cy.createMarkdown(fileName, '# from root\n\n ![yaha](/yaha.png)')
 
 			cy.openFile(fileName)
 
@@ -112,7 +107,7 @@ describe('Image View', () => {
 			cy.login(user)
 			cy.visit('/apps/files')
 			const fileName = 'native attachments.md'
-			createMarkdown(fileName, '# open image in modal\n\n ![git](.attachments.123/github.png)\n\n ![file.txt.gz](.attachments.123/file.txt.gz)')
+			cy.createMarkdown(fileName, '# open image in modal\n\n ![git](.attachments.123/github.png)\n\n ![file.txt.gz](.attachments.123/file.txt.gz)')
 
 			cy.getFileId(fileName).then((fileId) => {
 				const attachmentsFolder = `.attachments.${fileId}`


### PR DESCRIPTION
This reverts commit 66d5c7dc07330669b0e7fd7a917648584a2d84d2

Further commit fixes the tests, isolates them a bit more and moves file operations from clicking through UI to actual API calls.
