### PR TITLE
fix: Avoid throwing when a workspace file cannot be found due to a failed storage

### DIFF
--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -6,6 +6,7 @@ namespace OCA\Text\Service;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
+use OCP\Files\StorageInvalidException;
 use OCP\IL10N;
 
 class WorkspaceService {
@@ -29,7 +30,8 @@ class WorkspaceService {
 					if ($file instanceof File) {
 						return $file;
 					}
-				} catch (NotFoundException $e) {
+				} catch (NotFoundException|StorageInvalidException) {
+					return null;
 				}
 			}
 		}


### PR DESCRIPTION
This fixes an uncaught exception found in some log where a federated share has been throwing `"message": "Sabre\\HTTP\\ClientHttpException: Unauthorized",` while trying to iterate over rich workspace file candidates which lead to the files list not loading.