### PR TITLE
Fix cypress workspace test by setting default language

### DIFF
--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -32,6 +32,9 @@ describe('Workspace', function() {
 
 	beforeEach(function() {
 		cy.login(user)
+		// Some tests modify the language.
+		// Make sure it's the default otherwise.
+		cy.modifyUser(user, 'language', 'en')
 		// isolate tests - each happens in its own folder
 		const retry = cy.state('test').currentRetry()
 		currentFolder = retry

--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -26,7 +26,7 @@ const user = randUser()
 describe('Workspace', function() {
 
 	before(function() {
-		cy.createUser(user, 'password')
+		cy.createUser(user)
 	})
 
 	beforeEach(function() {
@@ -125,7 +125,7 @@ describe('Workspace', function() {
 			.should('contain', 'Hello world')
 	})
 
-	it('emoji picker', () => {
+	it('emoji picker', function() {
 		cy.visitTestFolder()
 		cy.openWorkspace()
 			.type('# Let\'s smile together{enter}## ')
@@ -142,7 +142,7 @@ describe('Workspace', function() {
 			.contains('😀')
 	})
 
-	it('relative folder links', () => {
+	it('relative folder links', function() {
 		cy.createFolder(`${this.testFolder}/sub-folder`)
 		cy.createFolder(`${this.testFolder}/sub-folder/alpha`)
 
@@ -182,7 +182,7 @@ describe('Workspace', function() {
 		cy.getModal().find('button.header-close').click()
 	})
 
-	describe('callouts', () => {
+	describe('callouts', function() {
 		const types = ['info', 'warn', 'error', 'success']
 
 		beforeEach(function() {
@@ -190,7 +190,7 @@ describe('Workspace', function() {
 			cy.openWorkspace().type('Callout')
 		})
 		// eslint-disable-next-line cypress/no-async-tests
-		it('create callout', () => {
+		it('create callout', function() {
 			cy.wrap(types).each((type) => {
 				cy.log(`creating ${type} callout`)
 
@@ -211,7 +211,7 @@ describe('Workspace', function() {
 			})
 		})
 
-		it('toggle callouts', () => {
+		it('toggle callouts', function() {
 			const [first, ...rest] = types
 
 			// enable callout
@@ -232,7 +232,7 @@ describe('Workspace', function() {
 		})
 	})
 
-	describe('localize', () => {
+	describe('localize', function() {
 		it('takes localized file name into account', function() {
 			cy.modifyUser(user, 'language', 'de_DE')
 			cy.uploadFile('test.md', 'text/markdown', `${this.testFolder}/Anleitung.md`)
@@ -247,11 +247,13 @@ describe('Workspace', function() {
 			cy.uploadFile('test.md', 'text/markdown', `${this.testFolder}/Anleitung.md`)
 			cy.visitTestFolder()
 			cy.getFile('Anleitung.md')
+			cy.get('#rich-workspace .ProseMirror')
+				.should('not.exist')
 		})
 	})
 
-	describe('create Readme.md', () => {
-		const checkContent = () => {
+	describe('create Readme.md', function() {
+		const checkContent = function() {
 			const txt = Cypress.currentTest.title
 
 			cy.getEditor().find('[data-text-el="editor-content-wrapper"]').click()
@@ -260,21 +262,21 @@ describe('Workspace', function() {
 			cy.getContent().should('contain', txt)
 		}
 
-		beforeEach(() => {
+		beforeEach(function() {
 			cy.visitTestFolder()
 		})
 
-		it('click', () => {
+		it('click', function() {
 			cy.openWorkspace().click()
 			checkContent()
 		})
 
-		it('enter', () => {
+		it('enter', function() {
 			cy.openWorkspace().type('{enter}')
 			checkContent()
 		})
 
-		it('spacebar', () => {
+		it('spacebar', function() {
 			cy.openWorkspace()
 				.trigger('keyup', {
 					keyCode: 32,

--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -24,7 +24,6 @@ import { randUser } from '../utils/index.js'
 const user = randUser()
 
 describe('Workspace', function() {
-	let currentFolder
 
 	before(function() {
 		cy.createUser(user, 'password')
@@ -36,17 +35,13 @@ describe('Workspace', function() {
 		// Make sure it's the default otherwise.
 		cy.modifyUser(user, 'language', 'en')
 		// isolate tests - each happens in its own folder
-		const retry = cy.state('test').currentRetry()
-		currentFolder = retry
-			? `${Cypress.currentTest.title} (${retry})`
-			: Cypress.currentTest.title
-		cy.createFolder(currentFolder)
+		cy.createTestFolder().as('testFolder')
 	})
 
 	it('Hides the workspace when switching to another folder', function() {
-		cy.uploadFile('test.md', 'text/markdown', `${currentFolder}/README.md`)
-		cy.createFolder(`${currentFolder}/subdirectory`)
-		cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
+		cy.uploadFile('test.md', 'text/markdown', `${this.testFolder}/README.md`)
+		cy.createFolder(`${this.testFolder}/subdirectory`)
+		cy.visitTestFolder()
 		cy.getFile('README.md')
 		cy.get('#rich-workspace .ProseMirror')
 			.should('contain', 'Hello world')
@@ -56,8 +51,8 @@ describe('Workspace', function() {
 	})
 
 	it('Hides the workspace when switching to another view', function() {
-		cy.uploadFile('test.md', 'text/markdown', `${currentFolder}/README.md`)
-		cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
+		cy.uploadFile('test.md', 'text/markdown', `${this.testFolder}/README.md`)
+		cy.visitTestFolder()
 		cy.getFile('README.md')
 		cy.get('#rich-workspace .ProseMirror')
 			.should('contain', 'Hello world')
@@ -68,15 +63,16 @@ describe('Workspace', function() {
 	})
 
 	it('adds a Readme.md', function() {
-		cy.createDescription(currentFolder)
+		cy.visitTestFolder()
+		cy.createDescription()
 		openSidebar('Readme.md')
 		cy.get('#rich-workspace .text-editor .text-editor__wrapper')
 			.should('be.visible')
 	})
 
 	it('formats text', function() {
-		cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
-		cy.openWorkspace(currentFolder)
+		cy.visitTestFolder()
+		cy.openWorkspace()
 		const buttons = [
 			['bold', 'strong'],
 			['italic', 'em'],
@@ -90,8 +86,8 @@ describe('Workspace', function() {
 	})
 
 	it('creates headings via submenu', function() {
-		cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
-		cy.openWorkspace(currentFolder).type('Heading')
+		cy.visitTestFolder()
+		cy.openWorkspace().type('Heading')
 		cy.getContent().type('{selectall}')
 		;['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].forEach((heading) => {
 			const actionName = `headings-${heading}`
@@ -111,8 +107,8 @@ describe('Workspace', function() {
 	})
 
 	it('creates lists', function() {
-		cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
-		cy.openWorkspace(currentFolder).type('List me')
+		cy.visitTestFolder()
+		cy.openWorkspace().type('List me')
 		cy.getContent().type('{selectall}')
 		;[
 			['unordered-list', 'ul'],
@@ -122,16 +118,16 @@ describe('Workspace', function() {
 	})
 
 	it('takes README.md into account', function() {
-		cy.uploadFile('test.md', 'text/markdown', `${Cypress.currentTest.title}/README.md`)
-		cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
+		cy.uploadFile('test.md', 'text/markdown', `${this.testFolder}/README.md`)
+		cy.visitTestFolder()
 		cy.getFile('README.md')
 		cy.get('#rich-workspace .ProseMirror')
 			.should('contain', 'Hello world')
 	})
 
 	it('emoji picker', () => {
-		cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
-		cy.openWorkspace(currentFolder)
+		cy.visitTestFolder()
+		cy.openWorkspace()
 			.type('# Let\'s smile together{enter}## ')
 
 		cy.getMenuEntry('emoji-picker')
@@ -147,13 +143,13 @@ describe('Workspace', function() {
 	})
 
 	it('relative folder links', () => {
-		cy.createFolder(`${currentFolder}/sub-folder`)
-		cy.createFolder(`${currentFolder}/sub-folder/alpha`)
+		cy.createFolder(`${this.testFolder}/sub-folder`)
+		cy.createFolder(`${this.testFolder}/sub-folder/alpha`)
 
-		cy.uploadFile('test.md', 'text/markdown', `${currentFolder}/sub-folder/alpha/test.md`)
-		cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
+		cy.uploadFile('test.md', 'text/markdown', `${this.testFolder}/sub-folder/alpha/test.md`)
+		cy.visitTestFolder()
 
-		cy.openWorkspace(currentFolder)
+		cy.openWorkspace()
 			.type('link me')
 		cy.getContent()
 			.type('{selectall}')
@@ -169,7 +165,7 @@ describe('Workspace', function() {
 		cy.getEditor()
 			.find('a')
 			.should('have.attr', 'href')
-			.and('contains', `dir=/${currentFolder}/sub-folder/alpha`)
+			.and('contains', `dir=/${this.testFolder}/sub-folder/alpha`)
 			.and('contains', '#relPath=sub-folder/alpha/test.md')
 
 		cy.getEditor()
@@ -190,8 +186,8 @@ describe('Workspace', function() {
 		const types = ['info', 'warn', 'error', 'success']
 
 		beforeEach(function() {
-			cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
-			cy.openWorkspace(currentFolder).type('Callout')
+			cy.visitTestFolder()
+			cy.openWorkspace().type('Callout')
 		})
 		// eslint-disable-next-line cypress/no-async-tests
 		it('create callout', () => {
@@ -239,8 +235,8 @@ describe('Workspace', function() {
 	describe('localize', () => {
 		it('takes localized file name into account', function() {
 			cy.modifyUser(user, 'language', 'de_DE')
-			cy.uploadFile('test.md', 'text/markdown', `${Cypress.currentTest.title}/Anleitung.md`)
-			cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
+			cy.uploadFile('test.md', 'text/markdown', `${this.testFolder}/Anleitung.md`)
+			cy.visitTestFolder()
 			cy.getFile('Anleitung.md')
 			cy.get('#rich-workspace .ProseMirror')
 				.should('contain', 'Hello world')
@@ -248,8 +244,8 @@ describe('Workspace', function() {
 
 		it('ignores localized file name in other language', function() {
 			cy.modifyUser(user, 'language', 'fr')
-			cy.uploadFile('test.md', 'text/markdown', `${Cypress.currentTest.title}/Anleitung.md`)
-			cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
+			cy.uploadFile('test.md', 'text/markdown', `${this.testFolder}/Anleitung.md`)
+			cy.visitTestFolder()
 			cy.getFile('Anleitung.md')
 		})
 	})
@@ -265,21 +261,21 @@ describe('Workspace', function() {
 		}
 
 		beforeEach(() => {
-			cy.visit(`apps/files?dir=/${encodeURIComponent(currentFolder)}`)
+			cy.visitTestFolder()
 		})
 
 		it('click', () => {
-			cy.openWorkspace(currentFolder).click()
+			cy.openWorkspace().click()
 			checkContent()
 		})
 
 		it('enter', () => {
-			cy.openWorkspace(currentFolder).type('{enter}')
+			cy.openWorkspace().type('{enter}')
 			checkContent()
 		})
 
 		it('spacebar', () => {
-			cy.openWorkspace(currentFolder)
+			cy.openWorkspace()
 				.trigger('keyup', {
 					keyCode: 32,
 					which: 32,

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -473,8 +473,8 @@ Cypress.Commands.add('clearContent', () => {
 	cy.getContent()
 })
 
-Cypress.Commands.add('openWorkspace', (folder) => {
-	cy.createDescription(folder)
+Cypress.Commands.add('openWorkspace', () => {
+	cy.createDescription()
 	cy.get('#rich-workspace .editor__content').click({ force: true })
 	cy.getEditor().find('[data-text-el="editor-content-wrapper"]').click({ force: true })
 
@@ -510,12 +510,11 @@ Cypress.Commands.add('showHiddenFiles', (value = true) => {
 		})
 })
 
-Cypress.Commands.add('createDescription', (folder) => {
+Cypress.Commands.add('createDescription', () => {
 	const url = '**/remote.php/dav/files/**'
 	cy.intercept({ method: 'PUT', url })
 		.as('addDescription')
 
-	cy.visit(`apps/files?dir=/${encodeURIComponent(folder)}`)
 	cy.get('[data-cy-files-list] tr[data-cy-files-list-row-name="Readme.md"]').should('not.exist')
 	cy.get('[data-cy-upload-picker] button.action-item__menutoggle').click()
 	cy.get('li.upload-picker__menu-entry button').contains('Add description').click()


### PR DESCRIPTION
### 📝 Summary

Some tests modify it - so set it to `en` in `beforeEach`.

Following the recommendataion of preparing everything
in `beforeEach` hooks
rather then reverting the changes in `after` hooks
so the state of failing tests can be inspected.

Includes a seperate commit to make use of `createTestFolder` and `visitTestFolder` commands.

#### 🖼️ Screenshots of failure

:earth_asia: Browser | :computer:  Console
---|---
![grafik](https://github.com/nextcloud/text/assets/97337118/28100ce4-1359-4b69-9018-302d775c75f0) | ![grafik](https://github.com/nextcloud/text/assets/97337118/c0a112b2-8a1d-414a-b633-a5a23b6cf84d)
 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- fixes tests - so no new tests or docs.