### PR TITLE
[Backport to 27] Hide share and close buttons on direct editing for desktop

### DIFF
--- a/cypress/e2e/directediting.spec.js
+++ b/cypress/e2e/directediting.spec.js
@@ -53,83 +53,41 @@ describe('direct editing', function() {
 		initUserAndFiles(user, 'test.md', 'empty.md', 'empty.txt')
 	})
 
-	it('Open an existing file, edit and close it', () => {
+	it('Open an existing file, edit it', () => {
 		createDirectEditingLink(user, 'empty.md')
 			.then((token) => {
 				cy.logout()
 				cy.visit(token)
 			})
-		const closeRequestAlias = 'closeRequest'
-		cy.intercept({ method: 'POST', url: '**/session/close' }).as(closeRequestAlias)
-		cy.intercept({ method: 'POST', url: '**/apps/text/session/sync' }).as('sync')
 		cy.getContent().type('# This is a headline')
 		cy.getContent().type('{enter}')
 		cy.getContent().type('Some text')
 		cy.getContent().type('{enter}')
-
-		// ensure we have received our own steps
-		cy.wait('@sync', { timeout: 7000 })
-		cy.wait('@sync', { timeout: 7000 })
-
-		cy.get('button.icon-close').click()
-		cy.wait(`@${closeRequestAlias}`).then(() => {
-			cy.getFileContent('empty.md').then((content) => {
-				expect(content).to.equal('# This is a headline\n\nSome text')
-			})
-		})
 	})
 
-	it('Create a file, edit and close it', () => {
+	it('Create a file, edit it', () => {
 		createDirectEditingLinkForNewFile(user, 'newfile.md')
 			.then((token) => {
 				cy.logout()
 				cy.visit(token)
 			})
-		const closeRequestAlias = 'closeRequest'
-		cy.intercept({ method: 'POST', url: '**/session/close' }).as(closeRequestAlias)
-		cy.intercept({ method: 'POST', url: '**/apps/text/session/sync' }).as('sync')
 
 		cy.getContent().type('# This is a headline')
 		cy.getContent().type('{enter}')
 		cy.getContent().type('Some text')
 		cy.getContent().type('{enter}')
-
-		// ensure we have received our own steps
-		cy.wait('@sync', { timeout: 7000 })
-		cy.wait('@sync', { timeout: 7000 })
-
-		cy.get('button.icon-close').click()
-		cy.wait(`@${closeRequestAlias}`).then(() => {
-			cy.getFileContent('newfile.md').then((content) => {
-				expect(content).to.equal('# This is a headline\n\nSome text')
-			})
-		})
 	})
 
-	it('Open an existing plain text file, edit and close it', () => {
+	it('Open an existing plain text file, edit it', () => {
 		createDirectEditingLink(user, 'empty.txt')
 			.then((token) => {
 				cy.logout()
 				cy.visit(token)
 			})
-		const closeRequestAlias = 'closeRequest'
-		cy.intercept({ method: 'POST', url: '**/session/close' }).as(closeRequestAlias)
-		cy.intercept({ method: 'POST', url: '**/apps/text/session/sync' }).as('sync')
 
 		cy.getContent().type('# This is a headline')
 		cy.getContent().type('{enter}')
 		cy.getContent().type('Some text')
 		cy.getContent().type('{enter}')
-
-		// ensure we have received our own steps
-		cy.wait('@sync', { timeout: 7000 })
-		cy.wait('@sync', { timeout: 7000 })
-
-		cy.get('button.icon-close').click()
-		cy.wait(`@${closeRequestAlias}`).then(() => {
-			cy.getFileContent('empty.txt').then((content) => {
-				expect(content).to.equal('# This is a headline\nSome text\n')
-			})
-		})
 	})
 })

--- a/src/views/DirectEditing.vue
+++ b/src/views/DirectEditing.vue
@@ -29,7 +29,7 @@
 			:mime="initial.mimetype"
 			:is-direct-editing="true"
 			@ready="loaded">
-			<template #header>
+			<template v-if="isMobile" #header>
 				<button class="icon-share" @click="share" />
 				<button class="icon-close" @click="close" />
 			</template>
@@ -102,6 +102,11 @@ export default {
 	computed: {
 		initialSession() {
 			return JSON.parse(this.initial.session) || null
+		},
+		isMobile() {
+			return (window.DirectEditingMobileInterface || (window.webkit
+				&& window.webkit.messageHandlers
+				&& window.webkit.messageHandlers.DirectEditingMobileInterface))
 		},
 	},
 	beforeMount() {


### PR DESCRIPTION
### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
