### PR TITLE
stick to @nextcloud/files v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/browser-storage": "^0.3.0",
         "@nextcloud/event-bus": "^3.1.0",
-        "@nextcloud/files": "^3.0.0",
+        "@nextcloud/files": "^2.1.0",
         "@nextcloud/initial-state": "^2.1.0",
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/logger": "^2.7.0",
@@ -3848,6 +3848,38 @@
         "vue": "^2.7.14"
       }
     },
+    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.1.0.tgz",
+      "integrity": "sha512-i0g9L5HRBJ2vr/gXYb0Gtg379u6nYZJFL30W50OV0F0qlf8OtkAlNpfOVOg3sJf9zklARE2lVY9g2Y9sv/iQ3g==",
+      "dependencies": {
+        "@nextcloud/auth": "^2.2.1",
+        "@nextcloud/l10n": "^2.2.0",
+        "@nextcloud/logger": "^2.7.0",
+        "@nextcloud/paths": "^2.1.0",
+        "@nextcloud/router": "^2.2.0",
+        "is-svg": "^5.0.0",
+        "webdav": "^5.3.1"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^9.0.0"
+      }
+    },
+    "node_modules/@nextcloud/dialogs/node_modules/is-svg": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-5.0.0.tgz",
+      "integrity": "sha512-sRl7J0oX9yUNamSdc8cwgzh9KBLnQXNzGmW0RVHwg/jEYjGNYHC6UvnYD8+hAeut9WwxRvhG9biK7g/wDGxcMw==",
+      "dependencies": {
+        "fast-xml-parser": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@nextcloud/eslint-config": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/eslint-config/-/eslint-config-8.3.0.tgz",
@@ -3935,35 +3967,21 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.0.0.tgz",
-      "integrity": "sha512-zk5oIuVDyk2gWBKCJ+0B1HE3VjhuGnz2iLNbTcbRuTjMYb6aYCAEn1LY0dXbUQG93ehndYJCOdaYri/TaGrlXw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-2.1.0.tgz",
+      "integrity": "sha512-i5Q8oNPONwBWLnNjQOC3EmnUhExXpwmO45BonzaovzXdhFzFeT/g85kRNR8LWEjiK9vOMOdozz+z6I0adU0JlQ==",
       "dependencies": {
-        "@nextcloud/auth": "^2.2.1",
-        "@nextcloud/l10n": "^2.2.0",
-        "@nextcloud/logger": "^2.7.0",
-        "@nextcloud/paths": "^2.1.0",
-        "@nextcloud/router": "^2.2.0",
-        "is-svg": "^5.0.0",
-        "webdav": "^5.3.0"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "@nextcloud/l10n": "^1.3.0",
+        "core-js": "^3.6.4"
       }
     },
-    "node_modules/@nextcloud/files/node_modules/is-svg": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-5.0.0.tgz",
-      "integrity": "sha512-sRl7J0oX9yUNamSdc8cwgzh9KBLnQXNzGmW0RVHwg/jEYjGNYHC6UvnYD8+hAeut9WwxRvhG9biK7g/wDGxcMw==",
+    "node_modules/@nextcloud/files/node_modules/@nextcloud/l10n": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
+      "integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
       "dependencies": {
-        "fast-xml-parser": "^4.1.3"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "core-js": "^3.6.4",
+        "node-gettext": "^3.0.0"
       }
     },
     "node_modules/@nextcloud/initial-state": {
@@ -23067,9 +23085,9 @@
       "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "node_modules/webdav": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/webdav/-/webdav-5.3.0.tgz",
-      "integrity": "sha512-xRu/URZGCxDPXmT+9Gu6tNGvlETBwjcuz69lx/6Qlq/0q3Gu2GSVyRt+mP0vTlLFfaY3xZ5O/SPTQ578tC/45Q==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/webdav/-/webdav-5.3.1.tgz",
+      "integrity": "sha512-wzZdTHtMuSIXqHGBznc8FM2L94Mc/17Tbn9ppoMybRO0bjWOSIeScdVXWX5qqHsg00EjfiOcwMqGFx6ghIhccQ==",
       "dependencies": {
         "@buttercup/fetch": "^0.1.1",
         "base-64": "^1.0.0",
@@ -26399,6 +26417,30 @@
         "toastify-js": "^1.12.0",
         "vue-frag": "^1.4.3",
         "webdav": "^5.2.3"
+      },
+      "dependencies": {
+        "@nextcloud/files": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.1.0.tgz",
+          "integrity": "sha512-i0g9L5HRBJ2vr/gXYb0Gtg379u6nYZJFL30W50OV0F0qlf8OtkAlNpfOVOg3sJf9zklARE2lVY9g2Y9sv/iQ3g==",
+          "requires": {
+            "@nextcloud/auth": "^2.2.1",
+            "@nextcloud/l10n": "^2.2.0",
+            "@nextcloud/logger": "^2.7.0",
+            "@nextcloud/paths": "^2.1.0",
+            "@nextcloud/router": "^2.2.0",
+            "is-svg": "^5.0.0",
+            "webdav": "^5.3.1"
+          }
+        },
+        "is-svg": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-5.0.0.tgz",
+          "integrity": "sha512-sRl7J0oX9yUNamSdc8cwgzh9KBLnQXNzGmW0RVHwg/jEYjGNYHC6UvnYD8+hAeut9WwxRvhG9biK7g/wDGxcMw==",
+          "requires": {
+            "fast-xml-parser": "^4.1.3"
+          }
+        }
       }
     },
     "@nextcloud/eslint-config": {
@@ -26451,25 +26493,21 @@
       }
     },
     "@nextcloud/files": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.0.0.tgz",
-      "integrity": "sha512-zk5oIuVDyk2gWBKCJ+0B1HE3VjhuGnz2iLNbTcbRuTjMYb6aYCAEn1LY0dXbUQG93ehndYJCOdaYri/TaGrlXw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-2.1.0.tgz",
+      "integrity": "sha512-i5Q8oNPONwBWLnNjQOC3EmnUhExXpwmO45BonzaovzXdhFzFeT/g85kRNR8LWEjiK9vOMOdozz+z6I0adU0JlQ==",
       "requires": {
-        "@nextcloud/auth": "^2.2.1",
-        "@nextcloud/l10n": "^2.2.0",
-        "@nextcloud/logger": "^2.7.0",
-        "@nextcloud/paths": "^2.1.0",
-        "@nextcloud/router": "^2.2.0",
-        "is-svg": "^5.0.0",
-        "webdav": "^5.3.0"
+        "@nextcloud/l10n": "^1.3.0",
+        "core-js": "^3.6.4"
       },
       "dependencies": {
-        "is-svg": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-5.0.0.tgz",
-          "integrity": "sha512-sRl7J0oX9yUNamSdc8cwgzh9KBLnQXNzGmW0RVHwg/jEYjGNYHC6UvnYD8+hAeut9WwxRvhG9biK7g/wDGxcMw==",
+        "@nextcloud/l10n": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
+          "integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
           "requires": {
-            "fast-xml-parser": "^4.1.3"
+            "core-js": "^3.6.4",
+            "node-gettext": "^3.0.0"
           }
         }
       }
@@ -40782,9 +40820,9 @@
       "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "webdav": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/webdav/-/webdav-5.3.0.tgz",
-      "integrity": "sha512-xRu/URZGCxDPXmT+9Gu6tNGvlETBwjcuz69lx/6Qlq/0q3Gu2GSVyRt+mP0vTlLFfaY3xZ5O/SPTQ578tC/45Q==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/webdav/-/webdav-5.3.1.tgz",
+      "integrity": "sha512-wzZdTHtMuSIXqHGBznc8FM2L94Mc/17Tbn9ppoMybRO0bjWOSIeScdVXWX5qqHsg00EjfiOcwMqGFx6ghIhccQ==",
       "requires": {
         "@buttercup/fetch": "^0.1.1",
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nextcloud/axios": "^2.4.0",
     "@nextcloud/browser-storage": "^0.3.0",
     "@nextcloud/event-bus": "^3.1.0",
-    "@nextcloud/files": "^3.0.0",
+    "@nextcloud/files": "^2.1.0",
     "@nextcloud/initial-state": "^2.1.0",
     "@nextcloud/l10n": "^2.2.0",
     "@nextcloud/logger": "^2.7.0",


### PR DESCRIPTION
### 📝 Summary

* Forward ports: #5264
* Resolves: failing build in #5251

`@nextcloud/files` requires node 20 and npm 9. This dependency was introduced based on a beta version that did not have these requirements yet. Roll back to version 2 rather than updating the entire node stack.

Only difference here is that `formatFileSize` which we use will default to non-binary file sizes - i.e 1.024KB instead of 1KiB as this only became available with v3:
* https://github.com/nextcloud-libraries/nextcloud-files/pull/770/files#diff-237392127cb275fc6789cf6faec014d758950c87ccdab0329dde793d034190d8



