### PR TITLE
fix: only register workspace once

### DIFF
--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -38,6 +38,15 @@ describe('Workspace', function() {
 		cy.createTestFolder().as('testFolder')
 	})
 
+	it('Initializes the workspace without errors', function() {
+		cy.visitTestFolder({
+			onBeforeLoad: win => cy.spy(win.console, 'error').as('consoleError'),
+		})
+		cy.then(() => {
+			expect(this.consoleError).to.not.have.been.calledWithMatch('workspace')
+		})
+	})
+
 	it('Hides the workspace when switching to another folder', function() {
 		cy.uploadFile('test.md', 'text/markdown', `${this.testFolder}/README.md`)
 		cy.createFolder(`${this.testFolder}/subdirectory`)

--- a/src/files.js
+++ b/src/files.js
@@ -21,7 +21,6 @@
  */
 import { linkTo } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
-import { registerFileListHeaders } from '@nextcloud/files'
 
 import { logger } from './helpers/logger.js'
 
@@ -54,11 +53,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 		OCA.Files.Settings.register(new OCA.Files.Settings.Setting('text', {
 			el: () => { return el },
 		}))
-	}
-
-	if (workspaceAvailable) {
-		const { FilesWorkspaceHeader } = await import('./helpers/files.js')
-		registerFileListHeaders(FilesWorkspaceHeader)
 	}
 })
 


### PR DESCRIPTION
### 📝 Summary

Fixes #5332.

Looks like #4698 brought back the file list header initialization that had just been moved to an init script in #4776.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits.
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests.
- Documentation is not required.
