### PR TITLE
test(cypress): Force-click breadcrumbs at filelist reload (might be hidden)

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -357,7 +357,7 @@ Cypress.Commands.add('propfindFolder', (path, depth = 0) => {
 })
 
 Cypress.Commands.add('reloadFileList', () => {
-	return cy.get('.vue-crumb:last-child a').click()
+	return cy.get('.vue-crumb:last-child a').click({ force: true })
 })
 
 Cypress.Commands.add('openFolder', (name) => {


### PR DESCRIPTION
Since nextcloud/server#43325, breadcrumbs might be hidden during file operations.

