### PR TITLE
fix: translate popup does not open in mobile apps

### DIFF
--- a/lib/Service/InitialStateProvider.php
+++ b/lib/Service/InitialStateProvider.php
@@ -64,4 +64,12 @@ class InitialStateProvider {
 	public function provideFileId(int $fileId): void {
 		$this->initialState->provideInitialState('file_id', $fileId);
 	}
+
+	public function provideFile(array $fileData): void {
+		$this->initialState->provideInitialState('file', $fileData);
+	}
+
+	public function provideDirectEditToken(string $token): void {
+		$this->initialState->provideInitialState('directEditingToken', $token);
+	}
 }


### PR DESCRIPTION
### 📝 Summary

* Resolves: #4233

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
