### PR TITLE
fix(gapcursor): Don't allow gap cursor in tables

### DIFF
--- a/src/nodes/Table/TableCaption.js
+++ b/src/nodes/Table/TableCaption.js
@@ -9,6 +9,7 @@ import { Node } from '@tiptap/core'
 export default Node.create({
 	name: 'tableCaption',
 	content: 'inline*',
+	allowGapCursor: false,
 	addAttributes() {
 		return {}
 	},

--- a/src/nodes/Table/TableHeadRow.js
+++ b/src/nodes/Table/TableHeadRow.js
@@ -3,6 +3,7 @@ import TableRow from './TableRow.js'
 export default TableRow.extend({
 	name: 'tableHeadRow',
 	content: 'tableHeader*',
+	allowGapCursor: false,
 
 	toMarkdown(state, node) {
 		state.write('|')

--- a/src/nodes/Table/TableRow.js
+++ b/src/nodes/Table/TableRow.js
@@ -2,6 +2,7 @@ import { TableRow } from '@tiptap/extension-table-row'
 
 export default TableRow.extend({
 	content: 'tableCell*',
+	allowGapCursor: false,
 
 	toMarkdown(state, node) {
 		state.write('|')


### PR DESCRIPTION
Without this, arrow keys can be used to move the gapcursor in between cells and rows.
