### PR TITLE
test(cy): use more robust selectors in file picker

### DIFF
--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -184,9 +184,9 @@ describe('Test all attachment insertion methods', () => {
 				cy.intercept({ method: 'POST', url: '**/filepath' }).as(requestAlias)
 
 				cy.log('Go to sub folder (a)')
-				cy.get('.file-picker__main .file-picker__file-name[title="sub"]').click()
-				cy.get('.file-picker__main .file-picker__file-name[title="a"]').click()
-				cy.get('.file-picker__main .file-picker__file-name[title="a"]').click()
+				cy.get('.file-picker [data-filename="sub"]').click()
+				cy.get('.file-picker [data-filename="a"]').click()
+				cy.get('.file-picker [data-filename="a.png"]').click()
 
 				cy.get('.dialog__actions button.button-vue--vue-primary').click()
 
@@ -198,12 +198,12 @@ describe('Test all attachment insertion methods', () => {
 				cy.intercept({ method: 'POST', url: '**/filepath' }).as(requestAlias)
 
 				cy.log('Go back from home to sub folder')
-				cy.get('.file-picker__breadcrumbs button[title="Home"]').click()
-				cy.get('.file-picker__main .file-picker__file-name[title="sub"]').click()
+				cy.get('.file-picker nav [aria-label="Home"]').click()
+				cy.get('.file-picker [data-filename="sub"]').click()
 
 				cy.log('Go to sub folder (b)')
-				cy.get('.file-picker__main .file-picker__file-name[title="b"]').click()
-				cy.get('.file-picker__main .file-picker__file-name[title="b"]').click()
+				cy.get('.file-picker [data-filename="b"]').click()
+				cy.get('.file-picker [data-filename="b.png"]').click()
 
 				cy.get('.dialog__actions button.button-vue--vue-primary').click()
 
@@ -217,10 +217,10 @@ describe('Test all attachment insertion methods', () => {
 				cy.intercept({ method: 'POST', url: '**/filepath' }).as(requestAlias)
 
 				cy.log('Go back to home')
-				cy.get('.file-picker__breadcrumbs button[title="Home"]').click()
+				cy.get('.file-picker nav [aria-label="Home"]').click()
 
 				cy.log('Select the file in the filepicker')
-				cy.get('.file-picker__main .file-picker__file-name[title="github"]').click()
+				cy.get('.file-picker [data-filename="github.png"]').click()
 				cy.log('Click OK in the filepicker')
 				cy.get('.dialog__actions button.button-vue--vue-primary').click()
 

--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -163,9 +163,9 @@ describe('Workspace', function() {
 		cy.getSubmenuEntry('insert-link', 'insert-link-file')
 			.click()
 
-		cy.get('.file-picker__main .file-picker__file-name[title="sub-folder"]').click()
-		cy.get('.file-picker__main .file-picker__file-name[title="alpha"]').click()
-		cy.get('.file-picker__main .file-picker__file-name[title="test"]').click()
+		cy.get('.file-picker [data-filename="sub-folder"]').click()
+		cy.get('.file-picker [data-filename="alpha"]').click()
+		cy.get('.file-picker [data-filename="test.md"]').click()
 		cy.get('.dialog__actions button.button-vue--vue-primary').click()
 
 		cy.getEditor()


### PR DESCRIPTION
### 📝 Summary

* Use the selectors used in server to test the files app.
* Rely on semantics (`nav`, `[aria-label=...]`).

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- Documentation is not required
