### PR TITLE
Bring back test failing due to server issue

### DIFF
--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -371,8 +371,7 @@ describe('Test all attachment insertion methods', () => {
 			})
 	})
 
-	// Skip as https://github.com/nextcloud/server/issues/42306 causes this to fail.
-	it.skip('test if attachment folder is deleted after having deleted a markdown file', () => {
+	it('test if attachment folder is deleted after having deleted a markdown file', () => {
 		const fileName = 'deleteSource.md'
 		cy.createMarkdown(fileName, '![git](.attachments.123/github.png)', false).then((fileId) => {
 			const attachmentsFolder = `.attachments.${fileId}`


### PR DESCRIPTION
This reverts commit 77d77561fc835335a72b6fecc6d5f53d895ca8e1.

Merge once 
* https://github.com/nextcloud/server/issues/42306
is fixed.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- bringing back a test case that was skipped - no new tests or docs needed.