### PR TITLE
Fix/5522 no link preview toggle for anchor links

### DIFF
--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -148,7 +148,7 @@ function previewPossible({ selection }) {
 	if (hasOtherContent($from.parent)) {
 		return false
 	}
-	const href = extractHref($from.nodeAfter || $from.nodeBefore)
+	const href = extractHref($from.parent.firstChild)
 	if (!href || href.startsWith('#')) {
 		return false
 	}

--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -148,7 +148,7 @@ function previewPossible({ selection }) {
 	if (hasOtherContent($from.parent)) {
 		return false
 	}
-	const href = extractHref($from.nodeAfter)
+	const href = extractHref($from.nodeAfter || $from.nodeBefore)
 	if (!href || href.startsWith('#')) {
 		return false
 	}
@@ -171,6 +171,9 @@ function hasOtherContent(node) {
  * @return {string} The href of the link mark of the node
  */
 function extractHref(node) {
+	if (!node) {
+		return undefined
+	}
 	const link = node.marks.find(mark => mark.type.name === 'link')
 	return link?.attrs.href
 }


### PR DESCRIPTION
### 📝 Summary

* Resolves: #5522 
* hide preview toggle if not available
* only show preview toggle for current paragraph
* enable toggling preview when cursor is in whitespace after link

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- Documentation is not required
