### PR TITLE
fix(outline): Make sure the outline is always in foreground

### DIFF
--- a/src/components/Editor/EditorOutline.vue
+++ b/src/components/Editor/EditorOutline.vue
@@ -61,10 +61,14 @@ export default {
 	// 204px = 50px nc header + 60px collectives titlebar + 44px menubar + 50px bottom margin
 	max-height: calc(100% - 204px);
 
+	border-radius: var(--border-radius-large);
+	box-shadow: 0 1px 10px var(--color-box-shadow);
+	background-color: var(--color-main-background);
+	z-index: 10021;
+
 	&-mobile {
 		box-shadow: 8px 0 17px -19px var(--color-box-shadow);
 		background-color: var(--color-main-background-translucent);
-		z-index: 1;
 	}
 
 	&__header {


### PR DESCRIPTION
### 📝 Summary

Add a border shadow around the outline. Also, make it overlay the editor content (e.g. on small screens). Required e.g. for Collectives.
    
Fixes: #4276

Copied from https://github.com/nextcloud/text/pull/4945#pullrequestreview-1711284684:

> Having the outline floating without borders was part of the design requirements or feedback when we introduced it, so I'd not change that as part of a bugfix at least.

@nextcloud/designers for feedback from the design team.

#### 🖼️ Screenshots

🏚️ Before Text standalone | 🏡 After Text standalone
---|---
![grafik](https://github.com/nextcloud/text/assets/3582805/0ca9cd11-b37f-4989-88fe-5752d7290e8b) | ![grafik](https://github.com/nextcloud/text/assets/3582805/e4df0986-0960-424c-b704-e8ce26720b1b)

🏚️ Before Collectives | 🏡 After Collectives
---|---
![grafik](https://github.com/nextcloud/text/assets/3582805/247c1971-bb9c-403d-a97b-a2b266947d7f) | ![grafik](https://github.com/nextcloud/text/assets/3582805/a89bacde-14d4-46a4-be7c-de931dbd6693)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
