### PR TITLE
fix: Only show translate if providers are available

### DIFF
--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -62,7 +62,7 @@
 				:can-be-focussed="activeMenuEntry === visibleEntries.length"
 				@click="activeMenuEntry = 'remain'">
 				<template #lastAction="{ visible }">
-					<NcActionButton @click="showTranslate">
+					<NcActionButton v-if="canTranslate" @click="showTranslate">
 						<template #icon>
 							<TranslateVariant />
 						</template>


### PR DESCRIPTION
Hide the translation menu entry if it is not available to be used