### PR TITLE
fix(link): Don't rewrite links with fileId inside Collectives

### DIFF
--- a/src/helpers/links.js
+++ b/src/helpers/links.js
@@ -20,6 +20,7 @@
  *
  */
 
+import { loadState } from '@nextcloud/initial-state'
 import { generateUrl } from '@nextcloud/router'
 
 const absolutePath = function(base, rel) {
@@ -59,6 +60,10 @@ const domHref = function(node, relativePath) {
 		return ref
 	}
 	if (ref.startsWith('#')) {
+		return ref
+	}
+	// Don't rewrite URL in Collectives context
+	if (loadState('core', 'active-app') === 'collectives') {
 		return ref
 	}
 

--- a/src/tests/helpers/links.spec.js
+++ b/src/tests/helpers/links.spec.js
@@ -1,4 +1,5 @@
 import { domHref, parseHref } from '../../helpers/links'
+import { loadState } from '@nextcloud/initial-state'
 
 global.OCA = {
 	Viewer: {
@@ -11,6 +12,9 @@ global.OC = {
 }
 
 global._oc_webroot = ''
+
+jest.mock('@nextcloud/initial-state')
+loadState.mockImplementation((app, key) => 'files')
 
 describe('Preparing href attributes for the DOM', () => {
 
@@ -102,4 +106,15 @@ describe('Inserting hrefs into the dom and extracting them again', () => {
 			.toBe('otherfile?fileId=123')
 	})
 
+})
+
+describe('Preparing href attributes for the DOM in Collectives app', () => {
+	beforeAll(() => {
+		loadState.mockImplementation((app, key) => 'collectives')
+	})
+
+	test('relative link with fileid in Collectives', () => {
+		expect(domHref({attrs: {href: 'otherfile?fileId=123'}}))
+			.toBe('otherfile?fileId=123')
+	})
 })


### PR DESCRIPTION
Required to allow relative links (and those without origin) to other collectives pages to be resolved by link previews.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits