### PR TITLE
fix(Preview): allow removing Preview with backspace

### DIFF
--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -34,7 +34,11 @@ export default Node.create({
 
 	content: 'text?',
 
-	defining: true,
+	atom: true,
+
+	marks: 'link',
+
+	isolating: true,
 
 	addOptions() {
 		return {

--- a/src/tests/nodes/Preview.spec.js
+++ b/src/tests/nodes/Preview.spec.js
@@ -1,5 +1,6 @@
 import Preview from './../../nodes/Preview'
 import Markdown from './../../extensions/Markdown'
+import Link from './../../marks/Link'
 import { getExtensionField } from '@tiptap/core'
 import { createCustomEditor, markdownThroughEditor, markdownThroughEditorHtml } from '../helpers'
 import markdownit from '../../markdownit/index.js'
@@ -11,9 +12,7 @@ describe('Preview extension', () => {
 	})
 
 	it('exposes the toMarkdown function in the prosemirror schema', () => {
-		const editor = createCustomEditor({
-			extensions: [Markdown, Preview]
-		})
+		const editor = createEditorWithPreview()
 		const preview = editor.schema.nodes.preview
 		expect(preview.spec.toMarkdown).toBeDefined()
 	})
@@ -32,9 +31,7 @@ describe('Preview extension', () => {
 
 	it('detects links', () => {
 		const link = `<a href="https://nextcloud.com" title="preview">link</a>`
-		const editor = createCustomEditor({
-			extensions: [Markdown, Preview]
-		})
+		const editor = createEditorWithPreview()
 		editor.commands.setContent(`${link}<p>hello></p>`)
 		const node = editor.state.doc.content.firstChild
 		expect(node.type.name).toBe('preview')
@@ -43,3 +40,9 @@ describe('Preview extension', () => {
 	})
 
 })
+
+function createEditorWithPreview() {
+		return createCustomEditor({
+			extensions: [Markdown, Preview, Link]
+		})
+}


### PR DESCRIPTION
* Also only allow link marks inside the Preview.
* See #5442 for list of other follow up fixes for Previews

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- documentation is not required.