### PR TITLE
Feat/4750 Make code type fields copyable

### DIFF
--- a/cypress/e2e/nodes/CodeBlock.spec.js
+++ b/cypress/e2e/nodes/CodeBlock.spec.js
@@ -46,14 +46,14 @@ describe('Front matter support', function() {
 
 			// Copy code to clipboard
 			cy.getContent().find('code').eq(1).invoke('text')
-			.then(code =>
-				cy.window().then(win => {
-					win.navigator.clipboard.readText()
-					.then(copiedCode => {
-						expect(copiedCode).to.equal(code)
-					})
-				})
-			)
+				.then(code =>
+					cy.window().then(win => {
+						win.navigator.clipboard.readText()
+							.then(copiedCode => {
+								expect(copiedCode).to.equal(code)
+							})
+					}),
+				)
 
 			// Remove language
 			cy.getContent().find('.code-block').eq(1).find('.view-switch div div button').click()

--- a/cypress/e2e/nodes/CodeBlock.spec.js
+++ b/cypress/e2e/nodes/CodeBlock.spec.js
@@ -42,8 +42,21 @@ describe('Front matter support', function() {
 			cy.getContent().find('code').eq(1).find('.hljs-string').eq(0).contains('"bar"')
 			cy.getContent().find('code').eq(1).find('.hljs-keyword').eq(1).contains('function')
 
+			cy.getContent().find('.code-block').eq(1).find('.view-switch > button').click()
+
+			// Copy code to clipboard
+			cy.getContent().find('code').eq(1).invoke('text')
+			.then(code =>
+				cy.window().then(win => {
+					win.navigator.clipboard.readText()
+					.then(copiedCode => {
+						expect(copiedCode).to.equal(code)
+					})
+				})
+			)
+
 			// Remove language
-			cy.getContent().find('.code-block').eq(1).find('.view-switch button').click()
+			cy.getContent().find('.code-block').eq(1).find('.view-switch div div button').click()
 			// FIXME: Label behaviour changed, should be back once https://github.com/nextcloud-libraries/nextcloud-vue/pull/4484 is merged
 			// cy.get('.action-input__text-label').contains('Code block language')
 			cy.get('.input-field__input:visible').clear()
@@ -53,7 +66,7 @@ describe('Front matter support', function() {
 			cy.getContent().find('code').eq(1).find('.hljs-keyword').should('not.exist')
 
 			// Re-add language
-			cy.getContent().find('.code-block').eq(1).find('.view-switch button').click()
+			cy.getContent().find('.code-block').eq(1).find('.view-switch div div button').click()
 			cy.get('.input-field__input:visible').type('javascript')
 
 			cy.getContent().find('code').eq(1).find('.hljs-keyword').eq(0).contains('const')
@@ -136,17 +149,17 @@ describe('Front matter support', function() {
 			cy.get('.split-view__code').find('code').should('be.visible')
 			cy.get('.split-view__preview').find('svg').should('be.visible')
 
-			cy.getContent().find('.code-block').eq(0).find('.view-switch button').click()
+			cy.getContent().find('.code-block').eq(0).find('.view-switch div div button').click()
 			cy.get('.action-button').eq(0).contains('Source code').click()
 			cy.get('.split-view__code').find('code').should('be.visible')
 			cy.get('.split-view__preview').find('svg').should('not.be.visible')
 
-			cy.getContent().find('.code-block').eq(0).find('.view-switch button').click()
+			cy.getContent().find('.code-block').eq(0).find('.view-switch div div button').click()
 			cy.get('.action-button').eq(1).contains('Diagram').click()
 			cy.get('.split-view__code').find('code').should('not.be.visible')
 			cy.get('.split-view__preview').find('svg').should('be.visible')
 
-			cy.getContent().find('.code-block').eq(0).find('.view-switch button').click()
+			cy.getContent().find('.code-block').eq(0).find('.view-switch div div button').click()
 			cy.get('.action-button').eq(2).contains('Both').click()
 			cy.get('.split-view__code').find('code').should('be.visible')
 			cy.get('.split-view__preview').find('svg').should('be.visible')

--- a/cypress/e2e/nodes/CodeBlock.spec.js
+++ b/cypress/e2e/nodes/CodeBlock.spec.js
@@ -42,7 +42,7 @@ describe('Front matter support', function() {
 			cy.getContent().find('code').eq(1).find('.hljs-string').eq(0).contains('"bar"')
 			cy.getContent().find('code').eq(1).find('.hljs-keyword').eq(1).contains('function')
 
-			cy.getContent().find('.code-block').eq(1).find('.view-switch > button').click()
+			cy.getContent().find('.code-block').eq(1).find('[data-cy="copy-code"]').click()
 
 			// Copy code to clipboard
 			cy.getContent().find('code').eq(1).invoke('text')
@@ -56,7 +56,7 @@ describe('Front matter support', function() {
 				)
 
 			// Remove language
-			cy.getContent().find('.code-block').eq(1).find('.view-switch div div button').click()
+			cy.getContent().find('.code-block').eq(1).find('[data-cy="code-action-group"]').find('div:first-child').click()
 			// FIXME: Label behaviour changed, should be back once https://github.com/nextcloud-libraries/nextcloud-vue/pull/4484 is merged
 			// cy.get('.action-input__text-label').contains('Code block language')
 			cy.get('.input-field__input:visible').clear()
@@ -66,7 +66,7 @@ describe('Front matter support', function() {
 			cy.getContent().find('code').eq(1).find('.hljs-keyword').should('not.exist')
 
 			// Re-add language
-			cy.getContent().find('.code-block').eq(1).find('.view-switch div div button').click()
+			cy.getContent().find('.code-block').eq(1).find('[data-cy="code-action-group"]').find('div:first-child').click()
 			cy.get('.input-field__input:visible').type('javascript')
 
 			cy.getContent().find('code').eq(1).find('.hljs-keyword').eq(0).contains('const')

--- a/src/mixins/CopyToClipboardMixin.js
+++ b/src/mixins/CopyToClipboardMixin.js
@@ -10,23 +10,23 @@ export default {
 	},
 
 	methods: {
-		async copyToClipboard(url) {
+		async copyToClipboard(content) {
 			// change to loading status
 			this.copyLoading = true
 
 			// copy link to clipboard
 			try {
-				await navigator.clipboard.writeText(url)
+				await navigator.clipboard.writeText(content)
 				this.copySuccess = true
 				this.copied = true
 
 				// Notify success
-				showSuccess(t('collectives', 'Link copied'))
+				showSuccess(t('text', 'Copied to the clipboard'))
 			} catch (error) {
 				this.copySuccess = false
 				this.copied = true
 				showError(
-					`<div>${t('collectives', 'Could not copy link to the clipboard:')}</div><div>${url}</div>`,
+					`<div>${t('text', 'Could not copy to the clipboard')}</div>`,
 					{ isHTML: true })
 			} finally {
 				this.copyLoading = false

--- a/src/nodes/CodeBlockView.vue
+++ b/src/nodes/CodeBlockView.vue
@@ -19,8 +19,7 @@
 				<NcActions v-if="isEditable"
 					data-cy="code-action-group"
 					:aria-label="t('text', 'Code block options')">
-					<NcActionInput
-						:label="t('text', 'Code block language')"
+					<NcActionInput :label="t('text', 'Code block language')"
 						:value="type"
 						:show-trailing-button="false"
 						:placeholder="t('text', 'e.g. php, javascript, json…')"

--- a/src/nodes/CodeBlockView.vue
+++ b/src/nodes/CodeBlockView.vue
@@ -4,6 +4,7 @@
 			<div class="view-switch">
 				<NcActions :aria-label="t('text', 'Copy code block')">
 					<NcActionButton v-if="hasCode"
+						data-cy="copy-code"
 						:aria-label="t('text', 'Copy code')"
 						:close-after-click="false"
 						@click="copyCode">
@@ -15,8 +16,11 @@
 					</NcActionButton>
 				</NcActions>
 
-				<NcActions v-if="isEditable" :aria-label="t('text', 'Code block options')">
-					<NcActionInput :label="t('text', 'Code block language')"
+				<NcActions v-if="isEditable"
+					data-cy="code-action-group"
+					:aria-label="t('text', 'Code block options')">
+					<NcActionInput
+						:label="t('text', 'Code block language')"
 						:value="type"
 						:show-trailing-button="false"
 						:placeholder="t('text', 'e.g. php, javascript, json…')"

--- a/src/nodes/CodeBlockView.vue
+++ b/src/nodes/CodeBlockView.vue
@@ -126,7 +126,7 @@ export default {
 	},
 	computed: {
 		hasCode() {
-			return this.node.textContent
+			return this.node?.textContent
 		},
 		type() {
 			return this.node?.attrs?.language || ''

--- a/src/nodes/CodeBlockView.vue
+++ b/src/nodes/CodeBlockView.vue
@@ -1,8 +1,21 @@
 <template>
 	<NodeViewWrapper as="div" :data-mode="viewMode" class="code-block">
-		<div v-if="isEditable" class="code-block-header">
+		<div class="code-block-header">
 			<div class="view-switch">
-				<NcActions :aria-label="t('text', 'Code block options')">
+				<NcActions :aria-label="t('text', 'Copy code block')">
+					<NcActionButton v-if="hasCode"
+						:aria-label="t('text', 'Copy code')"
+						:close-after-click="false"
+						@click="copyCode">
+						<template #icon>
+							<Check v-if="copySuccess" :size="20" />
+							<NcLoadingIcon v-else-if="copyLoading" :size="20" />
+							<ContentCopy v-else :size="20" />
+						</template>
+					</NcActionButton>
+				</NcActions>
+
+				<NcActions v-if="isEditable" :aria-label="t('text', 'Code block options')">
 					<NcActionInput :label="t('text', 'Code block language')"
 						:value="type"
 						:show-trailing-button="false"
@@ -59,7 +72,7 @@
 <script>
 import debounce from 'debounce'
 import { NodeViewWrapper, NodeViewContent } from '@tiptap/vue-2'
-import { NcActions, NcActionButton, NcActionInput, NcActionLink, NcActionSeparator } from '@nextcloud/vue'
+import { NcActions, NcActionButton, NcActionInput, NcActionLink, NcActionSeparator, NcLoadingIcon } from '@nextcloud/vue'
 import mermaid from 'mermaid'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -68,13 +81,19 @@ import CodeBraces from 'vue-material-design-icons/CodeBraces.vue'
 import Eye from 'vue-material-design-icons/Eye.vue'
 import MarkerIcon from 'vue-material-design-icons/Marker.vue'
 import Help from 'vue-material-design-icons/Help.vue'
+import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
+import Check from 'vue-material-design-icons/Check.vue'
+
+import CopyToClipboardMixin from '../mixins/CopyToClipboardMixin.js'
 
 export default {
 	// eslint-disable-next-line vue/match-component-file-name
 	name: 'CodeBlockView',
 	components: {
 		MarkerIcon,
+		ContentCopy,
 		Help,
+		Check,
 		Eye,
 		ViewSplitVertical,
 		CodeBraces,
@@ -83,9 +102,11 @@ export default {
 		NcActionInput,
 		NcActionLink,
 		NcActionSeparator,
+		NcLoadingIcon,
 		NodeViewWrapper,
 		NodeViewContent,
 	},
+	mixins: [CopyToClipboardMixin],
 	props: {
 		node: {
 			type: Object,
@@ -104,6 +125,9 @@ export default {
 		}
 	},
 	computed: {
+		hasCode() {
+			return this.node.textContent
+		},
 		type() {
 			return this.node?.attrs?.language || ''
 		},
@@ -169,6 +193,9 @@ export default {
 		})
 	},
 	methods: {
+		async copyCode() {
+			await this.copyToClipboard(this.node?.textContent)
+		},
 		updateLanguage(event) {
 			this.updateAttributes({
 				language: event.target.value,
@@ -180,6 +207,7 @@ export default {
 	},
 }
 </script>
+
 <style lang="scss" scoped>
 .code-block {
 	background-color: var(--color-background-dark);


### PR DESCRIPTION
### 📝 Summary

* Resolves: #4750 

This change introduces a code copy button on code blocks in applications that use Text (Notes, Collectives, Tables, ...). The button utilizes a method which was already present in the application for copying links from the link bubble view (src/mixins/CopyToClipboard.js), and makes changes to this function in order to make it more generalized so that it may be used for both purposes. The LinkBubbleView.vue component remains unaffected and should still work normally.

The button only appears when the code block is actually populated with text/code, and in Collectives it will appear in both Preview and Edit mode. I figured even those who do not have edit access may still need/want to copy the content of the code block.

### 🖼️ Screenshots
<details>
<summary>Collectives preview mode</summary>

![grafik](https://github.com/nextcloud/text/assets/23369449/4524f310-4fb8-474d-9eac-df548cb752a9)
</details>

<details>
<summary>Collectives edit mode</summary>
The button makes way for code block options when in Edit mode

![grafik](https://github.com/nextcloud/text/assets/23369449/b2212ea9-9cac-4da4-ab47-b66aa5be6ffa)
</details>

<details>
<summary>Copy toast text</summary>
This text is now displayed when code from a code block or a link from a link bubble view is copied.

![grafik](https://github.com/nextcloud/text/assets/23369449/55175026-9c3f-418b-af79-d5bd601648bc)
</details>


### 🚧 TODO

- [x] ...

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
