### PR TITLE
Reset document session on filesystem change

### DIFF
--- a/composer/composer/autoload_classmap.php
+++ b/composer/composer/autoload_classmap.php
@@ -38,6 +38,7 @@ return array(
     'OCA\\Text\\Listeners\\BeforeAssistantNotificationListener' => $baseDir . '/../lib/Listeners/BeforeAssistantNotificationListener.php',
     'OCA\\Text\\Listeners\\BeforeNodeDeletedListener' => $baseDir . '/../lib/Listeners/BeforeNodeDeletedListener.php',
     'OCA\\Text\\Listeners\\BeforeNodeRenamedListener' => $baseDir . '/../lib/Listeners/BeforeNodeRenamedListener.php',
+    'OCA\\Text\\Listeners\\BeforeNodeWrittenListener' => $baseDir . '/../lib/Listeners/BeforeNodeWrittenListener.php',
     'OCA\\Text\\Listeners\\FilesLoadAdditionalScriptsListener' => $baseDir . '/../lib/Listeners/FilesLoadAdditionalScriptsListener.php',
     'OCA\\Text\\Listeners\\FilesSharingLoadAdditionalScriptsListener' => $baseDir . '/../lib/Listeners/FilesSharingLoadAdditionalScriptsListener.php',
     'OCA\\Text\\Listeners\\LoadEditorListener' => $baseDir . '/../lib/Listeners/LoadEditorListener.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -53,6 +53,7 @@ class ComposerStaticInitText
         'OCA\\Text\\Listeners\\BeforeAssistantNotificationListener' => __DIR__ . '/..' . '/../lib/Listeners/BeforeAssistantNotificationListener.php',
         'OCA\\Text\\Listeners\\BeforeNodeDeletedListener' => __DIR__ . '/..' . '/../lib/Listeners/BeforeNodeDeletedListener.php',
         'OCA\\Text\\Listeners\\BeforeNodeRenamedListener' => __DIR__ . '/..' . '/../lib/Listeners/BeforeNodeRenamedListener.php',
+        'OCA\\Text\\Listeners\\BeforeNodeWrittenListener' => __DIR__ . '/..' . '/../lib/Listeners/BeforeNodeWrittenListener.php',
         'OCA\\Text\\Listeners\\FilesLoadAdditionalScriptsListener' => __DIR__ . '/..' . '/../lib/Listeners/FilesLoadAdditionalScriptsListener.php',
         'OCA\\Text\\Listeners\\FilesSharingLoadAdditionalScriptsListener' => __DIR__ . '/..' . '/../lib/Listeners/FilesSharingLoadAdditionalScriptsListener.php',
         'OCA\\Text\\Listeners\\LoadEditorListener' => __DIR__ . '/..' . '/../lib/Listeners/LoadEditorListener.php',

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,6 +32,7 @@ use OCA\Text\Listeners\AddMissingIndicesListener;
 use OCA\Text\Listeners\BeforeAssistantNotificationListener;
 use OCA\Text\Listeners\BeforeNodeDeletedListener;
 use OCA\Text\Listeners\BeforeNodeRenamedListener;
+use OCA\Text\Listeners\BeforeNodeWrittenListener;
 use OCA\Text\Listeners\FilesLoadAdditionalScriptsListener;
 use OCA\Text\Listeners\FilesSharingLoadAdditionalScriptsListener;
 use OCA\Text\Listeners\LoadEditorListener;
@@ -51,6 +52,7 @@ use OCP\DB\Events\AddMissingIndicesEvent;
 use OCP\DirectEditing\RegisterDirectEditorEvent;
 use OCP\Files\Events\Node\BeforeNodeDeletedEvent;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
+use OCP\Files\Events\Node\BeforeNodeWrittenEvent;
 use OCP\Files\Events\Node\NodeCopiedEvent;
 use OCP\Files\Template\ITemplateManager;
 use OCP\Files\Template\TemplateFileCreator;
@@ -71,6 +73,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(LoadEditor::class, LoadEditorListener::class);
 		// for attachments
 		$context->registerEventListener(NodeCopiedEvent::class, NodeCopiedListener::class);
+		$context->registerEventListener(BeforeNodeWrittenEvent::class, BeforeNodeWrittenListener::class);
 		$context->registerEventListener(BeforeNodeRenamedEvent::class, BeforeNodeRenamedListener::class);
 		$context->registerEventListener(BeforeNodeDeletedEvent::class, BeforeNodeDeletedListener::class);
 		$context->registerEventListener(AddMissingIndicesEvent::class, AddMissingIndicesListener::class);

--- a/lib/Cron/Cleanup.php
+++ b/lib/Cron/Cleanup.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\Text\Cron;
 
-use OCA\Text\Service\AttachmentService;
+use OCA\Text\Exception\DocumentHasUnsavedChangesException;
 use OCA\Text\Service\DocumentService;
 use OCA\Text\Service\SessionService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -39,26 +39,22 @@ class Cleanup extends TimedJob {
 	private SessionService $sessionService;
 	private DocumentService $documentService;
 	private LoggerInterface $logger;
-	private AttachmentService $attachmentService;
 
 	public function __construct(ITimeFactory $time,
 		SessionService $sessionService,
 		DocumentService $documentService,
-		AttachmentService $attachmentService,
 		LoggerInterface $logger) {
 		parent::__construct($time);
 		$this->sessionService = $sessionService;
 		$this->documentService = $documentService;
-		$this->attachmentService = $attachmentService;
 		$this->logger = $logger;
 		$this->setInterval(SessionService::SESSION_VALID_TIME);
 	}
 
 	/**
 	 * @param array $argument
-	 * @return void
 	 */
-	protected function run($argument) {
+	protected function run($argument): void {
 		$this->logger->debug('Run cleanup job for text documents');
 		$documents = $this->documentService->getAll();
 		foreach ($documents as $document) {
@@ -69,11 +65,10 @@ class Cleanup extends TimedJob {
 				continue;
 			}
 
-			if ($this->documentService->hasUnsavedChanges($document)) {
-				continue;
+			try {
+				$this->documentService->resetDocument($document->getId());
+			} catch (DocumentHasUnsavedChangesException) {
 			}
-
-			$this->documentService->resetDocument($document->getId());
 		}
 
 		$this->logger->debug('Run cleanup job for text sessions');

--- a/lib/Listeners/BeforeNodeDeletedListener.php
+++ b/lib/Listeners/BeforeNodeDeletedListener.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Text\Listeners;
 
 use OCA\Text\Service\AttachmentService;
+use OCA\Text\Service\DocumentService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\BeforeNodeDeletedEvent;
@@ -35,10 +36,13 @@ use OCP\Files\File;
  * @template-implements IEventListener<Event|BeforeNodeDeletedEvent>
  */
 class BeforeNodeDeletedListener implements IEventListener {
-	private $attachmentService;
+	private AttachmentService $attachmentService;
+	private DocumentService $documentService;
 
-	public function __construct(AttachmentService $attachmentService) {
+	public function __construct(AttachmentService $attachmentService,
+		DocumentService $documentService) {
 		$this->attachmentService = $attachmentService;
+		$this->documentService = $documentService;
 	}
 
 	public function handle(Event $event): void {
@@ -48,6 +52,7 @@ class BeforeNodeDeletedListener implements IEventListener {
 		$node = $event->getNode();
 		if ($node instanceof File && $node->getMimeType() === 'text/markdown') {
 			$this->attachmentService->deleteAttachments($node);
+			$this->documentService->resetDocument($node->getId(), true);
 		}
 	}
 }

--- a/lib/Listeners/BeforeNodeWrittenListener.php
+++ b/lib/Listeners/BeforeNodeWrittenListener.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2024 Jonas <jonas@freesources.org>
+ *
+ * @author Jonas <jonas@freesources.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Text\Listeners;
+
+use OCA\Text\Service\DocumentService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Events\Node\BeforeNodeWrittenEvent;
+use OCP\Files\File;
+
+/**
+ * @template-implements IEventListener<Event|BeforeNodeWrittenEvent>
+ */
+class BeforeNodeWrittenListener implements IEventListener {
+	private DocumentService $documentService;
+
+	public function __construct(DocumentService $documentService) {
+		$this->documentService = $documentService;
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof BeforeNodeWrittenEvent) {
+			return;
+		}
+		$node = $event->getNode();
+		if ($node instanceof File && $node->getMimeType() === 'text/markdown') {
+			if (!$this->documentService->isSaveFromText()) {
+				// Reset document session to avoid manual conflict resolution if there's no unsaved steps
+				$this->documentService->resetDocument($node->getId());
+			}
+		}
+	}
+}

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -74,6 +74,8 @@ class DocumentService {
 	 */
 	public const AUTOSAVE_MINIMUM_DELAY = 10;
 
+	private bool $saveFromText = false;
+
 	private ?string $userId;
 	private DocumentMapper $documentMapper;
 	private SessionMapper $sessionMapper;
@@ -116,6 +118,10 @@ class DocumentService {
 		} catch (DoesNotExistException|NotFoundException $e) {
 			return null;
 		}
+	}
+
+	public function isSaveFromText(): bool {
+		return $this->saveFromText;
 	}
 
 	/**
@@ -389,6 +395,7 @@ class DocumentService {
 				ILock::TYPE_APP,
 				Application::APP_NAME
 			), function () use ($file, $autoSaveDocument, $documentState) {
+				$this->saveFromText = true;
 				$file->putContent($autoSaveDocument);
 				if ($documentState) {
 					$this->writeDocumentState($file->getId(), $documentState);

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -432,10 +432,8 @@ class DocumentService {
 			$this->stepMapper->deleteAll($documentId);
 			$this->sessionMapper->deleteByDocumentId($documentId);
 			$this->documentMapper->delete($document);
+			$this->getStateFile($documentId)->delete();
 
-			if ($force) {
-				$this->getStateFile($documentId)->delete();
-			}
 			$this->logger->debug('document reset for ' . $documentId);
 		} catch (DoesNotExistException|NotFoundException $e) {
 			// Ignore if document not found or state file not found


### PR DESCRIPTION
Contributes to #5476

### 📝 Summary

1. **fix(backend): Reset document session and yjs file when file is deleted**
2. **fix(backend): Reset document session when updated from outside editor**
   When a text file is updated via other means than from the editor (e.g. when uploaded/synced via webdav) and there is no unsaved steps in the document session, reset the document session  This will prevent conflict resolution dialogs in this case. Client frontends will have to reload the document afterwards though.
3. **fix(backend): Remove yjs file and all steps when resetting document session**
   Instead of just deleting the newest steps, always remove all session data: document, sessions and steps from the database as well as the yjs (document state) file.
   Without the `--force` option, don't reset document sessions with unsaved steps.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
