### PR TITLE
Several link handling fixes

### DIFF
--- a/src/components/Menu/ActionInsertLink.vue
+++ b/src/components/Menu/ActionInsertLink.vue
@@ -50,7 +50,7 @@
 		</NcActionButton>
 		<NcActionInput v-if="isInputMode"
 			type="text"
-			:value="href"
+			:value.sync="href"
 			:data-text-action-entry="`${actionEntry.key}-input`"
 			@submit="linkWebsite">
 			<template #icon>

--- a/src/components/Menu/ActionInsertLink.vue
+++ b/src/components/Menu/ActionInsertLink.vue
@@ -144,8 +144,8 @@ export default {
 				.then((file) => {
 					const client = OC.Files.getClient()
 					client.getFileInfo(file).then((_status, fileInfo) => {
-						const href = generateUrl(`/f/${fileInfo.id}`)
-						this.setLink(href, fileInfo.name)
+						const url = new URL(generateUrl(`/f/${fileInfo.id}`), window.origin)
+						this.setLink(url.href, fileInfo.name)
 						this.startPath = fileInfo.path + (fileInfo.type === 'dir' ? `/${fileInfo.name}/` : '')
 					})
 					this.menuOpen = false

--- a/src/extensions/LinkBubblePluginView.js
+++ b/src/extensions/LinkBubblePluginView.js
@@ -1,17 +1,15 @@
 import { VueRenderer } from '@tiptap/vue-2'
 import tippy from 'tippy.js'
+import debounce from 'debounce'
 import { domHref } from '../helpers/links.js'
 import LinkBubbleView from '../components/Link/LinkBubbleView.vue'
 
 import { getViewerVue } from '../ViewerVue.js'
 
-const updateDelay = 250
-
 class LinkBubblePluginView {
 
 	#component = null
 	#hadUpdateFromClick = false
-	#updateDebounceTimer = undefined
 
 	constructor({ editor, view }) {
 		this.editor = editor
@@ -103,16 +101,10 @@ class LinkBubblePluginView {
 			return
 		}
 
-		if (this.#updateDebounceTimer) {
-			clearTimeout(this.#updateDebounceTimer)
-		}
-
-		this.#updateDebounceTimer = setTimeout(() => {
-			this.updateFromSelection(view)
-		}, updateDelay)
+		this.updateFromSelection(view)
 	}
 
-	updateFromSelection(view) {
+	updateFromSelection = debounce((view) => {
 		// Don't update directly after updateFromClick. Prevents race condition in read-only documents in Chrome.
 		if (this.#hadUpdateFromClick) {
 			return
@@ -135,7 +127,7 @@ class LinkBubblePluginView {
 		const shouldShow = !!linkNode && hasEditorFocus
 
 		this.updateTooltip(view, shouldShow, linkNode, nodeStart)
-	}
+	}, 250)
 
 	updateFromClick(view, clickedLinkPos) {
 		const nodeStart = clickedLinkPos.pos - clickedLinkPos.textOffset
@@ -145,7 +137,7 @@ class LinkBubblePluginView {
 		this.#hadUpdateFromClick = true
 		setTimeout(() => {
 			this.#hadUpdateFromClick = false
-		}, 200)
+		}, 500)
 		this.updateTooltip(this.editor.view, shouldShow, clickedNode, nodeStart)
 	}
 

--- a/src/extensions/LinkBubblePluginView.js
+++ b/src/extensions/LinkBubblePluginView.js
@@ -34,7 +34,11 @@ class LinkBubblePluginView {
 		document.addEventListener('scroll', this.dragOrScrollHandler, { capture: true })
 	}
 
-	dragOrScrollHandler = () => {
+	dragOrScrollHandler = (event) => {
+		// Cypress fires unexpected scroll events, which breaks testing the link bubble
+		if (window.Cypress) {
+			return
+		}
 		this.hide()
 	}
 

--- a/src/helpers/links.js
+++ b/src/helpers/links.js
@@ -45,7 +45,7 @@ const domHref = function(node, relativePath) {
 	const match = ref.match(/^([^?]*)\?fileId=(\d+)/)
 	if (match) {
 		const [, , id] = match
-		return generateUrl(`/f/${id}`)
+		return (new URL(generateUrl(`/f/${id}`), window.origin)).href
 	}
 	return ref
 }
@@ -58,7 +58,7 @@ const parseHref = function(dom) {
 	const match = ref.match(/\?dir=([^&]*)&openfile=([^&]*)#relPath=([^&]*)/)
 	if (match) {
 		const [, , id] = match
-		return generateUrl(`/f/${id}`)
+		return (new URL(generateUrl(`/f/${id}`), window.origin)).href
 	}
 	return ref
 }

--- a/src/helpers/links.js
+++ b/src/helpers/links.js
@@ -20,6 +20,7 @@
  *
  */
 
+import { loadState } from '@nextcloud/initial-state'
 import { generateUrl } from '@nextcloud/router'
 
 const domHref = function(node, relativePath) {
@@ -34,6 +35,10 @@ const domHref = function(node, relativePath) {
 		return ref
 	}
 	if (ref.startsWith('#')) {
+		return ref
+	}
+	// Don't rewrite links in collectives app context
+	if (loadState('core', 'active-app') === 'collectives') {
 		return ref
 	}
 	// Don't rewrite links to the collectives app

--- a/src/marks/Link.js
+++ b/src/marks/Link.js
@@ -82,9 +82,10 @@ const Link = TipTapLink.extend({
 				props: {
 					handleDOMEvents: {
 						// Open link in new tab on middle click
-						pointerup: (view, event) => {
+						auxclick: (view, event) => {
 							if (event.target.closest('a') && event.button === 1 && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
 								event.preventDefault()
+								event.stopImmediatePropagation()
 
 								const linkElement = event.target.closest('a')
 								window.open(linkElement.href, '_blank')

--- a/src/tests/helpers/links.spec.js
+++ b/src/tests/helpers/links.spec.js
@@ -34,22 +34,22 @@ describe('Preparing href attributes for the DOM', () => {
 
 	test('relative link with fileid (old format from file picker)', () => {
 		expect(domHref({attrs: {href: 'otherfile?fileId=123'}}))
-			.toBe('/f/123')
+			.toBe('http://localhost/f/123')
 	})
 
 	test('relative path with ../ (old format from file picker)', () => {
 		expect(domHref({attrs: {href: '../other/otherfile?fileId=123'}}))
-			.toBe('/f/123')
+			.toBe('http://localhost/f/123')
 	})
 
 	test('absolute path (old format from file picker)', () => {
 		expect(domHref({attrs: {href: '/other/otherfile?fileId=123'}}))
-			.toBe('/f/123')
+			.toBe('http://localhost/f/123')
 	})
 
 	test('absolute path (old format from file picker)', () => {
 		expect(domHref({attrs: {href: '/otherfile?fileId=123'}}))
-			.toBe('/f/123')
+			.toBe('http://localhost/f/123')
 	})
 
 })
@@ -72,7 +72,7 @@ describe('Extracting short urls from the DOM', () => {
 
 	test('relative link with fileid (old format from file picker)', () => {
 		expect(parseHref(domStub('?dir=/other&openfile=123#relPath=../other/otherfile')))
-			.toBe('/f/123')
+			.toBe('http://localhost/f/123')
 	})
 
 })
@@ -99,22 +99,22 @@ describe('Inserting hrefs into the dom and extracting them again', () => {
 
 	test('old relative link format (from file picker) is rewritten', () => {
 		expect(insertAndExtract({href: 'otherfile?fileId=123'}))
-			.toBe('/f/123')
+			.toBe('http://localhost/f/123')
 	})
 
 	test('old relative link format with ../ (from file picker) is rewritten', () => {
 		expect(insertAndExtract({href: '../otherfile?fileId=123'}))
-			.toBe('/f/123')
+			.toBe('http://localhost/f/123')
 	})
 
 	test('old absolute link format (from file picker) is rewritten', () => {
 		expect(insertAndExtract({href: '/otherfile?fileId=123'}))
-			.toBe('/f/123')
+			.toBe('http://localhost/f/123')
 	})
 
-	test('default absolute link format is unchanged', () => {
-		expect(insertAndExtract({href: '/f/123'}))
-			.toBe('/f/123')
+	test('default full URL link format is unchanged', () => {
+		expect(insertAndExtract({href: 'http://localhost/f/123'}))
+			.toBe('http://localhost/f/123')
 	})
 
 	test('absolute link to collectives page is unchanged', () => {

--- a/src/tests/helpers/links.spec.js
+++ b/src/tests/helpers/links.spec.js
@@ -1,4 +1,5 @@
 import { domHref, parseHref } from '../../helpers/links'
+import { loadState } from '@nextcloud/initial-state'
 
 global.OCA = {
 	Viewer: {
@@ -11,6 +12,9 @@ global.OC = {
 }
 
 global._oc_webroot = ''
+
+jest.mock('@nextcloud/initial-state')
+loadState.mockImplementation((app, key) => 'files')
 
 describe('Preparing href attributes for the DOM', () => {
 
@@ -122,4 +126,15 @@ describe('Inserting hrefs into the dom and extracting them again', () => {
 			.toBe('/apps/collectives/page?fileId=123')
 	})
 
+})
+
+describe('Preparing href attributes for the DOM in Collectives app', () => {
+	beforeAll(() => {
+		loadState.mockImplementation((app, key) => 'collectives')
+	})
+
+	test('relative link with fileid in Collectives', () => {
+		expect(domHref({attrs: {href: 'otherfile?fileId=123'}}))
+			.toBe('otherfile?fileId=123')
+	})
 })


### PR DESCRIPTION
### 📝 Summary

* fix(LinkBubble): Remove custom blur/focus handling
* fix(LinkBubble): Use debounce instead of custom debounce implementation
* fix(link): Insert full URLs for links to Nextcloud files
* fix(link): Don't rewrite links with fileId inside Collectives
* fix(link): Prevent middle-click from opening two tabs on Firefox
* test(cypress): Don't hide LinkBubble on scroll event in Cypress
* fix(ActionInsertLink): Sync NcActionInput value property (Fixes: #5324, Fixes: #5003)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
