### PR TITLE
fix: register viewer by uniq name instead of "component"

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -26,13 +26,23 @@ import { openMimetypesMarkdown, openMimetypesPlainText } from './helpers/mime.js
 __webpack_nonce__ = btoa(OC.requestToken) // eslint-disable-line
 __webpack_public_path__ = OC.linkTo('text', 'js/') // eslint-disable-line
 
+/**
+ * Wrapper for async registration of ViewerComponent.
+ * Note: it should be named function - the name is used for component registration.
+ *
+ * @return {Promise<import('./components/ViewerComponent.vue')>} ViewerComponent
+ */
+function AsyncTextViewerComponent() {
+	return import('./components/ViewerComponent.vue')
+}
+
 if (typeof OCA.Viewer === 'undefined') {
 	logger.error('Viewer app is not installed')
 } else {
 	OCA.Viewer.registerHandler({
 		id: 'text',
 		mimes: [...openMimetypesMarkdown, ...openMimetypesPlainText],
-		component: () => import('./components/ViewerComponent.vue'),
+		component: AsyncTextViewerComponent,
 		group: null,
 		theme: 'default',
 		canCompare: true,


### PR DESCRIPTION
### 📝 Summary

- Anonymous function in object property has a name of the property - component
- This name is used for global viewer component registration
- `component` is not a valid name, because it is a built-in name for Vue and it registers a global component
- Using named function to have an explicit name

Probably should be handled by `Viewer`, but I haven't found any other app with async component registration. I guess it is not possible to use 2 viewers with dynamic anonymous components.

![image](https://github.com/nextcloud/text/assets/25978914/bee70506-d93d-4b5d-839e-414b9f73915b)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
