### PR TITLE
fix: Only unpause focus traps that we paused ourselves

### DIFF
--- a/src/extensions/FocusTrap.js
+++ b/src/extensions/FocusTrap.js
@@ -1,5 +1,7 @@
 import { Extension } from '@tiptap/core'
 
+let ownPaused = false
+
 const toggleFocusTrap = ({ editor }) => {
 	const trapStack = window._nc_focus_trap ?? []
 	const activeTrap = trapStack[trapStack.length - 1]
@@ -10,8 +12,12 @@ const toggleFocusTrap = ({ editor }) => {
 
 	if (possibleEditorTabCommand) {
 		activeTrap?.pause()
+		ownPaused = true
 	} else {
-		activeTrap?.unpause()
+		if (ownPaused) {
+			ownPaused = false
+			activeTrap?.unpause()
+		}
 	}
 }
 


### PR DESCRIPTION
Fix #5326 

Still need to check if there is a more elegant approach, but this seems to fix it.

Also to double check, probably for a separate issue
- [ ] Having a link after a code block will allow tabbing out of the paused focus trap