### PR TITLE
test(cypress): Avoid failure when editor is updated on webdav requests

### DIFF
--- a/cypress/e2e/propfind.spec.js
+++ b/cypress/e2e/propfind.spec.js
@@ -33,7 +33,6 @@ describe('Text PROPFIND extension ', function() {
 
 	beforeEach(function() {
 		cy.login(user)
-		cy.visit('/apps/files')
 	})
 
 	describe('with workspaces enabled', function() {
@@ -45,7 +44,9 @@ describe('Text PROPFIND extension ', function() {
 		// Android app relies on this to detect rich workspace availability
 		it('always adds rich workspace property', function() {
 			cy.uploadFile('empty.md', 'text/markdown', '/Readme.md')
-			cy.visit('/apps/files')
+			// FIXME: Ideally we do not need a page context for those tests at all
+			// For now the dashboard avoids that we have failing requests due to conflicts when updating the file
+			cy.visit('/apps/dashboard')
 			cy.propfindFolder('/')
 				.should('have.property', richWorkspace, '')
 			cy.uploadFile('test.md', 'text/markdown', '/Readme.md')
@@ -59,7 +60,9 @@ describe('Text PROPFIND extension ', function() {
 		// Android app relies on this when navigating nested folders
 		it('adds rich workspace property to nested folders', function() {
 			cy.createFolder('/workspace')
-			cy.visit('/apps/files')
+			// FIXME: Ideally we do not need a page context for those tests at all
+			// For now the dashboard avoids that we have failing requests due to conflicts when updating the file
+			cy.visit('/apps/dashboard')
 			cy.propfindFolder('/', 1)
 				.then(results => results.pop().propStat[0].properties)
 				.should('have.property', richWorkspace, '')
@@ -78,7 +81,9 @@ describe('Text PROPFIND extension ', function() {
 		})
 
 		it('does not return a rich workspace property', function() {
-			cy.visit('/apps/files')
+			// FIXME: Ideally we do not need a page context for those tests at all
+			// For now the dashboard avoids that we have failing requests due to conflicts when updating the file
+			cy.visit('/apps/dashboard')
 			cy.propfindFolder('/')
 				.should('not.have.property', richWorkspace)
 			cy.uploadFile('test.md', 'text/markdown', '/Readme.md')


### PR DESCRIPTION
This should make the propfind tests more stable.

We manually upload different file content through webdav which might cause the current editor to throw an exception when the file is deleted.

In the end we don't really need the page context for the tests, however as we use the Nextcloud dav client, asserting propfind responses is a lot easier. Mid-term we could migrate to just use axios or cy.request for those.

Example failure can be seen in https://github.com/nextcloud/text/actions/runs/8952598767/job/24590191037?pr=5762.