### PR TITLE
test(cy): skip test failing due to server issue

### DIFF
--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -371,7 +371,8 @@ describe('Test all attachment insertion methods', () => {
 			})
 	})
 
-	it('test if attachment folder is deleted after having deleted a markdown file', () => {
+	// Skip as https://github.com/nextcloud/server/issues/42306 causes this to fail.
+	it.skip('test if attachment folder is deleted after having deleted a markdown file', () => {
 		const fileName = 'deleteSource.md'
 		cy.createMarkdown(fileName, '![git](.attachments.123/github.png)', false).then((fileId) => {
 			const attachmentsFolder = `.attachments.${fileId}`


### PR DESCRIPTION
https://github.com/nextcloud/server/issues/42306
causes the DELETE request to fail with 423 Locked.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- fixes tests and does not need docs.