### PR TITLE
fix: Force visibility for tippy

### DIFF
--- a/cypress/e2e/Assistant.spec.js
+++ b/cypress/e2e/Assistant.spec.js
@@ -4,7 +4,7 @@ const currentUser = randUser()
 
 const fileName = 'empty.md'
 
-describe.skip('Assistant', () => {
+describe('Assistant', () => {
 	before(() => {
 		initUserAndFiles(currentUser, fileName)
 	})

--- a/src/css/prosemirror.scss
+++ b/src/css/prosemirror.scss
@@ -360,3 +360,7 @@ div.ProseMirror {
 .editor__content {
 	tab-size: 4;
 }
+
+.tippy-content div {
+	visibility: visible !important;
+}


### PR DESCRIPTION
This seems to have changed with viewer changing from `@nextcloud/vue` from 8.4.0 to 8.8.1 but I could not figure out the difference there, however this brings back the assistant button (consider it a hotfix)

Also noted as a workaround in https://github.com/ueberdosis/tiptap/issues/4851

Fix #5448 