### PR TITLE
chore: Bump @nextcloud/vue to v8.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nextcloud/logger": "^2.7.0",
         "@nextcloud/moment": "^1.2.2",
         "@nextcloud/router": "^2.2.0",
-        "@nextcloud/vue": "^8.0.1",
+        "@nextcloud/vue": "^8.2.0",
         "@quartzy/markdown-it-mentions": "^0.2.0",
         "@tiptap/core": "^2.1.12",
         "@tiptap/extension-blockquote": "^2.1.12",
@@ -4127,9 +4127,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.0.1.tgz",
-      "integrity": "sha512-x2RqRb+/hB94mkZ465zWct0a3A5m5KQniIO4RuwtBssMwlJdyv0MXZF3k7iE3omwChkbgNOkFDiZ/Ch+pfMm1g==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.2.0.tgz",
+      "integrity": "sha512-rfnB8yOhNce1RxBoHZWu9Kgf2IHwtdM7/dzoAyl/cseht4Mvk8+4aJAPuvKFHJaNjIbdNU4JfpK1GR653zOeQQ==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@nextcloud/auth": "^2.0.0",
@@ -4146,7 +4146,7 @@
         "@vueuse/components": "^10.0.2",
         "@vueuse/core": "^10.1.2",
         "clone": "^2.1.2",
-        "debounce": "1.2.1",
+        "debounce": "2.0.0",
         "dompurify": "^3.0.5",
         "emoji-mart-vue-fast": "^15.0.0",
         "escape-html": "^1.0.3",
@@ -4206,6 +4206,17 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
       "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/@nextcloud/vue/node_modules/debounce": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.0.0.tgz",
+      "integrity": "sha512-xRetU6gL1VJbs85Mc4FoEGSjQxzpdxRyFhe3lmWFyy2EzydIcD4xzUvRJMD+NPDfMwKNhxa3PvsIOU32luIWeA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@nextcloud/vue/node_modules/is-plain-obj": {
       "version": "4.1.0",
@@ -28236,9 +28247,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.0.1.tgz",
-      "integrity": "sha512-x2RqRb+/hB94mkZ465zWct0a3A5m5KQniIO4RuwtBssMwlJdyv0MXZF3k7iE3omwChkbgNOkFDiZ/Ch+pfMm1g==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.2.0.tgz",
+      "integrity": "sha512-rfnB8yOhNce1RxBoHZWu9Kgf2IHwtdM7/dzoAyl/cseht4Mvk8+4aJAPuvKFHJaNjIbdNU4JfpK1GR653zOeQQ==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@nextcloud/auth": "^2.0.0",
@@ -28255,7 +28266,7 @@
         "@vueuse/components": "^10.0.2",
         "@vueuse/core": "^10.1.2",
         "clone": "^2.1.2",
-        "debounce": "1.2.1",
+        "debounce": "2.0.0",
         "dompurify": "^3.0.5",
         "emoji-mart-vue-fast": "^15.0.0",
         "escape-html": "^1.0.3",
@@ -28303,6 +28314,11 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
           "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "debounce": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.0.0.tgz",
+          "integrity": "sha512-xRetU6gL1VJbs85Mc4FoEGSjQxzpdxRyFhe3lmWFyy2EzydIcD4xzUvRJMD+NPDfMwKNhxa3PvsIOU32luIWeA=="
         },
         "is-plain-obj": {
           "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@nextcloud/logger": "^2.7.0",
     "@nextcloud/moment": "^1.2.2",
     "@nextcloud/router": "^2.2.0",
-    "@nextcloud/vue": "^8.0.1",
+    "@nextcloud/vue": "^8.2.0",
     "@quartzy/markdown-it-mentions": "^0.2.0",
     "@tiptap/core": "^2.1.12",
     "@tiptap/extension-blockquote": "^2.1.12",


### PR DESCRIPTION
### 📝 Summary

Bump to https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v8.2.0

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required