### PR TITLE
fix(links): set default for `loadState('core', 'active-app')`

### DIFF
--- a/src/helpers/links.js
+++ b/src/helpers/links.js
@@ -38,7 +38,7 @@ const domHref = function(node, relativePath) {
 		return ref
 	}
 	// Don't rewrite links in collectives app context
-	if (loadState('core', 'active-app') === 'collectives') {
+	if (loadState('core', 'active-app', '') === 'collectives') {
 		return ref
 	}
 	// Don't rewrite links to the collectives app


### PR DESCRIPTION
Without, it threw an error in public shares, which broke loading pages with links.