### PR TITLE
Enh/preview links

### DIFF
--- a/cypress/e2e/nodes/ListItem.spec.js
+++ b/cypress/e2e/nodes/ListItem.spec.js
@@ -5,11 +5,10 @@ import ListItem from '@tiptap/extension-list-item'
 import TaskList from './../../../src/nodes/TaskList.js'
 import TaskItem from './../../../src/nodes/TaskItem.js'
 import BulletList from './../../../src/nodes/BulletList.js'
-import Markdown, { createMarkdownSerializer } from './../../../src/extensions/Markdown.js'
-import { findChildren } from './../../../src/helpers/prosemirrorUtils.js'
+import Markdown from './../../../src/extensions/Markdown.js'
 import { createCustomEditor } from './../../support/components.js'
 import testData from '../../fixtures/ListItem.md'
-import markdownit from './../../../src/markdownit/index.js'
+import { loadMarkdown, runCommands, expectMarkdown } from './helpers.js'
 
 describe('ListItem extension integrated in the editor', () => {
 
@@ -37,42 +36,9 @@ describe('ListItem extension integrated in the editor', () => {
 			expect(input).to.be.ok
 			expect(output).to.be.ok
 			/* eslint-enable no-unused-expressions */
-			loadMarkdown(input)
-			runCommands()
-			expectMarkdown(output.replace(/\n*$/, ''))
+			loadMarkdown(editor, input)
+			runCommands(editor)
+			expectMarkdown(editor, output.replace(/\n*$/, ''))
 		})
-	}
-
-	const loadMarkdown = (markdown) => {
-		const stripped = markdown.replace(/\t*/g, '')
-		editor.commands.setContent(markdownit.render(stripped))
-	}
-
-	const runCommands = () => {
-		let found
-		while ((found = findCommand())) {
-			const { node, pos } = found
-			const name = node.text
-			editor.commands.setTextSelection(pos)
-			editor.commands[name]()
-			editor.commands.insertContent('did ')
-		}
-	}
-
-	const findCommand = () => {
-		const doc = editor.state.doc
-		return findChildren(doc, child => {
-			return child.isText && Object.prototype.hasOwnProperty.call(editor.commands, child.text)
-		})[0]
-	}
-
-	const expectMarkdown = (markdown) => {
-		const stripped = markdown.replace(/\t*/g, '')
-		expect(getMarkdown()).to.equal(stripped)
-	}
-
-	const getMarkdown = () => {
-		const serializer = createMarkdownSerializer(editor.schema)
-		return serializer.serialize(editor.state.doc)
 	}
 })

--- a/cypress/e2e/nodes/Preview.spec.js
+++ b/cypress/e2e/nodes/Preview.spec.js
@@ -1,0 +1,134 @@
+/**
+ * @copyright Copyright (c) 2024 Max <max@nextcloud.com>
+ *
+ * @author Max <max@nextcloud.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import Markdown from './../../../src/extensions/Markdown.js'
+import Preview from './../../../src/nodes/Preview.js'
+import { Italic, Link } from './../../../src/marks/index.js'
+import { createCustomEditor } from './../../support/components.js'
+import testData from '../../fixtures/Preview.md'
+import { loadMarkdown, runCommands, expectMarkdown } from './helpers.js'
+
+describe.only('Preview extension', { retries: 0 }, () => {
+
+	const editor = createCustomEditor({
+		content: '',
+		extensions: [
+			Markdown,
+			Preview,
+			Link,
+			Italic,
+		],
+	})
+
+	describe('togglePreview command', { retries: 0 }, () => {
+
+		it('is available in commands', () => {
+			expect(editor.commands).to.have.property('togglePreview')
+		})
+
+		it('cannot run on normal paragraph', () => {
+			prepareEditor('hello\n')
+			expect(editor.can().togglePreview()).to.be.false
+		})
+
+		it('cannot run on a paragraph with a different mark', () => {
+			prepareEditor('*link text*\n')
+			expect(editor.can().togglePreview()).to.be.false
+		})
+
+		it('cannot run on a paragraph with a link without a href', () => {
+			prepareEditor('[link text]()\n')
+			expect(editor.can().togglePreview()).to.be.false
+		})
+
+		it('cannot run on a paragraph with an anchor link', () => {
+			prepareEditor('[link text](#top)\n')
+			expect(editor.can().togglePreview()).to.be.false
+		})
+
+		it('cannot run on a paragraph with other content', () => {
+			prepareEditor('[link text](https://nextcloud.com) hello\n')
+			expect(editor.can().togglePreview()).to.be.false
+		})
+
+		it('can run on a paragraph with a link', () => {
+			prepareEditor('[link text](https://nextcloud.com)\n')
+			expect(editor.can().togglePreview()).to.be.true
+		})
+
+		it('results in a preview node with the href', () => {
+			prepareEditor('[link text](https://nextcloud.com)\n')
+			editor.commands.togglePreview()
+			expect(getParentNode().type.name).to.equal('preview')
+			expect(getParentNode().attrs.href).to.equal('https://nextcloud.com')
+		})
+
+		it('reverts when toggled twice', () => {
+			prepareEditor('[link text](https://nextcloud.com)\n')
+			editor.commands.togglePreview()
+			editor.commands.togglePreview()
+			expect(getParentNode().type.name).to.equal('paragraph')
+			expect(getParentNode().attrs.href).to.equal('https://nextcloud.com')
+		})
+
+	})
+
+	function getParentNode() {
+		const { state: { selection } } = editor
+		return selection.$head.parent
+	}
+
+	function prepareEditor(input) {
+		loadMarkdown(editor, input)
+		editor.commands.setTextSelection(1)
+	}
+
+})
+
+describe('Markdown tests for Previews in the editor', { retries: 0 }, () => {
+	const editor = createCustomEditor({
+		content: '',
+		extensions: [
+			Markdown,
+			Preview,
+			Link,
+		],
+	})
+
+	for (const spec of testData.split(/#+\s+/)) {
+		const [description, ...rest] = spec.split(/\n/)
+		const [input, output] = rest.join('\n').split(/\n\n---\n\n/)
+		if (!description) {
+			continue
+		}
+		it(description, () => {
+			expect(spec).to.include('\n')
+			/* eslint-disable no-unused-expressions */
+			expect(input).to.be.ok
+			expect(output).to.be.ok
+			/* eslint-enable no-unused-expressions */
+			loadMarkdown(editor, input)
+			runCommands(editor)
+			expectMarkdown(editor, output.replace(/\n*$/, ''))
+		})
+	}
+})

--- a/cypress/e2e/nodes/Preview.spec.js
+++ b/cypress/e2e/nodes/Preview.spec.js
@@ -75,6 +75,12 @@ describe.only('Preview extension', { retries: 0 }, () => {
 			expect(editor.can().setPreview()).to.be.true
 		})
 
+		it('can run the second a paragraph with a link', () => {
+			prepareEditor('hello\n\n[link text](https://nextcloud.com)\n')
+			editor.commands.setTextSelection(10)
+			expect(editor.can().setPreview()).to.be.true
+		})
+
 		it('results in a preview node with the href and text with link mark', () => {
 			prepareEditor('[link text](https://nextcloud.com)\n')
 			editor.commands.setPreview()

--- a/cypress/e2e/nodes/Preview.spec.js
+++ b/cypress/e2e/nodes/Preview.spec.js
@@ -75,12 +75,12 @@ describe.only('Preview extension', { retries: 0 }, () => {
 			expect(editor.can().setPreview()).to.be.true
 		})
 
-		it('results in a preview node with the href and plain text', () => {
+		it('results in a preview node with the href and text with link mark', () => {
 			prepareEditor('[link text](https://nextcloud.com)\n')
 			editor.commands.setPreview()
 			expect(getParentNode().type.name).to.equal('preview')
 			expect(getParentNode().attrs.href).to.equal('https://nextcloud.com')
-			expect(getMark()).to.be.undefined
+			expect(getMark().attrs.href).to.equal('https://nextcloud.com')
 		})
 
 		it('cannot run twice', () => {

--- a/cypress/e2e/nodes/Preview.spec.js
+++ b/cypress/e2e/nodes/Preview.spec.js
@@ -75,11 +75,12 @@ describe.only('Preview extension', { retries: 0 }, () => {
 			expect(editor.can().setPreview()).to.be.true
 		})
 
-		it('results in a preview node with the href', () => {
+		it('results in a preview node with the href and plain text', () => {
 			prepareEditor('[link text](https://nextcloud.com)\n')
 			editor.commands.setPreview()
 			expect(getParentNode().type.name).to.equal('preview')
 			expect(getParentNode().attrs.href).to.equal('https://nextcloud.com')
+			expect(getMark()).to.be.undefined
 		})
 
 		it('cannot run twice', () => {

--- a/cypress/e2e/nodes/Preview.spec.js
+++ b/cypress/e2e/nodes/Preview.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 /**
  * @copyright Copyright (c) 2024 Max <max@nextcloud.com>
  *
@@ -130,17 +131,27 @@ describe.only('Preview extension', { retries: 0 }, () => {
 
 	})
 
+	/**
+	 *
+	 */
 	function getParentNode() {
 		const { state: { selection } } = editor
 		return selection.$head.parent
 	}
 
+	/**
+	 *
+	 */
 	function getMark() {
 		const { state: { selection } } = editor
 		console.info(selection.$head)
 		return selection.$head.nodeAfter.marks[0]
 	}
 
+	/**
+	 *
+	 * @param input
+	 */
 	function prepareEditor(input) {
 		loadMarkdown(editor, input)
 		editor.commands.setTextSelection(1)

--- a/cypress/e2e/nodes/helpers.js
+++ b/cypress/e2e/nodes/helpers.js
@@ -24,11 +24,20 @@ import markdownit from './../../../src/markdownit/index.js'
 import { findChildren } from './../../../src/helpers/prosemirrorUtils.js'
 import { createMarkdownSerializer } from './../../../src/extensions/Markdown.js'
 
+/**
+ *
+ * @param editor
+ * @param markdown
+ */
 export function loadMarkdown(editor, markdown) {
 	const stripped = markdown.replace(/\t*/g, '')
 	editor.commands.setContent(markdownit.render(stripped))
 }
 
+/**
+ *
+ * @param editor
+ */
 export function runCommands(editor) {
 	let found
 	while ((found = findCommand(editor))) {
@@ -40,18 +49,31 @@ export function runCommands(editor) {
 	}
 }
 
-function findCommand(editor){
+/**
+ *
+ * @param editor
+ */
+function findCommand(editor) {
 	const doc = editor.state.doc
 	return findChildren(doc, child => {
 		return child.isText && Object.prototype.hasOwnProperty.call(editor.commands, child.text)
 	})[0]
 }
 
-export function expectMarkdown(editor, markdown){
+/**
+ *
+ * @param editor
+ * @param markdown
+ */
+export function expectMarkdown(editor, markdown) {
 	const stripped = markdown.replace(/\t*/g, '')
 	expect(getMarkdown(editor)).to.equal(stripped)
 }
 
+/**
+ *
+ * @param editor
+ */
 function getMarkdown(editor) {
 	const serializer = createMarkdownSerializer(editor.schema)
 	return serializer.serialize(editor.state.doc)

--- a/cypress/e2e/nodes/helpers.js
+++ b/cypress/e2e/nodes/helpers.js
@@ -1,0 +1,58 @@
+/**
+ * @copyright Copyright (c) 2024 Max <max@nextcloud.com>
+ *
+ * @author Max <max@nextcloud.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import markdownit from './../../../src/markdownit/index.js'
+import { findChildren } from './../../../src/helpers/prosemirrorUtils.js'
+import { createMarkdownSerializer } from './../../../src/extensions/Markdown.js'
+
+export function loadMarkdown(editor, markdown) {
+	const stripped = markdown.replace(/\t*/g, '')
+	editor.commands.setContent(markdownit.render(stripped))
+}
+
+export function runCommands(editor) {
+	let found
+	while ((found = findCommand(editor))) {
+		const { node, pos } = found
+		const name = node.text
+		editor.commands.setTextSelection(pos)
+		editor.commands[name]()
+		editor.commands.insertContent('did ')
+	}
+}
+
+function findCommand(editor){
+	const doc = editor.state.doc
+	return findChildren(doc, child => {
+		return child.isText && Object.prototype.hasOwnProperty.call(editor.commands, child.text)
+	})[0]
+}
+
+export function expectMarkdown(editor, markdown){
+	const stripped = markdown.replace(/\t*/g, '')
+	expect(getMarkdown(editor)).to.equal(stripped)
+}
+
+function getMarkdown(editor) {
+	const serializer = createMarkdownSerializer(editor.schema)
+	return serializer.serialize(editor.state.doc)
+}

--- a/cypress/fixtures/Preview.md
+++ b/cypress/fixtures/Preview.md
@@ -14,10 +14,10 @@ empty
 
 [link text](https://nextcloud.com)
 
-## Preserves a preview 
+## Converts a link into a preview 
 
-[link text](https://nextcloud.com (Preview))
+[setPreviewENDLESS LOOP!](https://nextcloud.com (Preview))
 
 ---
 
-[link text](https://nextcloud.com (Preview))
+[did setPreview](https://nextcloud.com (Preview))

--- a/cypress/fixtures/Preview.md
+++ b/cypress/fixtures/Preview.md
@@ -14,10 +14,10 @@ empty
 
 [link text](https://nextcloud.com)
 
-## Converts a link into a preview 
+## Preserves a link preview
 
-[setPreviewENDLESS LOOP!](https://nextcloud.com (Preview))
+[link text](https://nextcloud.com (Preview))
 
 ---
 
-[did setPreview](https://nextcloud.com (Preview))
+[link text](https://nextcloud.com (Preview))

--- a/cypress/fixtures/Preview.md
+++ b/cypress/fixtures/Preview.md
@@ -1,0 +1,23 @@
+## Runs a spec
+
+empty
+
+---
+
+empty
+
+## Preserves a link
+
+[link text](https://nextcloud.com)
+
+---
+
+[link text](https://nextcloud.com)
+
+## Preserves a preview 
+
+[link text](https://nextcloud.com (Preview))
+
+---
+
+[link text](https://nextcloud.com (Preview))

--- a/sample.md
+++ b/sample.md
@@ -1,0 +1,2 @@
+[Test me](https://www.nextcloud.com (preview))
+

--- a/src/components/Editor/PreviewOptions.vue
+++ b/src/components/Editor/PreviewOptions.vue
@@ -50,17 +50,17 @@ import DotsVerticalIcon from 'vue-material-design-icons/DotsVertical.vue'
 
 export default {
 	name: 'PreviewOptions',
-	props: {
-		value: {
-			type: String,
-			required: true,
-		},
-	},
 	components: {
 		DotsVerticalIcon,
 		NcActions,
 		NcActionCaption,
 		NcActionRadio,
+	},
+	props: {
+		value: {
+			type: String,
+			required: true,
+		},
 	},
 }
 </script>

--- a/src/components/Editor/PreviewOptions.vue
+++ b/src/components/Editor/PreviewOptions.vue
@@ -1,0 +1,75 @@
+<!--
+  - @copyright Copyright (c) 2024 Max Wiehle <max@nextcloud.com>
+  -
+  - @author Max <max@nextcloud.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+<template>
+	<NcActions data-text-preview-options="select">
+		<template #icon>
+			<DotsVerticalIcon :size="20" />
+		</template>
+		<NcActionCaption :name="t('text', 'Preview options')" />
+		<NcActionRadio data-text-preview-option="text-only"
+			close-after-click
+			name="preview-option"
+			value="text-only"
+			:checked="value === 'text-only'"
+			@change="e => $emit('update:value', e.currentTarget.value)">
+			{{ t('text', 'Text only') }}
+		</NcActionRadio>
+		<NcActionRadio data-text-preview-option="link-preview"
+			close-after-click
+			name="preview-option"
+			value="link-preview"
+			:checked="value === 'link-preview'"
+			@change="e => $emit('update:value', e.currentTarget.value)">
+			{{ t('text', 'Show link preview') }}
+		</NcActionRadio>
+	</NcActions>
+</template>
+
+<script>
+import { NcActions, NcActionRadio, NcActionCaption } from '@nextcloud/vue'
+import DotsVerticalIcon from 'vue-material-design-icons/DotsVertical.vue'
+
+export default {
+	name: 'PreviewOptions',
+	props: {
+		value: {
+			type: String,
+			required: true,
+		},
+	},
+	components: {
+		DotsVerticalIcon,
+		NcActions,
+		NcActionCaption,
+		NcActionRadio,
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+
+[data-text-preview-options] {
+	position: absolute;
+	left: -44px;
+}
+
+</style>

--- a/src/extensions/LinkBubblePluginView.js
+++ b/src/extensions/LinkBubblePluginView.js
@@ -195,6 +195,12 @@ class LinkBubblePluginView {
 		const to = Math.max(...ranges.map(range => range.$to.pos))
 
 		const resolved = view.state.doc.resolve(from)
+
+		// ignore links in previews
+		if (resolved.parent.type.name === 'preview') {
+			return false
+		}
+
 		const node = resolved.parent.maybeChild(resolved.index())
 		const nodeStart = resolved.pos - resolved.textOffset
 		const nodeEnd = nodeStart + node?.nodeSize

--- a/src/extensions/RichText.js
+++ b/src/extensions/RichText.js
@@ -26,7 +26,7 @@ import { lowlight } from 'lowlight'
 /* eslint-disable import/no-named-as-default */
 import Blockquote from '@tiptap/extension-blockquote'
 import BulletList from './../nodes/BulletList.js'
-import Callout from './../nodes/Callouts.js'
+import Callouts from './../nodes/Callouts.js'
 import CharacterCount from '@tiptap/extension-character-count'
 import Code from '@tiptap/extension-code'
 import CodeBlock from './../nodes/CodeBlock.js'
@@ -51,6 +51,7 @@ import Mention from './../extensions/Mention.js'
 import OrderedList from '@tiptap/extension-ordered-list'
 import Paragraph from './../nodes/Paragraph.js'
 import Placeholder from '@tiptap/extension-placeholder'
+import Preview from './../nodes/Preview.js'
 import Table from './../nodes/Table.js'
 import TaskItem from './../nodes/TaskItem.js'
 import TaskList from './../nodes/TaskList.js'
@@ -100,7 +101,8 @@ export default Extension.create({
 			this.options.editing ? EditableTable : Table,
 			TaskList,
 			TaskItem,
-			Callout,
+			Callouts,
+			Preview,
 			Underline,
 			Image,
 			ImageInline,

--- a/src/helpers/links.js
+++ b/src/helpers/links.js
@@ -28,7 +28,7 @@ const domHref = function(node, relativePath) {
 	if (!ref) {
 		return ref
 	}
-	if (!OCA.Viewer) {
+	if (!window.OCA?.Viewer) {
 		return ref
 	}
 	if (ref.match(/^[a-zA-Z]*:/)) {

--- a/src/markdownit/index.js
+++ b/src/markdownit/index.js
@@ -4,6 +4,7 @@ import markdownitMentions from '@quartzy/markdown-it-mentions'
 import underline from './underline.js'
 import splitMixedLists from './splitMixedLists.js'
 import callouts from './callouts.js'
+import preview from './preview.js'
 import hardbreak from './hardbreak.js'
 import keepSyntax from './keepSyntax.js'
 import frontMatter from 'markdown-it-front-matter'
@@ -15,10 +16,11 @@ const markdownit = MarkdownIt('commonmark', { html: false, breaks: false })
 	.enable('table')
 	.use(taskLists, { enable: true, labelAfter: true })
 	.use(frontMatter, (fm) => {})
-	.use(splitMixedLists)
+	.use(splitMixedLists) // needs task Lists to be used first.
 	.use(underline)
 	.use(hardbreak)
 	.use(callouts)
+	.use(preview)
 	.use(keepSyntax)
 	.use(markdownitMentions)
 	.use(implicitFigures)

--- a/src/markdownit/preview.js
+++ b/src/markdownit/preview.js
@@ -1,0 +1,62 @@
+/**
+ * @copyright Copyright (c) 2024 Max <max@nextcloud.com>
+ *
+ * @author Max <max@nextcloud.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+function isPreviewLinkInParagraph(tokens, i) {
+	const [prev, cur, next] = tokens.slice(i-1, i+2)
+	return prev.type === 'paragraph_open'
+		&& cur.type === 'inline'
+		&& cur.children
+		&& cur.children.length === 3
+		&& cur.children[0].type === 'link_open'
+		&& cur.children[0].attrGet('title') === 'preview'
+		&& cur.children[1].type === 'text'
+		&& cur.children[2].type === 'link_close'
+		&& next.type === 'paragraph_close'
+}
+
+/* Remove wrapping tokens
+ *
+ * @param {array} tokens - the token stream to modify
+ * @param {Number} i - index of the token to unwrap
+ */
+function unwrapToken(tokens, i) {
+	// Start from the end so indexes stay the same.
+	tokens.splice(i+1, 1)
+	tokens.splice(i-1, 1)
+}
+
+/**
+ * @param {object} md Markdown object
+ */
+export default (md) => {
+
+	function linkPreviews({ tokens }) {
+		// do not process first and last token
+		for (let i = 1, l = tokens.length; i < (l - 1); ++i) {
+			if (isPreviewLinkInParagraph(tokens, i)) {
+				unwrapToken(tokens, i)
+			}
+		}
+	}
+
+	md.core.ruler.before('linkify', 'link_previews', linkPreviews);
+}

--- a/src/markdownit/preview.js
+++ b/src/markdownit/preview.js
@@ -20,8 +20,13 @@
  *
  */
 
+/**
+ *
+ * @param tokens
+ * @param i
+ */
 function isPreviewLinkInParagraph(tokens, i) {
-	const [prev, cur, next] = tokens.slice(i-1, i+2)
+	const [prev, cur, next] = tokens.slice(i - 1, i + 2)
 	return prev.type === 'paragraph_open'
 		&& cur.type === 'inline'
 		&& cur.children
@@ -38,10 +43,15 @@ function isPreviewLinkInParagraph(tokens, i) {
  * @param {array} tokens - the token stream to modify
  * @param {Number} i - index of the token to unwrap
  */
+/**
+ *
+ * @param tokens
+ * @param i
+ */
 function unwrapToken(tokens, i) {
 	// Start from the end so indexes stay the same.
-	tokens.splice(i+1, 1)
-	tokens.splice(i-1, 1)
+	tokens.splice(i + 1, 1)
+	tokens.splice(i - 1, 1)
 }
 
 /**
@@ -49,6 +59,11 @@ function unwrapToken(tokens, i) {
  */
 export default (md) => {
 
+	/**
+	 *
+	 * @param root0
+	 * @param root0.tokens
+	 */
 	function linkPreviews({ tokens }) {
 		// do not process first and last token
 		for (let i = 1, l = tokens.length; i < (l - 1); ++i) {
@@ -58,5 +73,5 @@ export default (md) => {
 		}
 	}
 
-	md.core.ruler.before('linkify', 'link_previews', linkPreviews);
+	md.core.ruler.before('linkify', 'link_previews', linkPreviews)
 }

--- a/src/marks/Link.js
+++ b/src/marks/Link.js
@@ -58,7 +58,6 @@ const Link = TipTapLink.extend({
 
 	renderHTML(options) {
 		const { mark } = options
-
 		return ['a', {
 			...mark.attrs,
 			href: domHref(mark, this.options.relativePath),

--- a/src/nodes/ParagraphView.vue
+++ b/src/nodes/ParagraphView.vue
@@ -79,7 +79,7 @@ export default {
 			console.info(...args)
 			this.$editor.chain()
 				.focus()
-				.setTextSelection(this.getPos())
+				.setTextSelection(this.getPos() + 1)
 				.setPreview()
 				.run()
 		},

--- a/src/nodes/ParagraphView.vue
+++ b/src/nodes/ParagraphView.vue
@@ -43,6 +43,7 @@ export default {
 		NodeViewContent,
 		PreviewOptions,
 	},
+	mixins: [useEditorMixin],
 	props: nodeViewProps,
 	data() {
 		return {
@@ -51,7 +52,6 @@ export default {
 			value: 'text-only',
 		}
 	},
-	mixins: [ useEditorMixin ],
 	watch: {
 		node: {
 			handler(newNode) {

--- a/src/nodes/ParagraphView.vue
+++ b/src/nodes/ParagraphView.vue
@@ -80,7 +80,7 @@ export default {
 			this.$editor.chain()
 				.focus()
 				.setTextSelection(this.getPos())
-				.setPreview({ href: this.href })
+				.setPreview()
 				.run()
 		},
 		getTextReference(node) {

--- a/src/nodes/ParagraphView.vue
+++ b/src/nodes/ParagraphView.vue
@@ -22,19 +22,18 @@
 
 <template>
 	<NodeViewWrapper class="vue-component" as="p">
+		<PreviewOptions v-if="editor.isEditable && href"
+			:value.sync="value"
+			@update:value="convertToPreview" />
 		<NodeViewContent class="paragraph-content" />
-		<NcReferenceList v-if="isLoggedIn && text"
-			:text="text"
-			:limit="1"
-			:interactive="true"
-			contenteditable="false" />
 	</NodeViewWrapper>
 </template>
 
 <script>
 import { NodeViewContent, nodeViewProps, NodeViewWrapper } from '@tiptap/vue-2'
+import PreviewOptions from '../components/Editor/PreviewOptions.vue'
+import { useEditorMixin } from '../components/Editor.provider.js'
 import { getCurrentUser } from '@nextcloud/auth'
-import { NcReferenceList } from '@nextcloud/vue/dist/Components/NcRichText.js'
 import debounce from 'debounce'
 
 export default {
@@ -42,20 +41,22 @@ export default {
 	components: {
 		NodeViewWrapper,
 		NodeViewContent,
-		NcReferenceList,
+		PreviewOptions,
 	},
 	props: nodeViewProps,
 	data() {
 		return {
-			text: null,
+			href: null,
 			isLoggedIn: getCurrentUser(),
+			value: 'text-only',
 		}
 	},
+	mixins: [ useEditorMixin ],
 	watch: {
 		node: {
 			handler(newNode) {
 				if (!newNode?.textContent) {
-					this.text = ''
+					this.href = ''
 					return
 				}
 				this.debouncedUpdateText(newNode)
@@ -64,16 +65,24 @@ export default {
 	},
 	beforeCreate() {
 		this.debouncedUpdateText = debounce((newNode) => {
-			this.text = this.getTextReference(this.node)
+			this.href = this.getTextReference(this.node)
 		}, 500)
 	},
 	created() {
-		this.text = this.getTextReference(this.node)
+		this.href = this.getTextReference(this.node)
 	},
 	beforeUnmount() {
 		this.debouncedUpdateText?.cancel()
 	},
 	methods: {
+		convertToPreview(...args) {
+			console.info(...args)
+			this.$editor.chain()
+				.focus()
+				.setTextSelection(this.getPos())
+				.togglePreview({ href: this.href })
+				.run()
+		},
 		getTextReference(node) {
 			if (!node?.childCount) {
 				return null
@@ -117,17 +126,15 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-:deep(div.widgets--list a.widget-default) {
-	color: var(--color-main-text);
-	padding: 0;
-	text-decoration: none;
-	max-width: calc(100vw - 56px);
+
+.vue-component {
+	position: relative;
 }
 
-:deep(.widget-default--details) {
-	overflow:hidden;
-	p {
-		margin-bottom: 4px !important;
-	}
+/* center around current line */
+:deep([data-text-preview-options]) {
+	top: 50%;
+	transform: translate(0, -50%);
 }
+
 </style>

--- a/src/nodes/ParagraphView.vue
+++ b/src/nodes/ParagraphView.vue
@@ -80,7 +80,7 @@ export default {
 			this.$editor.chain()
 				.focus()
 				.setTextSelection(this.getPos())
-				.togglePreview({ href: this.href })
+				.setPreview({ href: this.href })
 				.run()
 		},
 		getTextReference(node) {

--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -85,11 +85,10 @@ export default Node.create({
 			 *
 			 */
 			setPreview: () => ({ state, commands }) => {
-				const { selection } = state
-				return previewPossible(selection)
+				return previewPossible(state)
 					&& commands.setNode(
 						this.name,
-						previewAttributesFromSelection(selection),
+						previewAttributesFromSelection(state),
 					)
 			},
 
@@ -99,7 +98,6 @@ export default Node.create({
 			 *
 			 */
 			unsetPreview: () => ({ state, chain }) => {
-				const { selection } = state
 				return isPreview(this.name, this.attributes, state)
 					&& chain()
 						.setNode('paragraph')
@@ -111,7 +109,8 @@ export default Node.create({
 	},
 })
 
-function previewAttributesFromSelection({ $from }) {
+function previewAttributesFromSelection({ selection }) {
+	const { $from } = selection
 	const href = extractHref($from.nodeAfter)
 	return { href, title: 'preview' }
 }
@@ -121,7 +120,8 @@ function isPreview(typeOrName, attributes, state) {
 	return isNodeActive(state, type, attributes)
 }
 
-function previewPossible({ $from }) {
+function previewPossible({ selection }) {
+	const { $from } = selection
 	if (childCount($from.parent) > 1) {
 		return false
 	}

--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -108,17 +108,33 @@ export default Node.create({
 	},
 })
 
+/**
+ *
+ * @param root0
+ * @param root0.selection
+ */
 function previewAttributesFromSelection({ selection }) {
 	const { $from } = selection
 	const href = extractHref($from.nodeAfter)
 	return { href, title: 'preview' }
 }
 
+/**
+ *
+ * @param typeOrName
+ * @param attributes
+ * @param state
+ */
 function isPreview(typeOrName, attributes, state) {
 	const type = getNodeType(typeOrName, state.schema)
 	return isNodeActive(state, type, attributes)
 }
 
+/**
+ *
+ * @param root0
+ * @param root0.selection
+ */
 function previewPossible({ selection }) {
 	const { $from } = selection
 	if (childCount($from.parent) > 1) {
@@ -131,11 +147,19 @@ function previewPossible({ selection }) {
 	return true
 }
 
+/**
+ *
+ * @param node
+ */
 function extractHref(node) {
 	const link = node.marks.find(mark => mark.type.name === 'link')
 	return link?.attrs.href
 }
 
+/**
+ *
+ * @param node
+ */
 function childCount(node) {
 	return node.content.content.length
 }

--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -84,12 +84,12 @@ export default Node.create({
 			 * into a preview.
 			 *
 			 */
-			setPreview: () => ({ state, commands }) => {
+			setPreview: () => ({ state, chain }) => {
 				return previewPossible(state)
-					&& commands.setNode(
-						this.name,
-						previewAttributesFromSelection(state),
-					)
+					&& chain()
+						.unsetLink()
+						.setNode(this.name, previewAttributesFromSelection(state))
+						.run()
 			},
 
 			/**
@@ -98,6 +98,7 @@ export default Node.create({
 			 *
 			 */
 			unsetPreview: () => ({ state, chain }) => {
+				console.info(this.attributes)
 				return isPreview(this.name, this.attributes, state)
 					&& chain()
 						.setNode('paragraph')

--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -1,0 +1,91 @@
+/*
+ * @copyright Copyright (c) 2022 Vinicius Reis <vinicius@nextcloud.com>
+ *
+ * @author Vinicius Reis <vinicius@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { Node, isNodeActive } from '@tiptap/core'
+import { domHref, parseHref } from './../helpers/links.js'
+import { VueNodeViewRenderer } from '@tiptap/vue-2'
+
+import Preview from './Preview.vue'
+
+export default Node.create({
+
+	name: 'preview',
+
+	group: 'block',
+
+	content: 'text?',
+
+	defining: true,
+
+	addOptions() {
+		return {
+			relativePath: null,
+		}
+	},
+
+	addAttributes() {
+		return {
+			href: { parseHTML: parseHref },
+			title: { parseHTML: el => el.getAttribute('title') },
+		}
+	},
+
+	parseHTML() {
+		return [
+			{
+				tag: 'a[title="preview"]',
+				priority: 1001,
+			},
+		]
+	},
+
+	renderHTML({ node }) {
+		return ['a', {
+			...node.attrs,
+			href: domHref(node, this.options.relativePath),
+			rel: 'noopener noreferrer nofollow',
+		}, 0]
+	},
+
+	addNodeView() {
+		return VueNodeViewRenderer(Preview)
+	},
+
+	toMarkdown: (state, node) => {
+		state.write(`[`)
+		state.text(node.textContent, false)
+		state.write(`](${node.attrs.href} (${node.attrs.title}))`)
+	},
+
+	addCommands() {
+		return {
+			setPreview: attrs => ({ commands }) => {
+				const attributes = { ...attrs, title: 'preview' }
+				return commands.setNode(this.name, attributes)
+			},
+			togglePreview: attrs => ({ commands }) => {
+				const attributes = { ...attrs, title: 'preview' }
+				return commands.toggleNode(this.name, 'paragraph', attributes)
+			},
+		}
+	},
+})

--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -87,7 +87,6 @@ export default Node.create({
 			setPreview: () => ({ state, chain }) => {
 				return previewPossible(state)
 					&& chain()
-						.unsetLink()
 						.setNode(this.name, previewAttributesFromSelection(state))
 						.run()
 			},
@@ -102,7 +101,6 @@ export default Node.create({
 				return isPreview(this.name, this.attributes, state)
 					&& chain()
 						.setNode('paragraph')
-						.setLink(this.attributes)
 						.run()
 			},
 

--- a/src/nodes/Preview.vue
+++ b/src/nodes/Preview.vue
@@ -1,0 +1,96 @@
+<!--
+  - @copyright Copyright (c) 2024 Max <max@nextcloud.com>
+  -
+  - @author Max <max@nextcloud.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+<template>
+	<NodeViewWrapper data-text-el="preview"
+		class="preview"
+		as="div"
+		contenteditable="false">
+		<NodeViewContent style="display:none" />
+		<PreviewOptions v-if="editor.isEditable"
+			:value.sync="value"
+			@update:value="convertToParagraph" />
+		<NcReferenceList :text="node.attrs.href"
+			:limit="1" />
+	</NodeViewWrapper>
+</template>
+
+<script>
+import { nodeViewProps, NodeViewWrapper, NodeViewContent } from '@tiptap/vue-2'
+import { NcReferenceList } from '@nextcloud/vue/dist/Components/NcRichText.js'
+import PreviewOptions from '../components/Editor/PreviewOptions.vue'
+
+export default {
+	name: 'Preview',
+	components: {
+		NodeViewWrapper,
+		NodeViewContent,
+		NcReferenceList,
+		PreviewOptions,
+	},
+	props: nodeViewProps,
+	data() {
+		return {
+			value: 'link-preview',
+		}
+	},
+	methods: {
+		convertToParagraph(...args) {
+			console.info(...args)
+			this.$editor.chain()
+				.focus()
+				.setTextSelection(this.getPos())
+				.setNode('paragaph')
+				.run()
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+
+.preview {
+	position: relative;
+}
+
+:deep(div.widgets--list a.widget-default) {
+	color: var(--color-main-text);
+	padding: 0;
+	text-decoration: none;
+	max-width: calc(100vw - 156px);
+}
+
+:deep(.widget-default--details) {
+	overflow:hidden;
+	p {
+		margin-bottom: 4px !important;
+	}
+}
+
+/* Top align with preview image:
+ * 7px .preview padding
+ * + widget margin-top
+ */
+:deep([data-text-preview-options]) {
+	top: calc(7px + var(--default-grid-baseline, 4px) * 3);
+}
+
+</style>

--- a/src/nodes/Preview.vue
+++ b/src/nodes/Preview.vue
@@ -59,7 +59,7 @@ export default {
 			console.info(...args)
 			this.$editor.chain()
 				.focus()
-				.setTextSelection(this.getPos())
+				.setTextSelection(this.getPos() + 1)
 				.unsetPreview()
 				.run()
 		},

--- a/src/nodes/Preview.vue
+++ b/src/nodes/Preview.vue
@@ -37,6 +37,7 @@
 import { nodeViewProps, NodeViewWrapper, NodeViewContent } from '@tiptap/vue-2'
 import { NcReferenceList } from '@nextcloud/vue/dist/Components/NcRichText.js'
 import PreviewOptions from '../components/Editor/PreviewOptions.vue'
+import { useEditorMixin } from '../components/Editor.provider.js'
 
 export default {
 	name: 'Preview',
@@ -52,13 +53,14 @@ export default {
 			value: 'link-preview',
 		}
 	},
+	mixins: [ useEditorMixin ],
 	methods: {
 		convertToParagraph(...args) {
 			console.info(...args)
 			this.$editor.chain()
 				.focus()
 				.setTextSelection(this.getPos())
-				.setNode('paragaph')
+				.unsetPreview()
 				.run()
 		},
 	},

--- a/src/nodes/Preview.vue
+++ b/src/nodes/Preview.vue
@@ -47,13 +47,13 @@ export default {
 		NcReferenceList,
 		PreviewOptions,
 	},
+	mixins: [useEditorMixin],
 	props: nodeViewProps,
 	data() {
 		return {
 			value: 'link-preview',
 		}
 	},
-	mixins: [ useEditorMixin ],
 	methods: {
 		convertToParagraph(...args) {
 			console.info(...args)

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -103,6 +103,16 @@ describe('Markdown though editor', () => {
 		})
 	})
 
+	test('preview with url only', () => {
+		const entry = '::: preview\nhttps://nextcloud.com\n\n:::'
+		expect(markdownThroughEditor(entry)).toBe(entry)
+	})
+
+	test('preview with text', () => {
+		const entry = '::: preview\n[text](https://nextcloud.com)\n\n:::'
+		expect(markdownThroughEditor(entry)).toBe(entry)
+	})
+
 	test('front matter', () => {
 		expect(markdownThroughEditor('---\nhello: world\n---')).toBe('---\nhello: world\n---')
 		expect(markdownThroughEditor('---\n---')).toBe('---\n---')

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -104,12 +104,12 @@ describe('Markdown though editor', () => {
 	})
 
 	test('preview with url only', () => {
-		const entry = '::: preview\nhttps://nextcloud.com\n\n:::'
+		const entry = '[https://nextcloud.com](https://nextcloud.com (preview))'
 		expect(markdownThroughEditor(entry)).toBe(entry)
 	})
 
 	test('preview with text', () => {
-		const entry = '::: preview\n[text](https://nextcloud.com)\n\n:::'
+		const entry = '[some other text](https://nextcloud.com (preview))'
 		expect(markdownThroughEditor(entry)).toBe(entry)
 	})
 

--- a/src/tests/markdownit/preview.spec.js
+++ b/src/tests/markdownit/preview.spec.js
@@ -1,0 +1,63 @@
+/**
+ * @copyright Copyright (c) 2024 Max <max@nextcloud.com>
+ *
+ * @author Max <max@nextcloud.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import markdownit from '../../markdownit'
+import stripIndent from './stripIndent.js'
+
+describe('Preview extension', () => {
+
+	const link = {
+		md: `[link](https://nextcloud.com)`,
+		html: `<a href="https://nextcloud.com">link</a>`,
+	}
+	const preview = {
+		md: `[link](https://nextcloud.com (preview))`,
+		html: `<a href="https://nextcloud.com" title="preview">link</a>`,
+	}
+
+	it('wraps', () => {
+		expect(markdownit.render('[link](https://nextcloud.com)'))
+			.toBe(
+			`<p><a href="https://nextcloud.com">link</a></p>\n`
+			)
+	})
+
+	it(`unwraps preview from paragraph`, () => {
+		const rendered = markdownit.render(preview.md)
+		expect(rendered).toBe(preview.html)
+	})
+
+	it(`leaves non-preview links alone`, () => {
+		const rendered = markdownit.render(link.md)
+		expect(rendered).toBe(
+			`<p>${link.html}</p>\n`
+		)
+	})
+
+	it(`leaves two previews in one paragraph`, () => {
+		const rendered = markdownit.render(`${preview.md}\n${preview.md}`)
+		expect(rendered).toBe(
+			`<p>${preview.html}\n${preview.html}</p>\n`
+		)
+	})
+
+})

--- a/src/tests/nodes/Preview.spec.js
+++ b/src/tests/nodes/Preview.spec.js
@@ -1,0 +1,45 @@
+import Preview from './../../nodes/Preview'
+import Markdown from './../../extensions/Markdown'
+import { getExtensionField } from '@tiptap/core'
+import { createCustomEditor, markdownThroughEditor, markdownThroughEditorHtml } from '../helpers'
+import markdownit from '../../markdownit/index.js'
+
+describe('Preview extension', () => {
+	it('exposes toMarkdown function', () => {
+		const toMarkdown = getExtensionField(Preview, 'toMarkdown', Preview)
+		expect(typeof toMarkdown).toEqual('function')
+	})
+
+	it('exposes the toMarkdown function in the prosemirror schema', () => {
+		const editor = createCustomEditor({
+			extensions: [Markdown, Preview]
+		})
+		const preview = editor.schema.nodes.preview
+		expect(preview.spec.toMarkdown).toBeDefined()
+	})
+
+	it('markdown syntax is preserved through editor', () => {
+		const markdown = `[link](https://nextcloud.com (preview))`
+		expect(markdownThroughEditor(markdown)).toBe(markdown)
+	})
+
+	it('serializes HTML to markdown', () => {
+		const markdown = `[link](https://nextcloud.com (preview))`
+		const link = `<a href="https://nextcloud.com" title="preview">link</a>`
+		expect(markdownThroughEditorHtml(link))
+			.toBe(markdown)
+	})
+
+	it('detects links', () => {
+		const link = `<a href="https://nextcloud.com" title="preview">link</a>`
+		const editor = createCustomEditor({
+			extensions: [Markdown, Preview]
+		})
+		editor.commands.setContent(`${link}<p>hello></p>`)
+		const node = editor.state.doc.content.firstChild
+		expect(node.type.name).toBe('preview')
+		expect(node.attrs.title).toBe('preview')
+		expect(node.attrs.href).toBe('https://nextcloud.com')
+	})
+
+})


### PR DESCRIPTION
### 📝 Summary

* Resolves: #5270 


#### 🖼️ Screenshots (wip)

[Bildschirmaufzeichnung vom 20.02.2024, 12:23:34.webm](https://github.com/nextcloud/text/assets/97337118/c6180bf3-b551-4e96-8b7a-d03687940aa5)


### 🚧 TODO

- [x] allow turning the preview back into a link
- [x] make it work on more than the first line
- [x] squash commits in meaningful way.
- [ ] allow converting a link followed by whitespace into a preview
- [ ] fix backspace when cursor is right after the preview
- [ ] close bubble when opening menu
- [ ] close menu when opening bubble
- [ ] edit link target from menu

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
