### PR TITLE
fix(imageview): Don't try to load unresolved images

### DIFF
--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -243,6 +243,9 @@ export default {
 	methods: {
 		async loadPreview() {
 			this.attachment = await this.$attachmentResolver.resolve(this.src)
+			if (!this.attachment.previewUrl) {
+				throw new Error('Attachment source was not resolved')
+			}
 			return new Promise((resolve, reject) => {
 				const img = new Image()
 				img.onload = async () => {


### PR DESCRIPTION
### 📝 Summary

Currently a lot of people on our instance get bruteforce protected in Talk regularly. After some log reading it seems to always happen when interactive widgets are involved.
After some trying the smallest possible test is:

1. Create a test.md file with the following content: (on our instance it's `.attachment` links with wrong file ids)
    ```md
    ![](C.png)
    ```
2. Copy the `/f/...` link and post it into a chat
3. Check the browser console for calls to `index.php/call/undefined`

After some debugging I found this trace. The problem is the "default" resolver responds:
https://github.com/nextcloud/text/blob/648cf2036f229eaa5b00e8d4f83c763da1d5d564/src/components/Editor.provider.js#L91-L94
This means that
https://github.com/nextcloud/text/blob/99e7a7a1b842516c1b29ac4574f9ceee49e47a55/src/nodes/ImageView.vue#L245
makes `this.attachment = [this.src]`
in the Promise it sets `img.src = this.attachment.previewUrl` but `previewUrl` is undefined as only `0` exists.
This will make the browser load `undefined` relative to the current page which results in `https://localhost/index.php/call/undefined`
This however looks like you are trying to open a conversation with the token `undefined`, but you have no access to it => bruteforce registered.

by simply checking if `previewUrl` exists and otherwise jumping into the fail mode, it prevents the request to load `index.php/call/undefined` and so also no bruteforce attempt it registered.

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
