### PR TITLE
fix: copy-paste markdown/raw text inconsistencies

### DIFF
--- a/src/extensions/Markdown.js
+++ b/src/extensions/Markdown.js
@@ -114,7 +114,7 @@ const Markdown = Extension.create({
 							} else if (slice.isLeaf) {
 								return slice.textContent
 							} else {
-								traverseNodes(slice.content.firstChild)
+								return traverseNodes(slice.content.firstChild)
 							}
 						}
 

--- a/src/tests/extensions/Markdown.spec.js
+++ b/src/tests/extensions/Markdown.spec.js
@@ -1,5 +1,7 @@
 import { Markdown } from './../../extensions/index.js'
 import { createMarkdownSerializer } from './../../extensions/Markdown.js'
+import CodeBlock from '@tiptap/extension-code-block'
+import Blockquote from '@tiptap/extension-blockquote'
 import Image from './../../nodes/Image.js'
 import ImageInline from './../../nodes/ImageInline.js'
 import TaskList from './../../nodes/TaskList.js'
@@ -7,6 +9,7 @@ import TaskItem from './../../nodes/TaskItem.js'
 import Underline from './../../marks/Underline.js'
 import TiptapImage from '@tiptap/extension-image'
 import { getExtensionField } from '@tiptap/core'
+import { __serializeForClipboard as serializeForClipboard } from '@tiptap/pm/view'
 import { createCustomEditor } from '../helpers.js'
 
 describe('Markdown extension unit', () => {
@@ -75,6 +78,39 @@ describe('Markdown extension integrated in the editor', () => {
 		})
 		const serializer = createMarkdownSerializer(editor.schema)
 		expect(serializer.serialize(editor.state.doc)).toBe('inline image ![Hello](test) inside text')
+	})
+
+	it('copies task lists to plaintext like markdown', () => {
+		const editor = createCustomEditor({
+			content: '<p><ul class="contains-task-list"><li><input type="checkbox">Hello</li></ul></p>',
+			extensions: [Markdown, TaskList, TaskItem],
+		})
+		editor.commands.selectAll()
+		const slice = editor.state.selection.content()
+		const { text } = serializeForClipboard(editor.view, slice)
+		expect(text).toBe('\n- [ ] Hello')
+	})
+
+	it('copies code block content to plaintext according to their spec', () => {
+		const editor = createCustomEditor({
+			content: '<pre><code>Hello</code></pre>',
+			extensions: [Markdown, CodeBlock],
+		})
+		editor.commands.selectAll()
+		const slice = editor.state.selection.content()
+		const { text } = serializeForClipboard(editor.view, slice)
+		expect(text).toBe('Hello')
+	})
+
+	it('copies nested task list nodes to markdown like syntax', () => {
+		const editor = createCustomEditor({
+			content: '<blockquote><p><ul class="contains-task-list"><li><input type="checkbox">Hello</li></ul></blockquote>',
+			extensions: [Markdown, Blockquote, TaskList, TaskItem],
+		})
+		editor.commands.selectAll()
+		const slice = editor.state.selection.content()
+		const { text } = serializeForClipboard(editor.view, slice)
+		expect(text).toBe('\n- [ ] Hello')
 	})
 
 })


### PR DESCRIPTION
### 📝 Summary

Fix #5331

As described in #5331 and #5212, there are some issues with the copy-paste behavior and some inconsistencies regarding how markdown is copied vs. raw text. I think it would be helpful to define what the expected behavior would be in certain situations so that this can be refined.

This draft PR currently contains some additions I made which traverses ProseMirror Nodes upon copying text, and tries to determine if markdown should be copied or if the raw text should be copied. In my opinion, it works a bit better than before and behaves more consistently, but I did still notice some issues, such as losing block nesting sometimes (discovered when copying a code block nested in a list).

### Currently defined behavior

- [x] Copying from a code block should just paste the code in question
- [x] Copying multiple list items should result in something that resembles a list
- [x] Copying a larger fragment of a doc should result in markdown as this can be useful for creating github issues
- [x] Copying an address from inside a info block should only result in the address
- [x] Copying version numbers should not result in an escaped character (28\\.0.3 e.g.)

All testing and feedback is welcome.
