### PR TITLE
Fix migration from `v-tooltip` to native `title` in menu bar buttons `ActionEntry`

### DIFF
--- a/src/components/Menu/ActionSingle.vue
+++ b/src/components/Menu/ActionSingle.vue
@@ -104,18 +104,10 @@ export default {
 
 		const { class: classes, ...attrs } = bindState
 
-		// do not use tooltip if is a item of action list
-		const directives = isItem
-			? []
-			: [{
-				name: 'tooltip',
-				value: tooltip,
-			}]
-
 		const children = [h(icon, { slot: 'icon' })]
 
 		// do not use title if is a item of action list
-		const title = isItem ? undefined : label
+		const title = isItem ? undefined : tooltip
 
 		if (isItem || actionEntry.forceLabel) {
 			// add label
@@ -123,7 +115,6 @@ export default {
 		}
 
 		return h(component, {
-			directives,
 			staticClass: 'entry-single-action entry-action',
 			class: classes,
 			attrs: {

--- a/src/components/Suggestion/SuggestionListWrapper.vue
+++ b/src/components/Suggestion/SuggestionListWrapper.vue
@@ -42,6 +42,8 @@
 	</div>
 </template>
 <script>
+import { translate as t } from '@nextcloud/l10n'
+
 export default {
 	name: 'SuggestionListWrapper',
 

--- a/src/nodes/Table/TableCellView.vue
+++ b/src/nodes/Table/TableCellView.vue
@@ -82,7 +82,6 @@ export default {
 		},
 	},
 	computed: {
-		t: () => window.t,
 		textAlign() {
 			return { 'text-align': this.node.attrs.textAlign }
 		},

--- a/src/nodes/Table/TableHeaderView.vue
+++ b/src/nodes/Table/TableHeaderView.vue
@@ -122,7 +122,6 @@ export default {
 		},
 	},
 	computed: {
-		t: () => window.t,
 		textAlign() {
 			return { 'text-align': this.node.attrs.textAlign }
 		},

--- a/src/nodes/Table/TableView.vue
+++ b/src/nodes/Table/TableView.vue
@@ -68,9 +68,6 @@ export default {
 			required: true,
 		},
 	},
-	computed: {
-		t: () => window.t,
-	},
 }
 </script>
 


### PR DESCRIPTION
### 📝 Summary

#### Migration from `v-tooltip` to native `title` was not complete in `<ActionSingle>`

- Regression of: https://github.com/nextcloud/text/pull/5174/
  - Shows incorrect `title` on `NcAction`
  - Floods console with dozen errors per several seconds
- Removed using directive and fixed `title` text

![image](https://github.com/nextcloud/text/assets/25978914/f39f2a95-955c-4484-ba72-2754388f4ba3)

##### 🖼️ Screenshots

Before | After
---|---
![image](https://github.com/nextcloud/text/assets/25978914/10129050-7356-4d76-8aed-d4df01b91b58) | ![image](https://github.com/nextcloud/text/assets/25978914/12d1e70c-f332-4f28-8725-a75d893c4e05)

#### Duplication of `t` definition

In some components translation method `t` was added as a computed property `t: () => window.t` or a method. But method `t` is already added globally by prototype monkey-patching: `Vue.prototype.t = t`.

It caused error. Removed as not needed.

![image](https://github.com/nextcloud/text/assets/25978914/041b5724-4a4e-43e0-8656-f9396a4fd06a)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
