### PR TITLE
fix(LinkBubble): Limit hide on scroll to div elements

### DIFF
--- a/src/plugins/LinkBubblePluginView.js
+++ b/src/plugins/LinkBubblePluginView.js
@@ -25,10 +25,16 @@ class LinkBubblePluginView {
 	}
 
 	dragOrScrollHandler = (event) => {
+		// Only hide when scrolling on `<div>` (not .e.g. on `<input>`)
+		if (event.target.nodeName !== 'DIV') {
+			return
+		}
+
 		// Cypress fires unexpected scroll events, which breaks testing the link bubble
 		if (window.Cypress) {
 			return
 		}
+
 		this.hide()
 	}
 


### PR DESCRIPTION
Don't hide e.g. when scrolling in an input element.

Fixes: #5497

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
