### PR TITLE
fix(codeblock): Display mermaid graph per default in readonly mode

### DIFF
--- a/src/nodes/CodeBlockView.vue
+++ b/src/nodes/CodeBlockView.vue
@@ -116,6 +116,13 @@ export default {
 		showPreview() {
 			return this.supportPreview && (this.viewMode === 'preview' || this.viewMode === 'side-by-side')
 		},
+		defaultMode() {
+			if (this.isEditable) {
+				return 'side-by-side'
+			} else {
+				return this.supportPreview() ? 'code' : 'preview'
+			}
+		},
 	},
 	watch: {
 		'node.textContent'() {
@@ -135,7 +142,7 @@ export default {
 
 			const textContent = this.node?.textContent || ''
 			if (textContent.trim() === '') {
-				this.viewMode = this.isEditable ? 'side-by-side' : 'code'
+				this.viewMode = this.defaultMode
 				this.$refs.preview.innerHTML = ''
 			}
 


### PR DESCRIPTION
At the moment, we open all codeblocks in code view in readonly editors.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
