### PR TITLE
fix(psalm): getPassword may return null

### DIFF
--- a/lib/Controller/PublicSessionController.php
+++ b/lib/Controller/PublicSessionController.php
@@ -60,7 +60,7 @@ class PublicSessionController extends PublicShareController implements ISessionA
 		return $this->share;
 	}
 
-	protected function getPasswordHash(): string {
+	protected function getPasswordHash(): ?string {
 		return $this->getShare()->getPassword();
 	}
 


### PR DESCRIPTION
### 📝 Summary

* Resolves: failing code standards checks in main branch such as https://github.com/nextcloud/text/actions/runs/7529119583/job/20492703878


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
