### PR TITLE
Remove bottom margin for better warning blocks display

### DIFF
--- a/src/nodes/Callout.vue
+++ b/src/nodes/Callout.vue
@@ -86,7 +86,7 @@ export default {
 
 	.callout__content {
 		margin-left: 1em;
-		&:deep(p) {
+		&:deep(p .paragraph-content) {
 			&:last-child {
 				margin-bottom: 0;
 			}


### PR DESCRIPTION
This CSS change removes the extra bottom padding (which is in fact a paragraph bottom margin).
It makes text more compact, which is IMO relevant because warning blocks aim to be compact.

### 🏚️ Before
![Capture d’écran du 2024-01-24 09-21-10](https://github.com/nextcloud/text/assets/33763786/d7358393-46c9-4474-9f22-f016c3d73efc)
### 🏡 After
![Capture d’écran du 2024-01-24 09-21-17](https://github.com/nextcloud/text/assets/33763786/53aca9d4-e74c-4b23-95f4-ab9ad3cab13f)

Fixes: nextcloud/collectives#1175

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
