### PR TITLE
fix: Use proper way of hiding the attachment input

### DIFF
--- a/src/components/Editor/MediaHandler.vue
+++ b/src/components/Editor/MediaHandler.vue
@@ -28,13 +28,11 @@
 		@dragover.prevent.stop="setDraggedOver(true)"
 		@dragleave.prevent.stop="setDraggedOver(false)"
 		@file-drop="onEditorDrop">
-		<input ref="attachmentFileInput"
-			tabindex="-1"
+		<input v-show="false"
+			ref="attachmentFileInput"
 			data-text-el="attachment-file-input"
 			type="file"
 			accept="*/*"
-			aria-hidden="true"
-			class="hidden-visually"
 			multiple
 			@change="onAttachmentUploadFilePicked">
 		<slot />


### PR DESCRIPTION
Hide the input field properly to make it not focusable and hidden for assistive technologies.

as described in https://github.com/nextcloud/text/pull/5224#issuecomment-1885255799
