### PR TITLE
fix(files): Change icons+wording for adding text doc and folder description

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -519,7 +519,7 @@ Cypress.Commands.add('createDescription', () => {
 
 	cy.get('[data-cy-files-list] tr[data-cy-files-list-row-name="Readme.md"]').should('not.exist')
 	cy.get('[data-cy-upload-picker] button.action-item__menutoggle').click()
-	cy.get('li.upload-picker__menu-entry button').contains('Add description').click()
+	cy.get('li.upload-picker__menu-entry button').contains('Add folder description').click()
 
 	cy.wait('@addDescription')
 })

--- a/img/article.svg
+++ b/img/article.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#000000">
+	<path d="M0 0h24v24H0z" fill="none" />
+	<path fill="#969696"
+		d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z" />
+</svg>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -44,6 +44,7 @@ use OCA\Text\Notification\Notifier;
 use OCA\Text\Service\ConfigService;
 use OCA\TpAssistant\Event\BeforeAssistantNotificationEvent;
 use OCA\Viewer\Event\LoadViewer;
+use OCP\App\IAppManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -84,12 +85,12 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		$context->injectFn(function (ITemplateManager $templateManager, IL10N $l, ConfigService $configService) {
-			$templateManager->registerTemplateFileCreator(function () use ($l, $configService) {
+		$context->injectFn(function (ITemplateManager $templateManager, IL10N $l, ConfigService $configService, IAppManager $appManager) {
+			$templateManager->registerTemplateFileCreator(function () use ($l, $configService, $appManager) {
 				$markdownFile = new TemplateFileCreator(Application::APP_NAME, $l->t('New text file'), '.' . $configService->getDefaultFileExtension());
 				$markdownFile->addMimetype('text/markdown');
 				$markdownFile->addMimetype('text/plain');
-				$markdownFile->setIconClass('icon-filetype-text');
+				$markdownFile->setIconSvgInline(file_get_contents($appManager->getAppPath('text') . '/img/article.svg'));
 				$markdownFile->setRatio(1);
 				$markdownFile->setOrder(10);
 				$markdownFile->setActionLabel($l->t('Create new text file'));

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -33,7 +33,7 @@ import { showSuccess, showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import { dirname } from 'path'
 
-import FilePlusSvg from '@mdi/svg/svg/file-plus.svg'
+import TextSvg from '@mdi/svg/svg/text.svg'
 
 const FILE_ACTION_IDENTIFIER = 'Edit with text app'
 
@@ -134,14 +134,14 @@ export const addMenuRichWorkspace = () => {
 	const descriptionFile = t('text', 'Readme') + '.' + loadState('text', 'default_file_extension')
 	addNewFileMenuEntry({
 		id: 'rich-workspace-init',
-		displayName: t('text', 'Add description'),
+		displayName: t('text', 'Add folder description'),
 		enabled(context) {
 			if (Number(context.attributes['rich-workspace-file'])) {
 				return false
 			}
 			return (context.permissions & Permission.CREATE) !== 0
 		},
-		iconSvgInline: FilePlusSvg,
+		iconSvgInline: TextSvg,
 		async handler(context, content) {
 			const contentNames = content.map((node) => node.basename)
 

--- a/src/public.js
+++ b/src/public.js
@@ -28,7 +28,7 @@ const newRichWorkspaceFileMenuPlugin = {
 			id: 'rich-workspace-init',
 			displayName: t('text', 'Add folder description'),
 			templateName: descriptionFile,
-			iconClass: 'icon-rename',
+			iconClass: 'icon-add-folder-description',
 			fileType: 'file',
 			useInput: false,
 			actionHandler() {

--- a/src/public.js
+++ b/src/public.js
@@ -26,7 +26,7 @@ const newRichWorkspaceFileMenuPlugin = {
 		// register the new menu entry
 		menu.addMenuEntry({
 			id: 'rich-workspace-init',
-			displayName: t('text', 'Add description'),
+			displayName: t('text', 'Add folder description'),
 			templateName: descriptionFile,
 			iconClass: 'icon-rename',
 			fileType: 'file',


### PR DESCRIPTION
This is only a partial fix so far. We'll have to wait for the icon renames in server and the introduction of `icon-add-folder-description` in https://github.com/nextcloud/server/issues/44340.

Fixes: #5535
