### PR TITLE
Fix/5080 keep menubar in workspace

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -57,7 +57,7 @@
 				<template v-else>
 					<MenuBar v-if="renderMenus"
 						ref="menubar"
-						:autohide="autohide"
+						:is-hidden="hideMenu"
 						:loaded.sync="menubarLoaded">
 						<Status :document="document"
 							:dirty="dirty"
@@ -213,7 +213,7 @@ export default {
 			type: String,
 			default: null,
 		},
-		autohide: {
+		hideMenu: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -30,7 +30,7 @@
 		:class="{
 			'text-menubar--ready': isReady,
 			'text-menubar--show': isVisible,
-			'text-menubar--autohide': autohide,
+			'text-menubar--hide': isHidden,
 			'text-menubar--is-workspace': $isRichWorkspace
 		}">
 		<HelpModal v-if="displayHelp" @close="hideHelp" />
@@ -136,7 +136,7 @@ export default {
 		return val
 	},
 	props: {
-		autohide: {
+		isHidden: {
 			type: Boolean,
 			default: false,
 		},
@@ -274,13 +274,13 @@ export default {
 		justify-content: flex-end;
 		align-items: center;
 
-		&.text-menubar--ready:not(.text-menubar--autohide) {
+		&.text-menubar--ready:not(.text-menubar--hide) {
 			visibility: visible;
 			animation-name: fadeInDown;
 			animation-duration: 0.3s;
 		}
 
-		&.text-menubar--autohide {
+		&.text-menubar--hide {
 			opacity: 0;
 			transition: visibility 0.2s 0.4s, opacity 0.2s 0.4s;
 			&.text-menubar--show {

--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -29,7 +29,6 @@
 		:aria-label="t('text', 'Editor actions')"
 		:class="{
 			'text-menubar--ready': isReady,
-			'text-menubar--show': isVisible,
 			'text-menubar--hide': isHidden,
 			'text-menubar--is-workspace': $isRichWorkspace
 		}">
@@ -84,7 +83,6 @@
 <script>
 import { NcActionSeparator, NcActionButton } from '@nextcloud/vue'
 import { loadState } from '@nextcloud/initial-state'
-import debounce from 'debounce'
 import { useResizeObserver } from '@vueuse/core'
 
 import ActionFormattingHelp from './ActionFormattingHelp.vue'
@@ -148,7 +146,6 @@ export default {
 			displayHelp: false,
 			displayTranslate: false,
 			isReady: false,
-			isVisible: this.$editor.isFocused,
 			canTranslate: loadState('text', 'translation_languages', []).length > 0,
 			resize: null,
 			iconsLimit: 4,
@@ -178,16 +175,6 @@ export default {
 	mounted() {
 		this.resize = useResizeObserver(this.$refs.menubar, this.onResize)
 
-		this.$onFocusChange = () => {
-			this.isVisible = this.$editor.isFocused
-		}
-		this.$onBlurChange = debounce(() => {
-			this.isVisible = this.$editor.isFocused
-		}, 3000) // 3s
-
-		this.$editor.on('focus', this.$onFocusChange)
-		this.$editor.on('blur', this.$onBlurChange)
-
 		this.$nextTick(() => {
 			this.isReady = true
 			this.$emit('update:loaded', true)
@@ -195,9 +182,6 @@ export default {
 	},
 	beforeDestroy() {
 		this.resize?.stop()
-
-		this.$editor.off('focus', this.$onFocusChange)
-		this.$editor.off('blur', this.$onBlurChange)
 	},
 	methods: {
 		onResize(entries) {
@@ -283,10 +267,6 @@ export default {
 		&.text-menubar--hide {
 			opacity: 0;
 			transition: visibility 0.2s 0.4s, opacity 0.2s 0.4s;
-			&.text-menubar--show {
-				visibility: visible;
-				opacity: 1;
-			}
 		}
 		.text-menubar__entries {
 			display: flex;

--- a/src/views/RichWorkspace.vue
+++ b/src/views/RichWorkspace.vue
@@ -33,7 +33,7 @@
 			:share-token="shareToken"
 			:mime="file.mimetype"
 			:autofocus="autofocus"
-			:autohide="autohide"
+			:hide-menu="hideMenu"
 			active
 			rich-workspace
 			@ready="ready=true"
@@ -87,7 +87,7 @@ export default {
 			loaded: false,
 			ready: false,
 			autofocus: false,
-			autohide: true,
+			hideMenu: true,
 			darkTheme: OCA.Accessibility && OCA.Accessibility.theme === 'dark',
 			enabled: OCA.Text.RichWorkspaceEnabled,
 		}
@@ -136,7 +136,7 @@ export default {
 	methods: {
 		onFocus() {
 			this.focus = true
-			this.autohide = false
+			this.hideMenu = false
 			this.unlistenKeydownEvents()
 		},
 		reset() {
@@ -199,7 +199,7 @@ export default {
 		},
 		onKeydown(e) {
 			if (e.key === 'Tab') {
-				this.autohide = false
+				this.hideMenu = false
 			}
 		},
 		onFileCreated(node) {

--- a/src/views/RichWorkspace.vue
+++ b/src/views/RichWorkspace.vue
@@ -38,7 +38,6 @@
 			rich-workspace
 			@ready="ready=true"
 			@focus="onFocus"
-			@blur="onBlur"
 			@error="reset" />
 	</div>
 </template>
@@ -135,11 +134,9 @@ export default {
 		this.unlistenKeydownEvents()
 	},
 	methods: {
-		onBlur() {
-			this.listenKeydownEvents()
-		},
 		onFocus() {
 			this.focus = true
+			this.autohide = false
 			this.unlistenKeydownEvents()
 		},
 		reset() {
@@ -198,25 +195,12 @@ export default {
 			window.addEventListener('keydown', this.onKeydown)
 		},
 		unlistenKeydownEvents() {
-			clearInterval(this.$_timeoutAutohide)
-
 			window.removeEventListener('keydown', this.onKeydown)
 		},
-		onTimeoutAutohide() {
-			this.autohide = true
-		},
 		onKeydown(e) {
-			if (e.key !== 'Tab') {
-				return
+			if (e.key === 'Tab') {
+				this.autohide = false
 			}
-
-			// remove previous timeout
-			clearInterval(this.$_timeoutAutohide)
-
-			this.autohide = false
-
-			// schedule to normal behaviour
-			this.$_timeoutAutohide = setTimeout(this.onTimeoutAutohide, 7000) // 7s
 		},
 		onFileCreated(node) {
 			if (SUPPORTED_STATIC_FILENAMES.includes(node.basename)) {


### PR DESCRIPTION
### 📝 Summary

* Resolves: #5080
* rename `autohide` to `hideMenu` (in `Editor`) and `isHidden` (inside the menu)
* cleanup the autohide mechanism.


#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
[before.webm](https://github.com/nextcloud/text/assets/97337118/36345612-a9d1-4bf2-9405-29a2506c6485) | [after.webm](https://github.com/nextcloud/text/assets/97337118/648df8f3-6e9a-48de-8d98-911079a77090)


### :ballot_box_with_check: Todolist

- [x] take screenshots

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] no tests as we typically do not test styling
- no docs needed.
