### PR TITLE
fix: Disable nested embedding fully

### DIFF
--- a/src/EditorFactory.js
+++ b/src/EditorFactory.js
@@ -49,12 +49,13 @@ const loadSyntaxHighlight = async (language) => {
 	}
 }
 
-const createEditor = ({ language, onCreate, onUpdate = () => {}, extensions, enableRichEditing, session, relativePath }) => {
+const createEditor = ({ language, onCreate, onUpdate = () => {}, extensions, enableRichEditing, session, relativePath, isEmbedded = false }) => {
 	let defaultExtensions
 	if (enableRichEditing) {
 		defaultExtensions = [
 			RichText.configure({
 				relativePath,
+				isEmbedded,
 				component: this,
 				extensions: [
 					Mention.configure({

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -181,6 +181,7 @@ export default {
 
 		return val
 	},
+	inject: ['isEmbedded'],
 	props: {
 		richWorkspace: {
 			type: Boolean,
@@ -542,6 +543,7 @@ export default {
 								}),
 							],
 							enableRichEditing: this.isRichEditor,
+							isEmbedded: this.isEmbedded,
 						})
 						this.hasEditor = true
 						if (!documentState && documentSource) {

--- a/src/components/Link/LinkBubbleView.vue
+++ b/src/components/Link/LinkBubbleView.vue
@@ -73,6 +73,7 @@
 			ref="referencelist"
 			:text="sanitizedHref"
 			:limit="1"
+			:interactive="false"
 			:display-fallback="true"
 			class="link-view-bubble__reference-list"
 			@loaded="onReferenceListLoaded" />

--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -27,6 +27,7 @@
 		:active="active"
 		:autofocus="autofocus"
 		:share-token="shareToken"
+		:is-embedded="isEmbedded"
 		:mime="mime"
 		:show-outline-outside="showOutlineOutside" />
 	<div v-else
@@ -53,6 +54,11 @@ export default {
 		RichTextReader,
 		PlainTextReader,
 		Editor: getEditorInstance,
+	},
+	provide() {
+		return {
+			isEmbedded: this.isEmbedded,
+		}
 	},
 	props: {
 		filename: {
@@ -90,6 +96,10 @@ export default {
 		source: {
 			type: String,
 			default: undefined,
+		},
+		isEmbedded: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -24,7 +24,7 @@
 	<Editor v-if="!useSourceView"
 		:file-id="fileid"
 		:relative-path="filename"
-		:active="active"
+		:active="active || isEmbedded"
 		:autofocus="autofocus"
 		:share-token="shareToken"
 		:is-embedded="isEmbedded"

--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -27,7 +27,6 @@
 		:active="active || isEmbedded"
 		:autofocus="autofocus"
 		:share-token="shareToken"
-		:is-embedded="isEmbedded"
 		:mime="mime"
 		:show-outline-outside="showOutlineOutside" />
 	<div v-else

--- a/src/extensions/RichText.js
+++ b/src/extensions/RichText.js
@@ -73,6 +73,7 @@ export default Extension.create({
 			extensions: [],
 			component: null,
 			relativePath: null,
+			isEmbedded: false,
 		}
 	},
 
@@ -81,7 +82,9 @@ export default Extension.create({
 			this.options.editing ? Markdown : null,
 			Document,
 			Text,
-			Paragraph,
+			Paragraph.configure({
+				isEmbedded: this.options.isEmbedded,
+			}),
 			HardBreak,
 			Heading,
 			Strong,

--- a/src/extensions/RichText.js
+++ b/src/extensions/RichText.js
@@ -82,9 +82,7 @@ export default Extension.create({
 			this.options.editing ? Markdown : null,
 			Document,
 			Text,
-			Paragraph.configure({
-				isEmbedded: this.options.isEmbedded,
-			}),
+			Paragraph,
 			HardBreak,
 			Heading,
 			Strong,
@@ -105,7 +103,9 @@ export default Extension.create({
 			TaskList,
 			TaskItem,
 			Callouts,
-			Preview,
+			Preview.configure({
+				isEmbedded: this.options.isEmbedded,
+			}),
 			Underline,
 			Image,
 			ImageInline,

--- a/src/nodes/Paragraph.js
+++ b/src/nodes/Paragraph.js
@@ -8,12 +8,6 @@ const Paragraph = TiptapParagraph.extend({
 		return VueNodeViewRenderer(ParagraphView)
 	},
 
-	addOptions() {
-		return {
-			isEmbedded: false,
-		}
-	},
-
 	parseHTML() {
 		return this.parent().map(rule => Object.assign(rule, { preserveWhitespace: 'full' }))
 	},

--- a/src/nodes/Paragraph.js
+++ b/src/nodes/Paragraph.js
@@ -8,6 +8,12 @@ const Paragraph = TiptapParagraph.extend({
 		return VueNodeViewRenderer(ParagraphView)
 	},
 
+	addOptions() {
+		return {
+			isEmbedded: false,
+		}
+	},
+
 	parseHTML() {
 		return this.parent().map(rule => Object.assign(rule, { preserveWhitespace: 'full' }))
 	},

--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -38,6 +38,7 @@ export default Node.create({
 
 	addOptions() {
 		return {
+			isEmbedded: false,
 			relativePath: null,
 		}
 	},

--- a/src/nodes/Preview.vue
+++ b/src/nodes/Preview.vue
@@ -29,7 +29,8 @@
 			:value.sync="value"
 			@update:value="convertToParagraph" />
 		<NcReferenceList :text="node.attrs.href"
-			:limit="1" />
+			:limit="1"
+			:interactive="!extension.options.isEmbedded" />
 	</NodeViewWrapper>
 </template>
 


### PR DESCRIPTION
We want to prevent nesting interactive widgets, so this will ensure that we know about that text is rendered as an embedding with https://github.com/nextcloud/server/pull/44012

## Follow up to check

- [ ] Check if we can just use inject in the paragraph component if we use the viewer vue instance