### PR TITLE
fix(l10n): "Connection failed" not translatable

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -595,7 +595,7 @@ export default {
 			}
 			if (type === ERROR_TYPE.CONNECTION_FAILED && !this.hasConnectionIssue) {
 				this.hasConnectionIssue = true
-				OC.Notification.showTemporary('Connection failed.')
+				OC.Notification.showTemporary(t('text', 'Connection failed.'))
 			}
 			if (type === ERROR_TYPE.SOURCE_NOT_FOUND) {
 				this.hasConnectionIssue = true


### PR DESCRIPTION
### 📝 Summary

The *Connection failed* popup was not translatable, i.e. always in English.

### 🏁 Checklist

- [X] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [X] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [X] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
