### PR TITLE
fix: Skip editor container and file upload input during keyboard navigation

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -24,6 +24,7 @@
 	<div id="editor-container"
 		data-text-el="editor-container"
 		class="text-editor"
+		tabindex="-1"
 		@keydown.stop="onKeyDown">
 		<DocumentStatus v-if="displayedStatus"
 			:idle="idle"

--- a/src/components/Editor/MediaHandler.vue
+++ b/src/components/Editor/MediaHandler.vue
@@ -29,6 +29,7 @@
 		@dragleave.prevent.stop="setDraggedOver(false)"
 		@file-drop="onEditorDrop">
 		<input ref="attachmentFileInput"
+			tabindex="-1"
 			data-text-el="attachment-file-input"
 			type="file"
 			accept="*/*"


### PR DESCRIPTION
Fix https://github.com/nextcloud/text/issues/5222

The hidden `input[type=file]` is used by the image menu action to trigger a file upload but does not need to be interacted with. I'm not entirely sure why the `#editor-container` is considered a focussable dom element, but having the tabindex disabled there fixes the tab navigation to be logical.