### PR TITLE
fix(links): Insert `/f/<fileId>` format for links to files

### DIFF
--- a/cypress/e2e/nodes/Links.spec.js
+++ b/cypress/e2e/nodes/Links.spec.js
@@ -181,13 +181,18 @@ describe('test link marks', function() {
 				})
 
 				return cy.getContent()
-					.find(`a[href*="${encodeURIComponent(filename)}"]`)
+					.find(`a[href*="/index.php/f/${fileId}"]`)
 					.should('have.text', text === undefined ? filename : text)
 			}
+
+			let fileId = null
 
 			beforeEach(() => cy.clearContent())
 
 			it('without text', () => {
+				cy.getFileId(fileName).then((id) => {
+					fileId = id
+				})
 				cy.getFile(fileName)
 					.then($el => {
 						checkLinkFile(fileName)
@@ -195,6 +200,9 @@ describe('test link marks', function() {
 					})
 			})
 			it('with selected text', () => {
+				cy.getFileId(fileName).then((id) => {
+					fileId = id
+				})
 				cy.getFile(fileName)
 					.then($el => {
 						cy.getContent().type(`${text}{selectAll}`)
@@ -203,7 +211,9 @@ describe('test link marks', function() {
 					})
 			})
 			it('link to directory', () => {
-				cy.createFolder(`${window.__currentDirectory}/dummy folder`)
+				cy.createFolder(`${window.__currentDirectory}/dummy folder`).then((folderId) => {
+					fileId = folderId
+				})
 				cy.getFile(fileName).then($el => {
 					cy.getContent().type(`${text}{selectAll}`)
 					checkLinkFile('dummy folder', text, true)

--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -157,7 +157,7 @@ describe('Workspace', function() {
 			.contains('😀')
 	})
 
-	it('relative folder links', function() {
+	it('file links', function() {
 		cy.createFolder(`${this.testFolder}/sub-folder`)
 		cy.createFolder(`${this.testFolder}/sub-folder/alpha`)
 
@@ -179,9 +179,6 @@ describe('Workspace', function() {
 
 		cy.getEditor()
 			.find('a')
-			.should('have.attr', 'href')
-			.and('contains', `dir=/${this.testFolder}/sub-folder/alpha`)
-			.and('contains', '#relPath=sub-folder/alpha/test.md')
 
 		cy.getContent()
 			.type('{leftArrow}')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -261,13 +261,15 @@ Cypress.Commands.add('createFolder', (target) => {
 
 	return cy.getRequestToken()
 		.then(requesttoken => {
-			return cy.request({
+			cy.request({
 				url: `${rootPath}/${dirPath}`,
 				method: 'MKCOL',
 				auth,
 				headers: {
 					requesttoken,
 				},
+			}).then((response) => {
+				return parseInt(response.headers['oc-fileid'])
 			})
 		})
 })

--- a/src/components/Link/LinkBubbleView.vue
+++ b/src/components/Link/LinkBubbleView.vue
@@ -149,9 +149,8 @@ export default {
 		 * NcReferenceList only accepts full URLs with origin.
 		 */
 		sanitizedHref() {
-			return this.href?.startsWith('/')
-				? location.origin + this.href
-				: this.href
+			const url = new URL(this.href, window.location)
+			return url.href
 		},
 
 		title() {

--- a/src/components/Menu/ActionInsertLink.vue
+++ b/src/components/Menu/ActionInsertLink.vue
@@ -80,12 +80,12 @@
 import { NcActions, NcActionButton, NcActionInput } from '@nextcloud/vue'
 import { getLinkWithPicker } from '@nextcloud/vue/dist/Components/NcRichText.js'
 import { FilePickerType, getFilePickerBuilder } from '@nextcloud/dialogs'
+import { generateUrl } from '@nextcloud/router'
 
 import { getMarkAttributes, isActive } from '@tiptap/core'
 
 import { Document, Loading, LinkOff, Web, Shape } from '../icons.js'
 import { BaseActionEntry } from './BaseActionEntry.js'
-import { optimalPath } from '../../helpers/files.js'
 import { useFileMixin } from '../Editor.provider.js'
 import { useMenuIDMixin } from './MenuBar.provider.js'
 
@@ -144,9 +144,7 @@ export default {
 				.then((file) => {
 					const client = OC.Files.getClient()
 					client.getFileInfo(file).then((_status, fileInfo) => {
-						const path = optimalPath(this.relativePath, `${fileInfo.path}/${fileInfo.name}`)
-						const encodedPath = path.split('/').map(encodeURIComponent).join('/') + (fileInfo.type === 'dir' ? '/' : '')
-						const href = `${encodedPath}?fileId=${fileInfo.id}`
+						const href = generateUrl(`/f/${fileInfo.id}`)
 						this.setLink(href, fileInfo.name)
 						this.startPath = fileInfo.path + (fileInfo.type === 'dir' ? `/${fileInfo.name}/` : '')
 					})

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -37,25 +37,6 @@ import FilePlusSvg from '@mdi/svg/svg/file-plus.svg'
 
 const FILE_ACTION_IDENTIFIER = 'Edit with text app'
 
-const optimalPath = function(from, to) {
-	const current = from.split('/')
-	const target = to.split('/')
-	current.pop() // ignore filename
-	while (current[0] === target[0]) {
-		current.shift()
-		target.shift()
-		// Handle case where target is the current directory
-		if (current.length === 0 && target.length === 0) {
-			return '.'
-		}
-	}
-	const relativePath = current.fill('..').concat(target)
-	const absolutePath = to.split('/')
-	return relativePath.length < absolutePath.length
-		? relativePath.join('/')
-		: to
-}
-
 const registerFileCreate = () => {
 	const newFileMenuPlugin = {
 		attach(menu) {
@@ -260,7 +241,6 @@ export const FilesWorkspaceHeader = new Header({
 })
 
 export {
-	optimalPath,
 	registerFileActionFallback,
 	registerFileCreate,
 	FILE_ACTION_IDENTIFIER,

--- a/src/nodes/ParagraphView.vue
+++ b/src/nodes/ParagraphView.vue
@@ -106,9 +106,9 @@ export default {
 			const linkMark = textNode?.marks.find((m) => m.type.name === 'link')
 			const href = linkMark?.attrs?.href
 
-			const PATTERN = /(^)(https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)($)/ig
-			if ((new RegExp(PATTERN)).test(href)) {
-				return href
+			if (href) {
+				const url = new URL(href, window.location)
+				return url.href
 			}
 
 			return null

--- a/src/tests/helpers/links.spec.js
+++ b/src/tests/helpers/links.spec.js
@@ -1,5 +1,4 @@
 import { domHref, parseHref } from '../../helpers/links'
-import { loadState } from '@nextcloud/initial-state'
 
 global.OCA = {
 	Viewer: {
@@ -12,9 +11,6 @@ global.OC = {
 }
 
 global._oc_webroot = ''
-
-jest.mock('@nextcloud/initial-state')
-loadState.mockImplementation((app, key) => 'files')
 
 describe('Preparing href attributes for the DOM', () => {
 
@@ -36,24 +32,24 @@ describe('Preparing href attributes for the DOM', () => {
 			.toBe('mailTo:test@mail.example')
 	})
 
-	test('relative link with fileid', () => {
+	test('relative link with fileid (old format from file picker)', () => {
 		expect(domHref({attrs: {href: 'otherfile?fileId=123'}}))
-			.toBe('/apps/files/?dir=/Wiki&openfile=123#relPath=otherfile')
+			.toBe('/f/123')
 	})
 
-	test('relative path with ../', () => {
+	test('relative path with ../ (old format from file picker)', () => {
 		expect(domHref({attrs: {href: '../other/otherfile?fileId=123'}}))
-			.toBe('/apps/files/?dir=/other&openfile=123#relPath=../other/otherfile')
+			.toBe('/f/123')
 	})
 
-	test('absolute path', () => {
+	test('absolute path (old format from file picker)', () => {
 		expect(domHref({attrs: {href: '/other/otherfile?fileId=123'}}))
-			.toBe('/apps/files/?dir=/other&openfile=123#relPath=/other/otherfile')
+			.toBe('/f/123')
 	})
 
-	test('absolute path', () => {
+	test('absolute path (old format from file picker)', () => {
 		expect(domHref({attrs: {href: '/otherfile?fileId=123'}}))
-			.toBe('/apps/files/?dir=/&openfile=123#relPath=/otherfile')
+			.toBe('/f/123')
 	})
 
 })
@@ -74,9 +70,9 @@ describe('Extracting short urls from the DOM', () => {
 		expect(parseHref(domStub())).toBe(undefined)
 	})
 
-	test('relative link with fileid', () => {
+	test('relative link with fileid (old format from file picker)', () => {
 		expect(parseHref(domStub('?dir=/other&openfile=123#relPath=../other/otherfile')))
-			.toBe('../other/otherfile?fileId=123')
+			.toBe('/f/123')
 	})
 
 })
@@ -101,20 +97,29 @@ describe('Inserting hrefs into the dom and extracting them again', () => {
 		expect(insertAndExtract({})).toBe(undefined)
 	})
 
-	test('default relative link format is unchanged', () => {
+	test('old relative link format (from file picker) is rewritten', () => {
 		expect(insertAndExtract({href: 'otherfile?fileId=123'}))
-			.toBe('otherfile?fileId=123')
+			.toBe('/f/123')
 	})
 
-})
-
-describe('Preparing href attributes for the DOM in Collectives app', () => {
-	beforeAll(() => {
-		loadState.mockImplementation((app, key) => 'collectives')
+	test('old relative link format with ../ (from file picker) is rewritten', () => {
+		expect(insertAndExtract({href: '../otherfile?fileId=123'}))
+			.toBe('/f/123')
 	})
 
-	test('relative link with fileid in Collectives', () => {
-		expect(domHref({attrs: {href: 'otherfile?fileId=123'}}))
-			.toBe('otherfile?fileId=123')
+	test('old absolute link format (from file picker) is rewritten', () => {
+		expect(insertAndExtract({href: '/otherfile?fileId=123'}))
+			.toBe('/f/123')
 	})
+
+	test('default absolute link format is unchanged', () => {
+		expect(insertAndExtract({href: '/f/123'}))
+			.toBe('/f/123')
+	})
+
+	test('absolute link to collectives page is unchanged', () => {
+		expect(insertAndExtract({href: '/apps/collectives/page?fileId=123'}))
+			.toBe('/apps/collectives/page?fileId=123')
+	})
+
 })


### PR DESCRIPTION
### 📝 Summary

Get rid of the old `/path/?fileId=<id>` format. It never really worked anyway because the paths were relative to the users' home directory.

Instead, insert links to files/folders as full URLs with the `/f/<fileId>` format. This makes link previews work both in Text and Collectives.

Rewrite links in the old format to the new format. But don't touch absolute link (without origin) to the collectives app to not break collectives-specific link handling to other pages.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
