### PR TITLE
fix: Avoid race condition that may initialize a document twice on the clients

### DIFF
--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -37,6 +37,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Constants;
+use OCP\Files\AlreadyExistsException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\Lock\ILock;
 use OCP\Files\NotFoundException;
@@ -117,7 +118,12 @@ class ApiService {
 
 			if ($freshSession) {
 				$this->logger->info('Create new document of ' . $file->getId());
-				$document = $this->documentService->createDocument($file);
+				try {
+					$document = $this->documentService->createDocument($file);
+				} catch (AlreadyExistsException) {
+					$freshSession = false;
+					$document = $this->documentService->getDocument($file->getId());
+				}
 			} else {
 				$this->logger->info('Keep previous document of ' . $file->getId());
 			}

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -41,6 +41,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Constants;
 use OCP\DB\Exception;
 use OCP\DirectEditing\IManager;
+use OCP\Files\AlreadyExistsException;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\File;
 use OCP\Files\Folder;
@@ -157,7 +158,7 @@ class DocumentService {
 		} catch (Exception $e) {
 			if ($e->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 				// Document might have been created in the meantime
-				return $this->documentMapper->find($file->getId());
+				throw new AlreadyExistsException();
 			}
 
 			throw $e;


### PR DESCRIPTION
This fix may help with duplicate content of documents.

While staring at code and reading https://github.com/yjs/yjs-demos/issues/16 I noticed we may have a race condition where two browsers would attempt to create a new document, while that is catched the session receiving the unique constraint exception would still continue with the freshSession value set to true and handing over the file content and using that to initialize the document again locally.