### PR TITLE
fix: Properly copy selection as markdown to the plaintext clipboard

### DIFF
--- a/src/EditorFactory.js
+++ b/src/EditorFactory.js
@@ -80,24 +80,8 @@ const createEditor = ({ language, onCreate, onUpdate = () => {}, extensions, ena
 	})
 }
 
-const SerializeException = function(message) {
-	this.message = message
-}
-
-const serializePlainText = (tiptap) => {
-	const doc = tiptap.getJSON()
-
-	if (doc.content.length !== 1 || typeof doc.content[0].content === 'undefined' || doc.content[0].content.length !== 1) {
-		if (doc.content[0].type === 'codeBlock' && typeof doc.content[0].content === 'undefined') {
-			return ''
-		}
-		throw new SerializeException('Failed to serialize document to plain text')
-	}
-	const codeBlock = doc.content[0].content[0]
-	if (codeBlock.type !== 'text') {
-		throw new SerializeException('Failed to serialize document to plain text')
-	}
-	return codeBlock.text
+const serializePlainText = (doc) => {
+	return doc.textContent
 }
 
 export default createEditor

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -111,7 +111,7 @@ import { createEditor, serializePlainText, loadSyntaxHighlight } from './../Edit
 import { createMarkdownSerializer } from './../extensions/Markdown.js'
 import markdownit from './../markdownit/index.js'
 
-import { CollaborationCursor, Keymap } from '../extensions/index.js'
+import { CollaborationCursor } from '../extensions/index.js'
 import DocumentStatus from './Editor/DocumentStatus.vue'
 import isMobile from './../mixins/isMobile.js'
 import setContent from './../mixins/setContent.js'
@@ -371,8 +371,8 @@ export default {
 				filePath: this.relativePath,
 				forceRecreate: this.forceRecreate,
 				serialize: this.isRichEditor
-					? () => createMarkdownSerializer(this.$editor.schema).serialize(this.$editor.state.doc)
-					: () => serializePlainText(this.$editor),
+					? (content) => createMarkdownSerializer(this.$editor.schema).serialize(content ?? this.$editor.state.doc)
+					: (content) => serializePlainText(content ?? this.$editor.state.doc),
 				getDocumentState: () => getDocumentState(this.$ydoc),
 			})
 
@@ -524,16 +524,6 @@ export default {
 											: (session?.guestName || t('text', 'Guest')),
 										color: session?.color,
 										clientId: this.$ydoc.clientID,
-									},
-								}),
-								Keymap.configure({
-									'Shift-Mod-c': ({ editor }) => {
-										if (!navigator?.clipboard) {
-											console.error('Clipboard API is not available')
-										}
-
-										const proseMirrorMarkdown = this.$syncService.serialize(editor.state.doc)
-										navigator.clipboard.writeText(proseMirrorMarkdown)
 									},
 								}),
 							],

--- a/src/extensions/Markdown.js
+++ b/src/extensions/Markdown.js
@@ -107,6 +107,9 @@ const Markdown = Extension.create({
 
 						return parser.parseSlice(dom, { preserveWhitespace: true, context: $context })
 					},
+					clipboardTextSerializer: (slice) => {
+						return createMarkdownSerializer(this.editor.schema).serialize(slice.content)
+					},
 					transformPastedHTML,
 				},
 			}),

--- a/src/tests/plaintext.spec.js
+++ b/src/tests/plaintext.spec.js
@@ -17,7 +17,7 @@ const plaintextThroughEditor = (markdown) => {
     enableRichEditing: false
   })
   tiptap.commands.setContent(content)
-  return serializePlainText(tiptap) || 'failed'
+  return serializePlainText(tiptap.state.doc) || 'failed'
 }
 
 describe('commonmark as plaintext', () => {


### PR DESCRIPTION
Using clipboardTextSerializer we can copy the current selection as markdown and don't need the extra keyboard shortcut, which was broken anyways as it always selected the full text

Steps to reproduce:
- Select a text range
- Copy using Ctrl-C
- Paste to a plaintext editor, github issue or https://evercoder.github.io/clipboard-inspector/

Fix https://github.com/nextcloud/text/issues/5213