### PR TITLE
fix(ci): use output rather than failure

### DIFF
--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -53,10 +53,14 @@ jobs:
         id: changes
         continue-on-error: true
         run: |
-          bash -c "[[ ! \"`git status --porcelain `\" ]] || (echo 'Please recompile and commit the assets, see the section \"Show changes on failure\" for details' && exit 1)"
+          {
+            echo 'CHANGED<<EOF'
+            git status --porcelain
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Add and commit
-        if: steps.changes.outcome == 'failure'
+        if: steps.changes.outputs.CHANGED != ''
         run: |
           git add --force js/
           git commit --signoff -m 'chore(assets): recompile assets'


### PR DESCRIPTION
### 📝 Summary

* Resolves: build jobs from being marked as canceled and reduces notificiation noise.

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

(note that the error is gone)

🏚️ Before | 🏡 After - no changes :white_check_mark: | 🏡 After - with changes :building_construction: 
---|---|---
![grafik](https://github.com/nextcloud/text/assets/97337118/0fa9c295-e55a-4a43-a0a0-3a652471cd1f) | ![grafik](https://github.com/nextcloud/text/assets/97337118/78dabe2f-9285-41da-ab6e-451f44b35dc6) | ![grafik](https://github.com/nextcloud/text/assets/97337118/fce6c958-1154-4d76-963a-4623c844cae9)


### 🚧 TODO

- [x] test with a diff
- [x] test without a diff

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- Testing in this PR... hope it will just work afterwards.
- Documentation is not required
