### PR TITLE
debug(ci): use server commit of last successful cypress run

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           repository: nextcloud/server
-          ref: ${{ matrix.server-versions }}
+          ref: a4a120cb0c4f5f3f8856745dcdf7f7a4c7125828
           submodules: true
 
       - name: Checkout viewer


### PR DESCRIPTION
Cypress jobs fail on CI for a while now.

Debug what's the reason.