### PR TITLE
 fix: Limit asset/source loader rule to inline svg embeddings from @mdi/svg

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ webpackConfig.resolve.fallback = {
 // Load raw SVGs to be able to inject them via v-html
 webpackRules.RULE_ASSETS.test = /\.(png|jpe?g|gif|woff2?|eot|ttf)$/
 webpackRules.RULE_RAW_SVGS = {
-	test: /\.svg$/,
+	test: /@mdi\/svg/,
 	type: 'asset/source',
 }
 


### PR DESCRIPTION
Fix checkbox icons that were broken due to using the wrong rule:

<img width="847" alt="Screenshot 2023-11-13 at 09 35 58" src="https://github.com/nextcloud/text/assets/3404133/0a21f5c2-4834-45e3-9cef-f17f475b3ff4">
