### PR TITLE
fix: Get file from share link instead of user directory in case of no access

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -436,7 +436,11 @@ class DocumentService {
 	 */
 	public function getFileForSession(Session $session, ?string $shareToken = null): File {
 		if (!$session->isGuest()) {
-			return $this->getFileById($session->getDocumentId(), $session->getUserId());
+			try {
+				return $this->getFileById($session->getDocumentId(), $session->getUserId());
+			} catch (NotFoundException) {
+				// We may still have a user session but on a public share link so move on
+			}
 		}
 
 		if ($shareToken === null) {


### PR DESCRIPTION
If a user opens a public share link but does not have access to the file
in question on their filesystem, text failed to render the public share
link as we always tried to get the file directly.

Steps to reproduce:
- Create a file as userA
- Share the file as share link
- Login as userB
- open the share link as userB

Fixes #5001 

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
