### PR TITLE
fix: Add alt attribute to image nodes

### DIFF
--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -41,6 +41,7 @@
 							<div class="media__wrapper">
 								<img v-show="loaded"
 									:src="imageUrl"
+									:alt="alt"
 									class="image__main"
 									@load="onLoaded">
 								<div class="metadata">


### PR DESCRIPTION
### 📝 Summary

It seems otherwise browser would read out the full URL with screen readers. We already have the alt text as user defined description for each image so we should make use of that.
