### PR TITLE
fix: Make edit mode in interactive widgets opt-in

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -33,7 +33,7 @@
 			:has-connection-issue="hasConnectionIssue"
 			@reconnect="reconnect" />
 
-		<SkeletonLoading v-if="!contentLoaded && !displayedStatus" />
+		<SkeletonLoading v-if="showLoadingSkeleton" />
 		<Wrapper v-if="displayed"
 			:sync-error="syncError"
 			:has-connection-issue="hasConnectionIssue"
@@ -285,6 +285,9 @@ export default {
 		},
 		displayedStatus() {
 			return this.displayed || !!this.syncError
+		},
+		showLoadingSkeleton() {
+			return (!this.contentLoaded || !this.displayed) && !this.syncError
 		},
 		renderRichEditorMenus() {
 			return this.contentLoaded

--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -35,7 +35,7 @@
 		data-text-el="editor-container"
 		class="text-editor source-viewer">
 		<Component :is="readerComponent" :content="content" />
-		<NcButton class="toggle-interactive" @click="toggleEdit">
+		<NcButton v-if="isEmbedded" class="toggle-interactive" @click="toggleEdit">
 			{{ t('text', 'Edit') }}
 			<template #icon>
 				<PencilIcon />
@@ -45,22 +45,27 @@
 </template>
 
 <script>
+import Vue from 'vue'
 import axios from '@nextcloud/axios'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import PlainTextReader from './PlainTextReader.vue'
 import RichTextReader from './RichTextReader.vue'
+import { translate, translatePlural } from '@nextcloud/l10n'
 
 import { getSharingToken } from '../helpers/token.js'
 import getEditorInstance from './Editor.singleton.js'
 
+Vue.prototype.t = translate
+Vue.prototype.n = translatePlural
+
 export default {
 	name: 'ViewerComponent',
 	components: {
-		NcButton,
-		PencilIcon,
-		RichTextReader,
-		PlainTextReader,
+		NcButton: Vue.extend(NcButton),
+		PencilIcon: Vue.extend(PencilIcon),
+		RichTextReader: Vue.extend(RichTextReader),
+		PlainTextReader: Vue.extend(PlainTextReader),
 		Editor: getEditorInstance,
 	},
 	provide() {
@@ -139,6 +144,7 @@ export default {
 	},
 
 	methods: {
+		t: translate,
 		async loadFileContent() {
 			if (this.useSourceView) {
 				const response = await axios.get(this.source)

--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -27,6 +27,7 @@
 		:active="active || isEmbedded"
 		:autofocus="autofocus"
 		:share-token="shareToken"
+		:class="{ 'text-editor--embedding': isEmbedded }"
 		:mime="mime"
 		:show-outline-outside="showOutlineOutside" />
 	<div v-else
@@ -34,11 +35,19 @@
 		data-text-el="editor-container"
 		class="text-editor source-viewer">
 		<Component :is="readerComponent" :content="content" />
+		<NcButton class="toggle-interactive" @click="toggleEdit">
+			{{ t('text', 'Edit') }}
+			<template #icon>
+				<PencilIcon />
+			</template>
+		</NcButton>
 	</div>
 </template>
 
 <script>
 import axios from '@nextcloud/axios'
+import PencilIcon from 'vue-material-design-icons/Pencil.vue'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import PlainTextReader from './PlainTextReader.vue'
 import RichTextReader from './RichTextReader.vue'
 
@@ -48,6 +57,8 @@ import getEditorInstance from './Editor.singleton.js'
 export default {
 	name: 'ViewerComponent',
 	components: {
+		NcButton,
+		PencilIcon,
 		RichTextReader,
 		PlainTextReader,
 		Editor: getEditorInstance,
@@ -102,12 +113,13 @@ export default {
 	data() {
 		return {
 			content: '',
+			hasToggledInteractiveEmbedding: false,
 		}
 	},
 	computed: {
 		/** @return {boolean} */
 		useSourceView() {
-			return this.source && (this.fileVersion || !this.fileid)
+			return this.source && (this.fileVersion || !this.fileid || this.isEmbedded) && !this.hasToggledInteractiveEmbedding
 		},
 
 		/** @return {boolean} */
@@ -135,6 +147,9 @@ export default {
 			}
 			this.$emit('update:loaded', true)
 		},
+		toggleEdit() {
+			this.hasToggledInteractiveEmbedding = true
+		},
 	},
 }
 </script>
@@ -151,10 +166,26 @@ export default {
 	background-color: var(--color-main-background);
 
 	&.source-viewer {
+		display: block;
+
 		.text-editor__content-wrapper {
 			margin-top: var(--header-height);
 		}
+
+		.toggle-interactive {
+			position: sticky;
+			bottom: 0;
+			right: 0;
+			z-index: 1;
+			margin-left: auto;
+			margin-right: 0;
+		}
 	}
+
+	&.text-editor--embedding {
+		min-height: 400px;
+	}
+
 }
 </style>
 <style lang="scss">


### PR DESCRIPTION
- fix: Make edit mode in interactive widgets opt-in
- fix: Show skeleton loading until file is actually ready

Fix #5532 
Fix #5542 

#### 🖼️ Screenshots

##### View only mode

<img width="734" alt="Screenshot 2024-03-28 at 14 14 32" src="https://github.com/nextcloud/text/assets/3404133/d6182272-167e-4f7b-9582-a01506e028b5">

##### Edit mode 

<img width="734" alt="Screenshot 2024-03-28 at 14 16 49" src="https://github.com/nextcloud/text/assets/3404133/ca8d4893-3170-44ad-bd0e-18e52010116d">
