### PR TITLE
fix(linkBubble): load only when needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7937,9 +7937,9 @@
       "integrity": "sha512-A/8PwLk/T7IJDfUdQ68NR24QHa8rIlnN/stiJEBo6dmVUkD4K14LswG0w3VwdeK/o7qOwRUR1k2MhK5Rpy2m7A=="
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001509",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
-      "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
       "dev": true,
       "funding": [
         {
@@ -36579,9 +36579,9 @@
       "integrity": "sha512-A/8PwLk/T7IJDfUdQ68NR24QHa8rIlnN/stiJEBo6dmVUkD4K14LswG0w3VwdeK/o7qOwRUR1k2MhK5Rpy2m7A=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001509",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
-      "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
       "dev": true
     },
     "caseless": {

--- a/src/plugins/LinkBubblePluginView.js
+++ b/src/plugins/LinkBubblePluginView.js
@@ -24,7 +24,7 @@ class LinkBubblePluginView {
 		)
 		document.addEventListener('scroll',
 			this.closeOnExternalEvents,
-			{ capture: true }
+			{ capture: true },
 		)
 	}
 
@@ -37,7 +37,7 @@ class LinkBubblePluginView {
 		)
 		document.removeEventListener('scroll',
 			this.closeOnExternalEvents,
-			{ capture: true }
+			{ capture: true },
 		)
 	}
 

--- a/src/plugins/LinkBubblePluginView.js
+++ b/src/plugins/LinkBubblePluginView.js
@@ -13,14 +13,6 @@ class LinkBubblePluginView {
 		this.view = view
 		this.plugin = plugin
 		this.#editor = this.options.editor
-
-		this.#component = new VueRenderer(LinkBubbleView, {
-			parent: this.options.parent,
-			propsData: {
-				editor: this.options.editor,
-				href: null,
-			},
-		})
 	}
 
 	addEventListeners() {
@@ -71,6 +63,14 @@ class LinkBubblePluginView {
 			return
 		}
 
+		this.#component ||= new VueRenderer(LinkBubbleView, {
+			parent: this.options.parent,
+			propsData: {
+				editor: this.options.editor,
+				href: null,
+			},
+		})
+
 		this.tippy = tippy(editorElement, {
 			duration: 100,
 			getReferenceClientRect: null,
@@ -112,7 +112,7 @@ class LinkBubblePluginView {
 		}
 		const clientRect = referenceEl?.getBoundingClientRect()
 
-		this.#component.updateProps({
+		this.#component?.updateProps({
 			href: domHref(mark),
 		})
 

--- a/src/tests/nodes/TaskItem.spec.js
+++ b/src/tests/nodes/TaskItem.spec.js
@@ -18,7 +18,7 @@ describe('TaskItem extension', () => {
 		expect(taskItem.spec.toMarkdown).toBeDefined()
 	})
 
-	test('markdown syntax is preserved through editor', () => {
+	it('markdown syntax is preserved through editor', () => {
 		// Invalid ones but should be syntactical unchanged
 		expect(markdownThroughEditor('- [F] asd')).toBe('- [F] asd')
 		expect(markdownThroughEditor('- [ [asd](sdf)')).toBe('- [ [asd](sdf)')


### PR DESCRIPTION
### 📝 Summary

Prevents 503 requests during tests.
See https://github.com/nextcloud/text/issues/5442.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- Tests are improved by this (less noise).
- Documentation is not required
