### PR TITLE
fix: Prioritize un-collapsible menubar entries for mobile and aggregate children in the hidden entries

### DIFF
--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -161,14 +161,20 @@ export default {
 			return list
 		},
 		hiddenEntries() {
+			const entries = this.entries.filter(({ priority }) => {
+				// reverse logic from visibleEntries
+				return priority !== undefined && priority > this.iconsLimit
+			}).reduce((acc, entry) => {
+				// If entry has children, merge them into list. Otherwise keep entry itself.
+				const children = entry.children ?? [entry]
+				return [...acc, ...children]
+			}, [])
+
 			return {
 				key: 'remain',
 				label: this.t('text', 'Remaining actions'),
 				icon: DotsHorizontal,
-				children: this.entries.filter(({ priority }) => {
-					// reverse logic from visibleEntries
-					return priority !== undefined && priority > this.iconsLimit
-				}),
+				children: entries,
 			}
 		},
 	},

--- a/src/components/Menu/entries.js
+++ b/src/components/Menu/entries.js
@@ -308,7 +308,7 @@ export default [
 				},
 			},
 		],
-		priority: 3,
+		priority: 6,
 	},
 	{
 		key: 'code-block',
@@ -340,13 +340,13 @@ export default [
 		action: (command, emojiObject = {}) => {
 			return command.emoji(emojiObject)
 		},
-		priority: 5,
+		priority: 3,
 	},
 	{
 		key: 'insert-attachment',
 		label: t('text', 'Insert attachment'),
 		icon: Images,
 		component: ActionAttachmentUpload,
-		priority: 4,
+		priority: 1,
 	},
 ]


### PR DESCRIPTION
Fix https://github.com/nextcloud/text/issues/5220

There are some menubar entires that cannot be collapsed in the hidden entries list as they trigger another popover which comes with too much complexity to implement a nested popover now. However with 320px we have enough space to show all of them.

For others (like callout actions) where the menu is just a list of simple action buttons we can just merge them into the overflow menu.

This ensures that any action is usable on all screen sizes >= 320px.

<img width="377" alt="Screenshot 2024-01-10 at 15 24 13" src="https://github.com/nextcloud/text/assets/3404133/ab8823f5-01a0-452d-8831-4fc87c1ba7b4">

