### PR TITLE
fix(viewer): share Vue constructor from Viewer

### DIFF
--- a/src/ViewerVue.js
+++ b/src/ViewerVue.js
@@ -1,0 +1,16 @@
+/**
+ * @type {import('Vue').VueConstructor|null}
+ */
+let ViewerVue = null
+
+/**
+ * @param {import('Vue').VueConstructor} VueConstructor - Vue constructor from Viewer
+ */
+export const setViewerVue = (VueConstructor) => {
+	ViewerVue = VueConstructor
+}
+
+/**
+ * @return {import('Vue').VueConstructor|null}
+ */
+export const getViewerVue = () => ViewerVue

--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -45,6 +45,8 @@ import RichTextReader from './RichTextReader.vue'
 import { getSharingToken } from '../helpers/token.js'
 import getEditorInstance from './Editor.singleton.js'
 
+import { setViewerVue } from '../ViewerVue.js'
+
 export default {
 	name: 'ViewerComponent',
 	components: {
@@ -111,6 +113,14 @@ export default {
 		source() {
 			this.loadFileContent()
 		},
+	},
+
+	beforeCreate() {
+		// This component is rendered in the Viewer app
+		// Get Vue constructor from the Viewer app
+		// To reuse later as Vue constructor and not mix Text's Vue constructor and Viewer's Vue constructor in a single Virtual DOM
+		// Which is not fully supported by Vue
+		setViewerVue(this.$options._base)
 	},
 
 	mounted() {

--- a/src/extensions/LinkBubblePluginView.js
+++ b/src/extensions/LinkBubblePluginView.js
@@ -3,6 +3,8 @@ import tippy from 'tippy.js'
 import { domHref } from '../helpers/links.js'
 import LinkBubbleView from '../components/Link/LinkBubbleView.vue'
 
+import { getViewerVue } from '../ViewerVue.js'
+
 const updateDelay = 250
 
 class LinkBubblePluginView {
@@ -16,7 +18,11 @@ class LinkBubblePluginView {
 		this.editor = editor
 		this.view = view
 
-		this.#component = new VueRenderer(LinkBubbleView, {
+		// When editor is used in Viewer component, it should render comopnent using Viewer's Vue constructor,
+		// Otherwise there are VNodes with different Vue constructors in a single Virtual DOM which is not fully supported by Vue
+		const ViewerVue = getViewerVue()
+		const LinkBubbleViewConstructor = ViewerVue ? ViewerVue.extend(LinkBubbleView) : LinkBubbleView
+		this.#component = new VueRenderer(LinkBubbleViewConstructor, {
 			parent: this.editor.contentComponent,
 			propsData: {
 				editor: this.editor,


### PR DESCRIPTION
### 📝 Summary

* Resolves: https://github.com/nextcloud/text/issues/5392

Briefly: `<ViewerComponent>` from Text is rendered in Viewer's so everything that it uses must use the same Vue constructor as Viewer. Otherwise, there is a mix of Viewer's Vue constructor and Text's one in a single Virtual DOM, which is not fully supported by Vue.

More details: https://github.com/nextcloud-libraries/nextcloud-vue/issues/5267#issuecomment-1955229436

I don't know much about `tiptap`. Probably there is a cleaner way to provide Vue constructor to the plugin than using shared `src/ViewerVue.js`.

Also, the best to use this everywhere instead of `import Vue from 'vue'` in modules that can be used in Viewer.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
