### PR TITLE
chore: Skip files list in sharing tests

### DIFF
--- a/cypress/e2e/share.spec.js
+++ b/cypress/e2e/share.spec.js
@@ -43,7 +43,6 @@ describe('Open test.md in viewer', function() {
 	})
 	beforeEach(function() {
 		cy.login(user)
-		cy.visit('/apps/files')
 	})
 
 	it('Shares the file as a public read only link', function() {


### PR DESCRIPTION
Planned to debug the failing test, and seems removing an unrelated speed up stabilizes them already. Seems to pass during a few pushes

We can skip loading the files list in as we don't need it when the share request is done through the API.
