### PR TITLE
fix(links): 5539 close link bubble on click outside

### DIFF
--- a/cypress/e2e/nodes/Links.spec.js
+++ b/cypress/e2e/nodes/Links.spec.js
@@ -41,14 +41,32 @@ describe('test link marks', function() {
 			cy.getContent()
 				.type(`${link}{enter}`)
 			cy.getContent()
-				.type('{upArrow}')
+				.find(`a[href*="${link}"]`)
 
 			cy.getContent()
-				.find(`a[href*="${link}"]`)
+				.type('{upArrow}')
 
 			cy.get('.link-view-bubble .widget-default', { timeout: 10000 })
 				.find('.widget-default--name')
 				.contains('Nextcloud')
+		})
+
+		it('closes the link bubble when clicking elsewhere', () => {
+			const link = 'https://nextcloud.com/'
+			cy.getContent()
+				.type(`${link}{enter}`)
+			cy.getContent()
+				.find(`a[href*="${link}"]`)
+			cy.getContent()
+				.type('{upArrow}')
+			cy.get('.link-view-bubble .widget-default', { timeout: 10000 })
+				.find('.widget-default--name')
+				.contains('Nextcloud')
+
+			cy.get('[role="dialog"] h2.modal-name').click()
+
+			cy.get('.link-view-bubble .widget-default')
+				.should('not.exist')
 		})
 
 		it('allows to edit a link in the bubble', () => {


### PR DESCRIPTION
### 📝 Summary

* Resolves: #5539 


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation is not required
