### PR TITLE
fix: bring back rich workspace on public share links of folders

### DIFF
--- a/src/public.js
+++ b/src/public.js
@@ -8,9 +8,91 @@ import { logger } from './helpers/logger.js'
 import { openMimetypes } from './helpers/mime.js'
 import { documentReady } from './helpers/index.js'
 import store from './store/index.js'
+import { emit, subscribe } from '@nextcloud/event-bus'
+import RichWorkspace from './views/RichWorkspace.vue'
 
 __webpack_nonce__ = btoa(OC.requestToken) // eslint-disable-line
 __webpack_public_path__ = OC.linkTo('text', 'js/') // eslint-disable-line
+
+const newRichWorkspaceFileMenuPlugin = {
+	attach(menu) {
+		const fileList = menu.fileList
+		const descriptionFile = t('text', 'Readme') + '.' + loadState('text', 'default_file_extension')
+		// only attach to main file list, public view is not supported yet
+		if (fileList.id !== 'files' && fileList.id !== 'files.public') {
+			return
+		}
+
+		// register the new menu entry
+		menu.addMenuEntry({
+			id: 'rich-workspace-init',
+			displayName: t('text', 'Add description'),
+			templateName: descriptionFile,
+			iconClass: 'icon-rename',
+			fileType: 'file',
+			useInput: false,
+			actionHandler() {
+				return window.FileList
+					.createFile(descriptionFile, { scrollTo: false, animate: false })
+					.then(() => emit('Text::showRichWorkspace', { autofocus: true }))
+			},
+			shouldShow() {
+				return !fileList.findFile(descriptionFile)
+			},
+		})
+	},
+}
+
+const filesWorkspacePlugin = {
+	el: null,
+
+	attach(fileList) {
+		if (fileList.id !== 'files' && fileList.id !== 'files.public') {
+			return
+		}
+		this.el = document.createElement('div')
+		fileList.registerHeader({
+			id: 'workspace',
+			el: this.el,
+			render: this.render.bind(this),
+			priority: 10,
+		})
+	},
+
+	render(fileList) {
+		if (fileList.id !== 'files' && fileList.id !== 'files.public') {
+			return
+		}
+
+		OC.Plugins.register('OCA.Files.NewFileMenu', newRichWorkspaceFileMenuPlugin)
+		import('vue').then((module) => {
+			const Vue = module.default
+			this.el.id = 'files-workspace-wrapper'
+			Vue.prototype.t = window.t
+			Vue.prototype.n = window.n
+			Vue.prototype.OCA = window.OCA
+			const View = Vue.extend(RichWorkspace)
+			const vm = new View({
+				propsData: {
+					path: fileList.getCurrentDirectory(),
+					hasRichWorkspace: true,
+				},
+				store,
+			}).$mount(this.el)
+			subscribe('files:navigation:changed', () => {
+				// Expose if the default file list is active to the component
+				// to only render the workspace if the file list is actually visible
+				vm.active = OCA.Files.App.getCurrentFileList() === fileList
+			})
+			fileList.$el.on('urlChanged', data => {
+				vm.path = data.dir.toString()
+			})
+			fileList.$el.on('changeDirectory', data => {
+				vm.path = data.dir.toString()
+			})
+		})
+	},
+}
 
 const loadEditor = ({ sharingToken, mimetype, fileId, $el }) => {
 	const container = document.createElement('div')
@@ -58,7 +140,7 @@ documentReady(() => {
 
 	// list of files - dir sharing
 	if (filesTable) {
-		// OC.Plugins.register('OCA.Files.FileList', FilesWorkspacePlugin)
+		OC.Plugins.register('OCA.Files.FileList', filesWorkspacePlugin)
 		registerFileActionFallback()
 		registerFileCreate()
 		return


### PR DESCRIPTION
### 📝 Summary

* Resolves: #5000

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
