### PR TITLE
fix: Catch exceptions on non existing files

### DIFF
--- a/lib/Listeners/BeforeNodeWrittenListener.php
+++ b/lib/Listeners/BeforeNodeWrittenListener.php
@@ -31,6 +31,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\BeforeNodeWrittenEvent;
 use OCP\Files\File;
+use OCP\Files\NotFoundException;
 
 /**
  * @template-implements IEventListener<Event|BeforeNodeWrittenEvent>
@@ -47,15 +48,19 @@ class BeforeNodeWrittenListener implements IEventListener {
 			return;
 		}
 		$node = $event->getNode();
-		if ($node instanceof File && $node->getMimeType() === 'text/markdown') {
-			if (!$this->documentService->isSaveFromText()) {
-				// Reset document session to avoid manual conflict resolution if there's no unsaved steps
-				try {
-					$this->documentService->resetDocument($node->getId());
-				} catch (DocumentHasUnsavedChangesException) {
-					// Do not throw during event handling in this is expected to happen
+		try {
+			if ($node instanceof File && $node->getMimeType() === 'text/markdown') {
+				if (!$this->documentService->isSaveFromText()) {
+					// Reset document session to avoid manual conflict resolution if there's no unsaved steps
+					try {
+						$this->documentService->resetDocument($node->getId());
+					} catch (DocumentHasUnsavedChangesException) {
+						// Do not throw during event handling in this is expected to happen
+					}
 				}
 			}
+		} catch (NotFoundException) {
+			// This might occur on new files when a NonExistingFile is passed and we cannot access the mimetype
 		}
 	}
 }


### PR DESCRIPTION
As we have a before node written event listener the node might actually be non-existing yet, so we should catch this case.

Found this when adding a file attachment in deck:

```
{
  "reqId": "8eMUkqoFK5js0RrQTzAQ",
  "level": 3,
  "time": "2024-03-26T14:48:46+00:00",
  "remoteAddr": "192.168.65.1",
  "user": "admin",
  "app": "no app in context",
  "method": "POST",
  "url": "/index.php/apps/deck/cards/7/attachment",
  "message": "Exception thrown: OCP\\Files\\NotFoundException",
  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
  "version": "29.0.0.12",
  "exception": {
    "Exception": "OCP\\Files\\NotFoundException",
    "Message": "",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/html/apps/text/lib/Listeners/BeforeNodeWrittenListener.php",
        "line": 50,
        "function": "getMimeType",
        "class": "OC\\Files\\Node\\NonExistingFile",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 86,
        "function": "handle",
        "class": "OCA\\Text\\Listeners\\BeforeNodeWrittenListener",
        "type": "->",
        "args": [
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 230,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->",
        "args": [
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          ],
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent",
          [
            "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 59,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            [
              "Closure"
            ],
            [
              "Closure"
            ]
          ],
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent",
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 86,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          ],
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 98,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent",
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Node/HookConnector.php",
        "line": 93,
        "function": "dispatchTyped",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/legacy/OC_Hook.php",
        "line": 105,
        "function": "write",
        "class": "OC\\Files\\Node\\HookConnector",
        "type": "->",
        "args": [
          [
            true,
            "/Deck/wrk_scratchpad (2).json"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/View.php",
        "line": 1281,
        "function": "emit",
        "class": "OC_Hook",
        "type": "::",
        "args": [
          "OC_Filesystem",
          "write",
          [
            true,
            "/Deck/wrk_scratchpad (2).json"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/View.php",
        "line": 1148,
        "function": "runHooks",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          [
            "touch",
            "create",
            "write"
          ],
          "/Deck/wrk_scratchpad (2).json"
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/View.php",
        "line": 557,
        "function": "basicOperation",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "touch",
          "/admin/files/Deck/wrk_scratchpad (2).json",
          [
            "touch",
            "create",
            "write"
          ],
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Node/Folder.php",
        "line": 190,
        "function": "touch",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "/admin/files/Deck/wrk_scratchpad (2).json"
        ]
      },
      {
        "file": "/var/www/html/apps-extra/deck/lib/Service/FilesAppService.php",
        "line": 190,
        "function": "newFile",
        "class": "OC\\Files\\Node\\Folder",
        "type": "->",
        "args": [
          "wrk_scratchpad (2).json"
        ]
      },
      {
        "file": "/var/www/html/apps-extra/deck/lib/Service/AttachmentService.php",
        "line": 212,
        "function": "create",
        "class": "OCA\\Deck\\Service\\FilesAppService",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/apps-extra/deck/lib/Controller/AttachmentController.php",
        "line": 70,
        "function": "create",
        "class": "OCA\\Deck\\Service\\AttachmentService",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 232,
        "function": "create",
        "class": "OCA\\Deck\\Controller\\AttachmentController",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 138,
        "function": "executeController",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          [
            "OCA\\Deck\\Controller\\AttachmentController"
          ],
          "create"
        ]
      },
      {
        "file": "/var/www/html/lib/private/AppFramework/App.php",
        "line": 184,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          [
            "OCA\\Deck\\Controller\\AttachmentController"
          ],
          "create"
        ]
      },
      {
        "file": "/var/www/html/lib/private/Route/Router.php",
        "line": 338,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Deck\\Controller\\AttachmentController",
          "create",
          [
            "OC\\AppFramework\\DependencyInjection\\DIContainer"
          ],
          [
            "*** sensitive parameters replaced ***",
            "deck.attachment.create"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/base.php",
        "line": 1050,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/apps/deck/cards/7/attachment"
        ]
      },
      {
        "file": "/var/www/html/index.php",
        "line": 49,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "/var/www/html/lib/private/Files/Node/NonExistingFile.php",
    "Line": 136,
    "CustomMessage": "Exception thrown: OCP\\Files\\NotFoundException"
  }
}
```