### PR TITLE
fix: focus issue on translate modal, remove duplicate code

### DIFF
--- a/cypress/e2e/Assistant.spec.js
+++ b/cypress/e2e/Assistant.spec.js
@@ -73,4 +73,28 @@ describe('Assistant', () => {
 			.should('be.visible')
 			.should('contain', 'Hello World')
 	})
+
+	it('Open translate dialog', () => {
+		cy.isolateTest({
+			sourceFile: fileName,
+		})
+		cy.openFile(fileName, { force: true })
+
+		cy.getContent()
+			.click({ force: true })
+		cy.get('[data-cy="assistantMenu"]')
+			.click()
+		cy.get('[data-cy="open-translate"]')
+			.should('be.visible')
+			.click()
+
+		cy.get('[data-cy="translate-input"]')
+			.should('be.visible')
+			.click()
+		cy.get('[data-cy="translate-input"]')
+			.should('be.visible')
+			.type('Hello World')
+		cy.get('[data-cy="translate-input"]')
+			.should('be.focused')
+	})
 })

--- a/cypress/e2e/share.spec.js
+++ b/cypress/e2e/share.spec.js
@@ -117,7 +117,7 @@ describe('Open test.md in viewer', function() {
 				cy.getModal().getContent().should('contain', 'Hello world')
 				cy.getModal().getContent().find('h2').should('contain', 'Hello world')
 				cy.getModal().find('.modal-header button.header-close').click()
-				cy.get('.modal-mask').should('not.exist')
+				cy.get('.modal-mask').should('not.be.visible')
 				// cy.get('#rich-workspace').getContent().should('contain', 'Hello world')
 			})
 	})

--- a/src/components/Assistant.vue
+++ b/src/components/Assistant.vue
@@ -43,7 +43,7 @@
 					</template>
 					{{ provider.name }}
 				</NcActionButton>
-				<NcActionButton close-after-click @click="openTranslateDialog">
+				<NcActionButton data-cy="open-translate" close-after-click @click="openTranslateDialog">
 					<template #icon>
 						<TranslateVariant :size="20" />
 					</template>
@@ -295,6 +295,9 @@ export default {
 			await this.fetchTasks()
 		},
 		openTranslateDialog() {
+			if (!this.selection.trim().length) {
+				this.$editor.commands.selectAll()
+			}
 			emit('text:translate-modal:show', { content: this.selection || '' })
 		},
 		async openResult(task) {

--- a/src/components/Assistant.vue
+++ b/src/components/Assistant.vue
@@ -63,12 +63,6 @@
 				class="floating-menu--badge" />
 		</FloatingMenu>
 
-		<Translate v-if="displayTranslate !== false"
-			:content="displayTranslate"
-			@insert-content="translateInsert"
-			@replace-content="translateReplace"
-			@close="hideTranslate" />
-
 		<NcModal :show.sync="showTaskList">
 			<div class="task-list">
 				<h4 v-if="tasks.length > 0">
@@ -154,8 +148,7 @@ import {
 	useIsPublicMixin,
 } from './Editor.provider.js'
 import { FloatingMenu } from '@tiptap/vue-2'
-import Translate from './Modal/Translate.vue'
-import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 
 const limitInRange = (num, min, max) => {
 	return Math.min(Math.max(parseInt(num), parseInt(min)), parseInt(max))
@@ -170,7 +163,6 @@ const STATUS_UNKNOWN = 0
 export default {
 	name: 'Assistant',
 	components: {
-		Translate,
 		FloatingMenu,
 		ErrorIcon,
 		CreationIcon,
@@ -209,7 +201,6 @@ export default {
 			STATUS_UNKNOWN,
 
 			showTaskList: false,
-			displayTranslate: false,
 			canTranslate: loadState('text', 'translation_languages', []).length > 0,
 		}
 	},
@@ -304,27 +295,7 @@ export default {
 			await this.fetchTasks()
 		},
 		openTranslateDialog() {
-			this.displayTranslate = this.selection
-		},
-		hideTranslate() {
-			this.displayTranslate = false
-		},
-		translateInsert(content) {
-			this.$editor.commands.command(({ tr, commands }) => {
-				return commands.insertContentAt(tr.selection.to, content)
-			})
-			this.displayTranslate = false
-		},
-		translateReplace(content) {
-			this.$editor.commands.command(({ tr, commands }) => {
-				const selection = tr.selection
-				const range = {
-					from: selection.from,
-					to: selection.to,
-				}
-				return commands.insertContentAt(range, content)
-			})
-			this.displayTranslate = false
+			emit('text:translate-modal:show', { content: this.selection || '' })
 		},
 		async openResult(task) {
 			window.OCA?.TPAssistant.openAssistantResult(task)

--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -58,7 +58,7 @@
 				:can-be-focussed="activeMenuEntry === visibleEntries.length"
 				@click="activeMenuEntry = 'remain'">
 				<template #lastAction="{ visible }">
-					<NcActionButton close-after-click v-if="canTranslate" @click="showTranslate">
+					<NcActionButton v-if="canTranslate" close-after-click @click="showTranslate">
 						<template #icon>
 							<TranslateVariant />
 						</template>

--- a/src/components/Modal/Translate.vue
+++ b/src/components/Modal/Translate.vue
@@ -39,6 +39,7 @@
 						:value.sync="input"
 						:label="t('text', 'Text to translate from')"
 						autofocus
+						data-cy="translate-input"
 						input-class="translate-textarea"
 						resize="none"
 						@focus="onInputFocus" />

--- a/src/components/Modal/Translate.vue
+++ b/src/components/Modal/Translate.vue
@@ -20,7 +20,7 @@
   -->
 
 <template>
-	<NcModal size="large" @close="$emit('close')">
+	<NcModal :show="show" size="large" @close="$emit('close')">
 		<div class="translate-dialog">
 			<h2>{{ t('text', 'Translate') }}</h2>
 			<em>{{ t('text', 'To translate individual parts of the text, select it before using the translate function.') }}</em>
@@ -106,6 +106,10 @@ export default {
 		useIsMobileMixin,
 	],
 	props: {
+		show: {
+			type: Boolean,
+			default: false,
+		},
 		content: {
 			type: String,
 			default: '',
@@ -165,6 +169,9 @@ export default {
 		},
 	},
 	watch: {
+		content() {
+			this.input = this.content
+		},
 		input() {
 			this.result = null
 			this.error = null
@@ -246,6 +253,7 @@ export default {
 		resize: none;
 		box-sizing: border-box;
 		overflow-y: auto;
+		min-height: 62px;
 		max-height: 58vh;
 	}
 }


### PR DESCRIPTION
### 📝 Summary

* Resolves: #5576
* Fix focus issue on translate modal
* Reduce duplicate code

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
