### PR TITLE
fix(MarkdownContentEditor): Respect `onLoaded` callback passed via API

### DIFF
--- a/src/components/Editor/MarkdownContentEditor.vue
+++ b/src/components/Editor/MarkdownContentEditor.vue
@@ -147,11 +147,15 @@ export default {
 				extensions: this.extensions(),
 				onUpdate: ({ editor }) => {
 					const markdown = (createMarkdownSerializer(this.$editor.schema)).serialize(editor.state.doc)
-					this.$root.$emit('update:content', {
+					this.emit('update:content', {
 						json: editor.state.doc,
 						markdown,
 					})
 				},
+				onCreate: ({ editor }) => {
+					this.$emit('ready')
+					this.$parent.$emit('ready')
+				}
 			})
 		},
 
@@ -160,8 +164,24 @@ export default {
 		},
 
 		outlineToggled(visible) {
-			this.$emit('outline-toggled', visible)
-			this.$parent.$emit('outline-toggled', visible)
+			this.emit('outline-toggled', visible)
+		},
+
+		/**
+		 * Wrapper to emit events on our own and the parent component
+		 *
+		 * The parent might be either the root component of src/editor.js or Viewer.vue which collectives currently uses
+		 *
+		 * Ideally this would be done in a generic way in the src/editor.js API abstraction, but it seems
+		 * that there is no proper way to pass any received event along in vue, the only option I've found
+		 * in https://github.com/vuejs/vue/issues/230 feels too hacky to me, so we just emit twice for now
+		 *
+		 * @param {string} event The event name
+		 * @param {any} data The data to pass along
+		 */
+		emit(event, data) {
+			this.$emit(event, data)
+			this.$parent?.$emit(event, data)
 		},
 	},
 }


### PR DESCRIPTION
Emit `ready` once the editor is ready (Tiptap `create` event), which causes the `onLoaded` callback passed via editor API to be called.

Required by https://github.com/nextcloud/collectives/pull/1150

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits