### PR TITLE
Ensure document stays consistent with y.js state file

### DIFF
--- a/cypress/e2e/api/SessionApi.spec.js
+++ b/cypress/e2e/api/SessionApi.spec.js
@@ -315,7 +315,7 @@ describe('The session Api', function() {
 			})
 		})
 
-		it('sends initial content if other session is alive but did not push any steps', function() {
+		it('does not send initial content if other session is alive but did not push any steps', function() {
 			let joining
 			cy.createTextSession(undefined, { filePath: '', shareToken })
 				.then(con => {
@@ -323,7 +323,7 @@ describe('The session Api', function() {
 					return con
 				})
 				.its('state.documentSource')
-				.should('not.eql', '')
+				.should('eql', '')
 				.then(() => joining.close())
 				.then(() => connection.close())
 		})

--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -136,25 +136,19 @@ class ApiService {
 
 		$session = $this->sessionService->initSession($document->getId(), $guestName);
 
+		$documentState = null;
+		$content = null;
 		if ($freshSession) {
 			$this->logger->debug('Starting a fresh editing session for ' . $file->getId());
-			$documentState = null;
 			$content = $this->loadContent($file);
 		} else {
 			$this->logger->debug('Loading existing session for ' . $file->getId());
-			$content = null;
 			try {
 				$stateFile = $this->documentService->getStateFile($document->getId());
 				$documentState = $stateFile->getContent();
+				$this->logger->debug('Existing document, state file loaded ' . $file->getId());
 			} catch (NotFoundException $e) {
-				$this->logger->debug('State file not found for ' . $file->getId());
-				$documentState = ''; // no state saved yet.
-				// If there are no steps yet we might still need the content.
-				$steps = $this->documentService->getSteps($document->getId(), 0);
-				if (empty($steps)) {
-					$this->logger->debug('Empty steps, loading content for ' . $file->getId());
-					$content = $this->loadContent($file);
-				}
+				$this->logger->debug('Existing document, but state file not found for ' . $file->getId());
 			}
 		}
 

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -156,7 +156,7 @@ class DocumentService {
 		$document->setLastSavedVersion(0);
 		$document->setLastSavedVersionTime($file->getMTime());
 		$document->setLastSavedVersionEtag($file->getEtag());
-		$document->setBaseVersionEtag($file->getEtag());
+		$document->setBaseVersionEtag(uniqid());
 		try {
 			/** @var Document $document */
 			$document = $this->documentMapper->insert($document);


### PR DESCRIPTION
Contributes to #5476 

- fix: Clean up logic to return document state file or file content
- fix: Set base version etag to a unique id per document creation
- fix: Only cleanup earlier steps that haven't been persisted yet to the state file
- fix: Keep document table entry and only cleanup when we force it
