### PR TITLE
fix(LinkPicker): Don't open link picker inside code blocks

### DIFF
--- a/src/extensions/LinkPicker.js
+++ b/src/extensions/LinkPicker.js
@@ -14,6 +14,10 @@ export default Extension.create({
 				char: '/',
 				allowedPrefixes: [' '],
 				pluginKey: LinkPickerPluginKey,
+				allow: ({ state, range }) => {
+					const $from = state.doc.resolve(range.from)
+					return $from.parent.type.name !== 'codeBlock'
+				},
 				...suggestions(),
 			},
 		}


### PR DESCRIPTION
Fixes: #5381

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits