### PR TITLE
fix: disable callouts button when all callout variants are disabled

### DIFF
--- a/.github/workflows/block-merge-freeze.yml
+++ b/.github/workflows/block-merge-freeze.yml
@@ -19,11 +19,14 @@ concurrency:
 jobs:
   block-merges-during-freeze:
     name: Block merges during freezes
-
-    if: github.event.pull_request.draft == false
-
+    if: |
+      github.event.pull_request.draft == false
+      && (
+        startsWith(github.base_ref, 'stable')
+        || github.base_ref == 'main'
+        || github.base_ref == 'master'
+      )
     runs-on: ubuntu-latest-low
-
     steps:
       - name: Register server reference to fallback to master branch
         run: |

--- a/src/components/Menu/ActionList.vue
+++ b/src/components/Menu/ActionList.vue
@@ -31,7 +31,7 @@
 		:force-menu="true"
 		:data-text-action-entry="actionEntry.key"
 		:data-text-action-active="activeKey"
-		:disabled="isDisabled"
+		:disabled="!isEnabled"
 		@update:open="onOpenChange">
 		<template #icon>
 			<component :is="icon" :key="iconKey" />
@@ -77,7 +77,7 @@ export default {
 	},
 	data: () => ({
 		visible: false,
-		disabledChildren: [],
+		hasEnabledChild: true,
 	}),
 	computed: {
 		currentChild() {
@@ -130,8 +130,8 @@ export default {
 
 			return this.actionEntry.label
 		},
-		isDisabled() {
-			return !this.forceEnabled && this.disabledChildren.length === this.children.filter((child) => !child.isSeparator).length
+		isEnabled() {
+			return this.forceEnabled || this.hasEnabledChild
 		},
 	},
 	mounted() {
@@ -158,13 +158,11 @@ export default {
 			this.$emit('trigged', entry)
 		},
 		checkStateOfChildren() {
-			this.disabledChildren = this.children.filter((child) => {
-				if (child.isSeparator) {
-					return false
-				}
-				const { disabled } = getActionState(child, this.$editor)
-				return disabled
-			})
+			this.hasEnabledChild = this.children.some(child => this.isChildEnabled(child))
+		},
+		isChildEnabled(child) {
+			return !child.isSeparator
+				&& !getActionState(child, this.$editor).disabled
 		},
 	},
 }

--- a/src/components/Menu/ActionList.vue
+++ b/src/components/Menu/ActionList.vue
@@ -31,6 +31,7 @@
 		:force-menu="true"
 		:data-text-action-entry="actionEntry.key"
 		:data-text-action-active="activeKey"
+		:disabled="isDisabled"
 		@update:open="onOpenChange">
 		<template #icon>
 			<component :is="icon" :key="iconKey" />
@@ -53,10 +54,11 @@
 import { NcActions, NcActionSeparator } from '@nextcloud/vue'
 import { BaseActionEntry } from './BaseActionEntry.js'
 import ActionListItem from './ActionListItem.vue'
-import { getIsActive } from './utils.js'
+import { getActionState, getIsActive } from './utils.js'
 import { useOutlineStateMixin } from '../Editor/Wrapper.provider.js'
 import useStore from '../../mixins/store.js'
 import { useMenuIDMixin } from './MenuBar.provider.js'
+import debounce from 'debounce'
 
 export default {
 	name: 'ActionList',
@@ -67,8 +69,15 @@ export default {
 	},
 	extends: BaseActionEntry,
 	mixins: [useStore, useOutlineStateMixin, useMenuIDMixin],
+	props: {
+		forceEnabled: {
+			type: Boolean,
+			default: false,
+		},
+	},
 	data: () => ({
 		visible: false,
+		disabledChildren: [],
 	}),
 	computed: {
 		currentChild() {
@@ -121,6 +130,18 @@ export default {
 
 			return this.actionEntry.label
 		},
+		isDisabled() {
+			return !this.forceEnabled && this.disabledChildren.length === this.children.filter((child) => !child.isSeparator).length
+		},
+	},
+	mounted() {
+		this.$_updateState = debounce(this.checkStateOfChildren.bind(this), 50)
+		this.$editor.on('update', this.$_updateState)
+		this.$editor.on('selectionUpdate', this.$_updateState)
+	},
+	beforeDestroy() {
+		this.$editor.off('update', this.$_updateState)
+		this.$editor.off('selectionUpdate', this.$_updateState)
 	},
 	methods: {
 		onOpenChange(val) {
@@ -135,6 +156,15 @@ export default {
 			}
 			this.$editor.chain().focus().run()
 			this.$emit('trigged', entry)
+		},
+		checkStateOfChildren() {
+			this.disabledChildren = this.children.filter((child) => {
+				if (child.isSeparator) {
+					return false
+				}
+				const { disabled } = getActionState(child, this.$editor)
+				return disabled
+			})
 		},
 	},
 }

--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -56,6 +56,7 @@
 			<ActionList ref="remainingEntries"
 				:action-entry="hiddenEntries"
 				:can-be-focussed="activeMenuEntry === visibleEntries.length"
+				:force-enabled="true"
 				@click="activeMenuEntry = 'remain'">
 				<template #lastAction="{ visible }">
 					<NcActionButton v-if="canTranslate" close-after-click @click="showTranslate">


### PR DESCRIPTION
### 📝 Summary

* Resolves: #5460

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
