### PR TITLE
fix(ImageView): Fix detection of editable editor

### DIFF
--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -21,7 +21,7 @@
   -->
 
 <template>
-	<NodeViewWrapper contenteditable="true">
+	<NodeViewWrapper :contenteditable="isEditable">
 		<figure class="image image-view"
 			data-component="image-view"
 			:class="{'icon-loading': !loaded, 'image-view--failed': failed}"
@@ -75,7 +75,7 @@
 						v-show="loaded"
 						class="image__caption"
 						:title="alt">
-						<figcaption v-if="!editable">
+						<figcaption v-if="!isEditable">
 							{{ alt }}
 						</figcaption>
 						<div v-else class="image__caption__wrapper">
@@ -120,7 +120,7 @@
 						<input ref="altInput"
 							type="text"
 							:value="alt"
-							:disabled="!editable"
+							:disabled="!isEditable"
 							@blur="updateAlt"
 							@keyup.enter="updateAlt">
 					</div>
@@ -204,17 +204,15 @@ export default {
 			showImageModal: false,
 			embeddedImagesList: [],
 			imageIndex: null,
+			isEditable: false,
 		}
 	},
 	computed: {
 		isMediaAttachment() {
 			return this.attachmentType === this.$attachmentResolver.ATTACHMENT_TYPE_MEDIA
 		},
-		editable() {
-			return this.editor.isEditable
-		},
 		showDeleteIcon() {
-			return this.editable && this.showIcons
+			return this.isEditable && this.showIcons
 		},
 		showImageDeleteIcon() {
 			return this.showDeleteIcon && !this.isMediaAttachment
@@ -272,6 +270,10 @@ export default {
 		},
 	},
 	beforeMount() {
+		this.isEditable = this.editor.isEditable
+		this.editor.on('update', ({ editor }) => {
+			this.isEditable = editor.isEditable
+		})
 		if (!this.isSupportedImage) {
 			// TODO check if hasPreview and render a file preview if available
 			this.failed = true


### PR DESCRIPTION
Fixes images always being displayed as editable, even in readonly editor.

Also set `contenteditable` to false in readonly mode. This fixes image captions being editable in readonly editor without session.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
