### PR TITLE
fix(mention): use new url schema

### DIFF
--- a/cypress/e2e/nodes/Mentions.spec.js
+++ b/cypress/e2e/nodes/Mentions.spec.js
@@ -72,8 +72,11 @@ describe('Test mentioning users', () => {
 
 		return cy.wait(`@${autocompleteReauestAlias}`)
 			.then(() => {
+				cy.intercept({ method: 'PUT', url: '**/mention' }).as('putMention')
 				cy.get('.tippy-box .suggestion-list').contains(mention).click()
 				cy.get('span.mention').contains(mention).should('be.visible')
+				cy.wait('@putMention')
+					.its('response.statusCode').should('eq', 200)
 			})
 	})
 

--- a/src/components/Suggestion/Mention/suggestions.js
+++ b/src/components/Suggestion/Mention/suggestions.js
@@ -6,8 +6,9 @@ import createSuggestions from '../suggestions.js'
 const USERS_LIST_ENDPOINT_URL = generateUrl('apps/text/api/v1/users')
 
 const emitMention = ({ session, props }) => {
-	axios.put(generateUrl('apps/text/session/mention'), {
-		documentId: session.documentId,
+	const documentId = session.documentId
+	axios.put(generateUrl(`apps/text/session/${documentId}/mention`), {
+		documentId,
 		sessionId: session.id,
 		sessionToken: session.token,
 		mention: props.id,


### PR DESCRIPTION
### 📝 Summary

Fixes notifications for mentions in 28 and following.
* Resolves: Failing ci runs such as  https://github.com/nextcloud/text/actions/runs/7587197071?pr=5284

#### 🖼️ Screenshots

![Test mentioning users -- Select a user will insert the mention (failed)](https://github.com/nextcloud/text/assets/97337118/64e510d7-2c71-4edc-88b5-61a1303df6a4)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- Documentation is not required
