### PR TITLE
fix(attachments): Don't use currentSession for fetching attachments

### DIFF
--- a/src/services/AttachmentResolver.js
+++ b/src/services/AttachmentResolver.js
@@ -47,7 +47,7 @@ export default class AttachmentResolver {
 	}
 
 	async #updateAttachmentList() {
-		return setAttachmentList({ documentId: this.#documentId, shareToken: this.#shareToken })
+		return setAttachmentList({ documentId: this.#documentId, session: this.#session, shareToken: this.#shareToken })
 	}
 
 	/*

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -96,11 +96,11 @@ export const textModule = {
 		setHeadings({ commit }, value) {
 			commit(SET_HEADINGS, value)
 		},
-		async setAttachmentList({ commit, state }, { documentId, shareToken }) {
+		async setAttachmentList({ commit }, { documentId, session, shareToken }) {
 			const response = await axios.post(generateUrl('/apps/text/attachments'), {
-				documentId: state.currentSession?.documentId ?? documentId,
-				sessionId: state.currentSession?.id,
-				sessionToken: state.currentSession?.token,
+				documentId: session?.documentId ?? documentId,
+				sessionId: session?.id,
+				sessionToken: session?.token,
 				shareToken,
 			})
 


### PR DESCRIPTION
When switching pages in Collectives, `currentSession` might still be the session from the last page. The readonly view (`MarkdownContentEditor`) doesn't get a session, so the outdated session is used.

Instead, always pass the session from `AttachmentResolver` to `setAttachmentList`.

Fixes: nextcloud/collectives#1096
Fixes: nextcloud/collectives#1112

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
