### PR TITLE
feat: bring back cypress command createDescription through UI

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -451,8 +451,16 @@ Cypress.Commands.add('showHiddenFiles', (value = true) => {
 })
 
 Cypress.Commands.add('createDescription', (folder) => {
-	cy.uploadFile('empty.md', 'text/markdown', `${folder}/Readme.md`)
+	const url = '**/remote.php/dav/files/**'
+	cy.intercept({ method: 'PUT', url })
+		.as('addDescription')
+
 	cy.visit(`apps/files?dir=/${encodeURIComponent(folder)}`)
+	cy.get('[data-cy-files-list] tr[data-cy-files-list-row-name="Readme.md"]').should('not.exist')
+	cy.get('[data-cy-upload-picker] button.action-item__menutoggle').click()
+	cy.get('li.upload-picker__menu-entry button').contains('Add description').click()
+
+	cy.wait('@addDescription')
 })
 
 Cypress.on(

--- a/src/components/Menu/ActionList.vue
+++ b/src/components/Menu/ActionList.vue
@@ -37,8 +37,8 @@
 			<component :is="icon" :key="iconKey" />
 		</template>
 		<ActionSingle v-for="child in children"
-			:key="`child-${child.key}`"
 			:id="`${$menuID}-child-${child.key}`"
+			:key="`child-${child.key}`"
 			is-item
 			:action-entry="child"
 			v-on="$listeners"

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -147,7 +147,7 @@ const registerFileActionFallback = () => {
 
 }
 
-const addMenuRichWorkspace = () => {
+export const addMenuRichWorkspace = () => {
 	const descriptionFile = t('text', 'Readme') + '.' + loadState('text', 'default_file_extension')
 	addNewFileMenuEntry({
 		id: 'rich-workspace-init',
@@ -177,7 +177,7 @@ const addMenuRichWorkspace = () => {
 			})
 			const fileid = parseInt(response.headers['oc-fileid'])
 			const file = new File({
-				source,
+				source: context.source + '/' + encodeURIComponent(descriptionFile),
 				id: fileid,
 				mtime: new Date(),
 				mime: 'text/markdown',
@@ -185,11 +185,13 @@ const addMenuRichWorkspace = () => {
 				permissions: Permission.ALL,
 				root: context?.root || '/files/' + getCurrentUser()?.uid,
 			})
-			context._children.push(file.fileid)
 
 			showSuccess(t('text', 'Created "{name}"', { name: descriptionFile }))
+
 			emit('files:node:created', file)
-			emit('Text::showRichWorkspace', { autofocus: true })
+			setTimeout(() => {
+				emit('Text::showRichWorkspace', { autofocus: true })
+			}, 200)
 		},
 	})
 }
@@ -205,7 +207,6 @@ export const FilesWorkspaceHeader = new Header({
 	},
 
 	render(el, folder, view) {
-		addMenuRichWorkspace()
 		const hasRichWorkspace = !!folder.attributes['rich-workspace-file']
 
 		import('vue').then((module) => {

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -188,10 +188,9 @@ export const addMenuRichWorkspace = () => {
 
 			showSuccess(t('text', 'Created "{name}"', { name: descriptionFile }))
 
-			emit('files:node:created', file)
-			setTimeout(() => {
-				emit('Text::showRichWorkspace', { autofocus: true })
-			}, 200)
+			// We need a timeout as an empty file list does not render the header RichWorkspace component
+			// so it is not catching the event that early
+			setTimeout(() => emit('files:node:created', file), 200)
 		},
 	})
 }

--- a/src/init.js
+++ b/src/init.js
@@ -1,6 +1,6 @@
 import { registerFileListHeaders, registerDavProperty } from '@nextcloud/files'
 import { loadState } from '@nextcloud/initial-state'
-import { FilesWorkspaceHeader } from './helpers/files.js'
+import { addMenuRichWorkspace, FilesWorkspaceHeader } from './helpers/files.js'
 import { linkTo } from '@nextcloud/router'
 
 __webpack_nonce__ = window.btoa(OC.requestToken) // eslint-disable-line
@@ -12,5 +12,6 @@ registerDavProperty('nc:rich-workspace', { nc: 'http://nextcloud.org/ns' })
 registerDavProperty('nc:rich-workspace-file', { nc: 'http://nextcloud.org/ns' })
 
 if (workspaceAvailable) {
+	addMenuRichWorkspace()
 	registerFileListHeaders(FilesWorkspaceHeader)
 }

--- a/src/views/RichWorkspace.vue
+++ b/src/views/RichWorkspace.vue
@@ -112,6 +112,7 @@ export default {
 		}
 		subscribe('Text::showRichWorkspace', this.showRichWorkspace)
 		subscribe('Text::hideRichWorkspace', this.hideRichWorkspace)
+		subscribe('files:node:created', this.onFileCreated)
 		subscribe('files:node:deleted', this.onFileDeleted)
 		subscribe('files:node:renamed', this.onFileRenamed)
 
@@ -121,6 +122,7 @@ export default {
 	beforeDestroy() {
 		unsubscribe('Text::showRichWorkspace', this.showRichWorkspace)
 		unsubscribe('Text::hideRichWorkspace', this.hideRichWorkspace)
+		unsubscribe('files:node:created', this.onFileCreated)
 		unsubscribe('files:node:deleted', this.onFileDeleted)
 		unsubscribe('files:node:renamed', this.onFileRenamed)
 
@@ -207,6 +209,11 @@ export default {
 
 			// schedule to normal behaviour
 			this.$_timeoutAutohide = setTimeout(this.onTimeoutAutohide, 7000) // 7s
+		},
+		onFileCreated(node) {
+			if (SUPPORTED_STATIC_FILENAMES.includes(node.basename)) {
+				this.showRichWorkspace()
+			}
 		},
 		onFileDeleted(node) {
 			if (node.path === this.file.path) {

--- a/src/views/RichWorkspace.vue
+++ b/src/views/RichWorkspace.vue
@@ -22,7 +22,6 @@
 
 <template>
 	<div v-if="enabled"
-		v-show="hasRichWorkspace"
 		id="rich-workspace"
 		:class="{'focus': focus, 'dark': darkTheme }">
 		<RichTextReader v-if="!loaded || !ready" :content="content" class="rich-workspace--preview" />
@@ -89,7 +88,7 @@ export default {
 			autofocus: false,
 			autohide: true,
 			darkTheme: OCA.Accessibility && OCA.Accessibility.theme === 'dark',
-			enabled: OCA.Text.RichWorkspaceEnabled,
+			enabled: OCA.Text.RichWorkspaceEnabled && this.hasRichWorkspace,
 		}
 	},
 	computed: {
@@ -144,9 +143,10 @@ export default {
 			})
 		},
 		getFileInfo(autofocus) {
-			if (!this.hasRichWorkspace) {
+			if (!this.enabled) {
 				return
 			}
+			this.file = null
 			this.ready = false
 			this.loaded = true
 			this.autofocus = false

--- a/src/views/RichWorkspace.vue
+++ b/src/views/RichWorkspace.vue
@@ -21,7 +21,7 @@
   -->
 
 <template>
-	<div v-if="enabled"
+	<div v-if="enabled && file !== null"
 		id="rich-workspace"
 		:class="{'focus': focus, 'dark': darkTheme }">
 		<RichTextReader v-if="!loaded || !ready" :content="content" class="rich-workspace--preview" />
@@ -88,7 +88,7 @@ export default {
 			autofocus: false,
 			autohide: true,
 			darkTheme: OCA.Accessibility && OCA.Accessibility.theme === 'dark',
-			enabled: OCA.Text.RichWorkspaceEnabled && this.hasRichWorkspace,
+			enabled: OCA.Text.RichWorkspaceEnabled,
 		}
 	},
 	computed: {
@@ -107,7 +107,7 @@ export default {
 		},
 	},
 	mounted() {
-		if (this.enabled) {
+		if (this.enabled && this.hasRichWorkspace) {
 			this.getFileInfo()
 		}
 		subscribe('Text::showRichWorkspace', this.showRichWorkspace)


### PR DESCRIPTION
### 📝 Summary

* Resolves: #4937

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
