### PR TITLE
Cleanup `_oc_webroot` stubs where possible

### DIFF
--- a/cypress/e2e/api/SessionApi.spec.js
+++ b/cypress/e2e/api/SessionApi.spec.js
@@ -34,11 +34,7 @@ describe('The session Api', function() {
 
 	before(function() {
 		cy.createUser(user)
-		window.OC = {
-			config: { modRewriteWorking: false },
-			webroot: '',
-		}
-		window._oc_webroot = ''
+		cy.prepareWindowForSessionApi()
 	})
 
 	beforeEach(function() {

--- a/cypress/e2e/api/SyncServiceProvider.spec.js
+++ b/cypress/e2e/api/SyncServiceProvider.spec.js
@@ -32,10 +32,7 @@ describe('Sync service provider', function() {
 
 	before(function() {
 		cy.createUser(user)
-		window.OC = {
-			config: { modRewriteWorking: false },
-		}
-		window._oc_webroot = ''
+		cy.prepareWindowForSessionApi()
 	})
 
 	beforeEach(function() {

--- a/cypress/e2e/api/UsersApi.spec.js
+++ b/cypress/e2e/api/UsersApi.spec.js
@@ -37,7 +37,7 @@ describe('The user mention API', function() {
 		cy.login(user)
 		cy.uploadTestFile('test.md').as('fileId')
 			.then(cy.createTextSession).as('connection')
-		cy.getRequestToken().as('requesttoken')
+		cy.getRequestToken()
 	})
 
 	afterEach(function() {
@@ -51,53 +51,29 @@ describe('The user mention API', function() {
 	})
 
 	it('fetches users with valid session', function() {
-		const body = {
-			documentId: this.connection.document.id,
-			sessionId: this.connection.session.id,
-			sessionToken: this.connection.session.token,
-			requesttoken: this.requesttoken,
-		}
-		const requestData = {
-			method: 'POST',
-			url: '/apps/text/api/v1/users',
-			body,
-			failOnStatusCode: false,
-		}
-		const invalidRequestData = { ...requestData }
 
-		cy.request(requestData).then(({ status }) => {
+		cy.sessionUsers(this.connection).then(({ status }) => {
 			expect(status).to.eq(200)
-
-			invalidRequestData.body = {
-				...requestData.body,
-				sessionToken: 'invalid',
-			}
 		})
 
-		cy.request(invalidRequestData).then(({ status }) => {
+		cy.sessionUsers(this.connection, { sessionToken: 'invalid' })
+			.then(({ status }) => {
 			expect(status).to.eq(403)
-			invalidRequestData.body = {
-				...requestData.body,
-				sessionId: 0,
-			}
 		})
 
-		cy.request(invalidRequestData).then(({ status }) => {
+		cy.sessionUsers(this.connection, { sessionId: 0 })
+			.then(({ status }) => {
 			expect(status).to.eq(403)
-
-			invalidRequestData.body = {
-				...requestData.body,
-				documentId: 0,
-			}
 		})
 
-		cy.request(invalidRequestData).then(({ status }) => {
+		cy.sessionUsers(this.connection, { documentId: 0 })
+			.then(({ status }) => {
 			expect(status).to.eq(403)
 		})
 
 		cy.then(() => this.connection.close())
 
-		cy.request(requestData).then(({ status, body }) => {
+		cy.sessionUsers(this.connection).then(({ status }) => {
 			expect(status).to.eq(403)
 		})
 	})

--- a/cypress/e2e/api/UsersApi.spec.js
+++ b/cypress/e2e/api/UsersApi.spec.js
@@ -30,10 +30,7 @@ describe('The user mention API', function() {
 
 	before(function() {
 		cy.createUser(user)
-		window.OC = {
-			config: { modRewriteWorking: false },
-		}
-		window._oc_webroot = ''
+		cy.prepareWindowForSessionApi()
 	})
 
 	let fileId

--- a/cypress/e2e/api/UsersApi.spec.js
+++ b/cypress/e2e/api/UsersApi.spec.js
@@ -51,30 +51,22 @@ describe('The user mention API', function() {
 	})
 
 	it('fetches users with valid session', function() {
+		cy.sessionUsers(this.connection)
+			.its('status').should('eq', 200)
+	})
 
-		cy.sessionUsers(this.connection).then(({ status }) => {
-			expect(status).to.eq(200)
-		})
-
+	it('rejects invalid sessions', function() {
 		cy.sessionUsers(this.connection, { sessionToken: 'invalid' })
-			.then(({ status }) => {
-			expect(status).to.eq(403)
-		})
-
+			.its('status').should('eq', 403)
 		cy.sessionUsers(this.connection, { sessionId: 0 })
-			.then(({ status }) => {
-			expect(status).to.eq(403)
-		})
-
+			.its('status').should('eq', 403)
 		cy.sessionUsers(this.connection, { documentId: 0 })
-			.then(({ status }) => {
-			expect(status).to.eq(403)
-		})
+			.its('status').should('eq', 403)
+	})
 
+	it('rejects closed sessions', function() {
 		cy.then(() => this.connection.close())
-
-		cy.sessionUsers(this.connection).then(({ status }) => {
-			expect(status).to.eq(403)
-		})
+		cy.sessionUsers(this.connection)
+			.its('status').should('eq', 403)
 	})
 })

--- a/cypress/support/sessions.js
+++ b/cypress/support/sessions.js
@@ -23,6 +23,14 @@
 import SessionApi from '../../src/services/SessionApi.js'
 import { emit } from '@nextcloud/event-bus'
 
+Cypress.Commands.add('prepareWindowForSessionApi', () => {
+	window.OC = {
+		config: { modRewriteWorking: false },
+	}
+	// Prevent @nextcloud/router from reading window.location
+	window._oc_webroot = ''
+})
+
 Cypress.Commands.add('prepareSessionApi', () => {
 	return cy.request('/csrftoken')
 		.then(({ body }) => {

--- a/cypress/support/sessions.js
+++ b/cypress/support/sessions.js
@@ -88,6 +88,22 @@ Cypress.Commands.add('failToSave', (connection, options = { version: 0 }) => {
 		}, (err) => err.response)
 })
 
+Cypress.Commands.add('sessionUsers', function(connection, bodyOptions = {}) {
+	const body = {
+		documentId: connection.document.id,
+		sessionId: connection.session.id,
+		sessionToken: connection.session.token,
+		requesttoken: this.requesttoken,
+		...bodyOptions,
+	}
+	cy.request({
+		method: 'POST',
+		url: '/apps/text/api/v1/users',
+		body,
+		failOnStatusCode: false,
+	})
+})
+
 // Used to test for race conditions between the last push and the close request
 Cypress.Commands.add('pushAndClose', ({ connection, steps, version, awareness = '' }) => {
 	cy.log('Race between push and close')

--- a/src/tests/services/AttachmentResolver.spec.js
+++ b/src/tests/services/AttachmentResolver.spec.js
@@ -87,7 +87,7 @@ describe('Image resolver', () => {
 		const resolver = new AttachmentResolver({ fileId, user, currentDirectory })
 		const attachment = await resolver.resolve(src)
 		expect(attachment.isImage).toBe(true)
-		expect(attachment.previewUrl).toBe('http://localhost/nc-webroot/remote.php/dav/files/user-uid/parentDir/path/to/some%20image.png')
+		expect(attachment.previewUrl).toBe('http://localhost/remote.php/dav/files/user-uid/parentDir/path/to/some%20image.png')
 	})
 
 })

--- a/src/tests/setup.js
+++ b/src/tests/setup.js
@@ -73,8 +73,8 @@ global.OC = {
 	}
 }
 
-global._oc_webroot = '/nc-webroot'
 global.OCA = {}
+global._oc_webroot = ''
 
 
 Vue.prototype.t = global.t


### PR DESCRIPTION
- test(jest): remove internal _oc_webroot stub
- test(cy): introduce `cy.prepareWindowForSessionApi`
- test(cy): refactor to use aliases
- test(cy): introduce `cy.sessionUsers()` for users endpoint
- test(api): split test and use `.its` and `.should`
