### PR TITLE
feat(editor): Add keyboard shortcut (Ctrl-Alt-H) to toggle outline

### DIFF
--- a/src/components/Editor/EditorOutline.vue
+++ b/src/components/Editor/EditorOutline.vue
@@ -36,7 +36,7 @@ export default {
 	mounted() {
 		this.$resizeObserver = new ResizeObserver(this.onResize)
 		this.$resizeObserver.observe(this.$el.parentElement)
-		this.onResize()
+		this.onResize([this.$el.parentElement])
 	},
 	beforeDestroy() {
 		this.$resizeObserver.unobserve(this.$el.parentElement)

--- a/src/components/Editor/Wrapper.vue
+++ b/src/components/Editor/Wrapper.vue
@@ -127,11 +127,21 @@ export default {
 				Object.assign(this.outline, { enable })
 			},
 		)
+
+		document.addEventListener('keydown', this.handleKeyDown)
+	},
+	beforeDestroy() {
+		document.removeEventListener('keydown', this.handleKeyDown)
 	},
 	methods: {
 		outlineToggle() {
 			this.outline.visible = !this.outline.visible
 			this.$emit('outline-toggled', this.outline.visible)
+		},
+		handleKeyDown(event) {
+			if (event.ctrlKey && event.altKey && event.key === 'h') {
+				this.outlineToggle()
+			}
 		},
 	},
 

--- a/src/components/HelpModal.vue
+++ b/src/components/HelpModal.vue
@@ -1,10 +1,10 @@
 <template>
 	<NcDialog size="normal"
 		data-text-el="formatting-help"
-		:name="t('text', 'Formatting help')"
+		:name="t('text', 'Formatting and shortcuts')"
 		:close-on-click-outside="true"
 		@closing="$emit('close')">
-		<h2>{{ t('text', 'Formatting help') }}</h2>
+		<h2>{{ t('text', 'Formatting and shortcuts') }}</h2>
 		<p>{{ t('text', 'Speed up your writing with simple shortcuts.') }}</p>
 		<p v-if="!isMobileCached">
 			{{ t('text', 'Just type the Markdown syntax or use keyboard shortcuts from below.') }}
@@ -173,6 +173,64 @@
 						<code>``` {{ t('text', 'Some code') }}</code>
 					</td>
 					<td v-if="!isMobileCached" />
+				</tr>
+				<tr>
+					<td>{{ t('text', 'Insert emoji') }}</td>
+					<td>
+						<code>:{{ t('text', 'emoji') }}</code>
+					</td>
+					<td v-if="!isMobileCached" />
+				</tr>
+				<tr>
+					<td>{{ t('text', 'Mention someone') }}</td>
+					<td>
+						<code>@{{ t('text', 'name') }}</code>
+					</td>
+					<td v-if="!isMobileCached" />
+				</tr>
+				<tr>
+					<td>{{ t('text', 'Smart picker') }}</td>
+					<td>
+						<code>/{{ t('text', 'something') }}</code>
+					</td>
+					<td v-if="!isMobileCached" />
+				</tr>
+			</tbody>
+		</table>
+
+		<table vif="!isMobileCached">
+			<thead>
+				<tr>
+					<th>{{ t('text', 'Action') }}</th>
+					<th>{{ t('text', 'Keyboard shortcuts') }}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>{{ t('text', 'Undo') }}</td>
+					<td>
+						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						+
+						<kbd>Z</kbd>
+					</td>
+				</tr>
+				<tr>
+					<td>{{ t('text', 'Redo') }}</td>
+					<td>
+						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						+
+						<kbd>Y</kbd>
+					</td>
+				</tr>
+				<tr>
+					<td>{{ t('text', 'Toggle outline') }}</td>
+					<td>
+						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						+
+						<kbd>{{ t('text', 'Alt') }}</kbd>
+						+
+						<kbd>H</kbd>
+					</td>
 				</tr>
 			</tbody>
 		</table>


### PR DESCRIPTION
Fixes: #5798

Edit: shortcut changed to <kbd>Ctrl</kbd>-<kbd>Alt</kbd>-<kbd>H</kbd> like it's in Google Docs.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
