### PR TITLE
fix: Do not overwrite current local version on reconnect

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -377,6 +377,7 @@ export default {
 
 			this.listenSyncServiceEvents()
 
+			this.$providers.forEach(p => p?.destroy())
 			const syncServiceProvider = createSyncServiceProvider({
 				ydoc: this.$ydoc,
 				syncService: this.$syncService,

--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -111,7 +111,12 @@ class SyncService {
 			return
 		}
 		this.backend = new PollingBackend(this, this.connection)
-		this.version = this.connection.docStateVersion
+
+		// If we reconnect we may already have a version set so we should keep that
+		if (this.version === null) {
+			this.version = this.connection.docStateVersion
+		}
+
 		this.emit('opened', {
 			...this.connection.state,
 			version: this.version,


### PR DESCRIPTION
Experimenting a bit with reconnect behaviour i noticed an issue that might cause disconnected session states.

Two separate sessions A and B
- A and B are editing
- A network goes offline (sometimes i needed to also quickly type something as A after setting the network offline)
- B continues typing
- A waits until the first auto close request gets blocked in the network console
- A network goes online again
- Reconnect happens

Now I observed that the last sync message had a different version to request steps compared to the first of the new session which turned out to be the case because we always overwrite the version with the docStateVersion on opening a session in the frontend, however in the reconnect case we already have a different state as we do not start from scratch.


Contributes to #4943 

- [ ] Check if there is a full recreate approach possible as a quick solution
- [ ] Just refetching the steps should not have any effect here as the new document state should already contain those
  - Maybe it is more about the local steps that then conflict with the new document state?
- [ ] check how applying the document state influences the existing y.js doc
- [ ] Figure out some visual indicator for beta versions if something goes wrong and one should report the browser console logs

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
