### PR TITLE
fix(LinkBubble): Display link bubble view only if href is set

### DIFF
--- a/src/components/Link/LinkBubbleView.vue
+++ b/src/components/Link/LinkBubbleView.vue
@@ -69,7 +69,7 @@
 		</div>
 
 		<!-- link preview -->
-		<NcReferenceList v-else
+		<NcReferenceList v-else-if="href"
 			ref="referencelist"
 			:text="sanitizedHref"
 			:limit="1"


### PR DESCRIPTION
This prevents requests to `/resolve?reference=.../null` when a document gets opened without a link being selected.

Contributes to nextcloud/collectives#1167

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
