### PR TITLE
chore(deps): update @nextcloud/vue to 8.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4050,15 +4050,15 @@
       }
     },
     "node_modules/@nextcloud/calendar-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
-      "integrity": "sha512-thVS6Bz+TV7rUB+LO5yFbOhdm65zICDRKcHDUquaZiWL9r6TyV9hCYDcP7cDRV+62wZJh8QPmf1E+d7ZFUOVeA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-7.0.0.tgz",
+      "integrity": "sha512-CvCcO4hFPjMfIB2AKW0QLNYukGoHFS7QQVvIC8khJjzNfVGS6qMJd2oaZtD9Q9w1fLpvwp1X7orcYGYmosDkAA==",
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       },
       "peerDependencies": {
-        "ical.js": "^1.5.0",
+        "ical.js": "^2.0.1",
         "uuid": "^9.0.0"
       }
     },
@@ -4461,16 +4461,16 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.3.tgz",
-      "integrity": "sha512-W+0zsu8JIvHDI+DD+suYRBRqEGotgE4aBIPTLx7AxiL9CMTEzKP8g3hrEnpen9P7DBs6JpxIzsAWN7yyRzkP4w==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.12.0.tgz",
+      "integrity": "sha512-MHL12+XGIDvpsSdrJn79pYKYrTVUouEymc4No91lKTNZTWDN6bciDSprmMs553hECXrqj7sfwxu6sepj0zcR3Q==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "@nextcloud/auth": "^2.2.1",
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/browser-storage": "^0.4.0",
-        "@nextcloud/calendar-js": "^6.1.0",
+        "@nextcloud/calendar-js": "^7.0.0",
         "@nextcloud/capabilities": "^1.1.0",
         "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/initial-state": "^2.1.0",
@@ -4509,7 +4509,7 @@
       },
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/vue-select": {
@@ -12819,9 +12819,9 @@
       "dev": true
     },
     "node_modules/ical.js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.5.0.tgz",
-      "integrity": "sha512-7ZxMkogUkkaCx810yp0ZGKvq1ZpRgJeornPttpoxe6nYZ3NLesZe1wWMXDdwTkj/b5NtXT+Y16Aakph/ao98ZQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.0.1.tgz",
+      "integrity": "sha512-uYYb1CwTXbd9NP/xTtgQZ5ivv6bpUjQu9VM98s3X78L3XRu00uJW5ZtmnLwyxhztpf5fSiRyDpFW7ZNCePlaPw==",
       "peer": true
     },
     "node_modules/identity-obj-proxy": {
@@ -30954,9 +30954,9 @@
       "dev": true
     },
     "@nextcloud/calendar-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
-      "integrity": "sha512-thVS6Bz+TV7rUB+LO5yFbOhdm65zICDRKcHDUquaZiWL9r6TyV9hCYDcP7cDRV+62wZJh8QPmf1E+d7ZFUOVeA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-7.0.0.tgz",
+      "integrity": "sha512-CvCcO4hFPjMfIB2AKW0QLNYukGoHFS7QQVvIC8khJjzNfVGS6qMJd2oaZtD9Q9w1fLpvwp1X7orcYGYmosDkAA==",
       "requires": {}
     },
     "@nextcloud/capabilities": {
@@ -31231,16 +31231,16 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.3.tgz",
-      "integrity": "sha512-W+0zsu8JIvHDI+DD+suYRBRqEGotgE4aBIPTLx7AxiL9CMTEzKP8g3hrEnpen9P7DBs6JpxIzsAWN7yyRzkP4w==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.12.0.tgz",
+      "integrity": "sha512-MHL12+XGIDvpsSdrJn79pYKYrTVUouEymc4No91lKTNZTWDN6bciDSprmMs553hECXrqj7sfwxu6sepj0zcR3Q==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "@nextcloud/auth": "^2.2.1",
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/browser-storage": "^0.4.0",
-        "@nextcloud/calendar-js": "^6.1.0",
+        "@nextcloud/calendar-js": "^7.0.0",
         "@nextcloud/capabilities": "^1.1.0",
         "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/initial-state": "^2.1.0",
@@ -37453,9 +37453,9 @@
       "dev": true
     },
     "ical.js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.5.0.tgz",
-      "integrity": "sha512-7ZxMkogUkkaCx810yp0ZGKvq1ZpRgJeornPttpoxe6nYZ3NLesZe1wWMXDdwTkj/b5NtXT+Y16Aakph/ao98ZQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.0.1.tgz",
+      "integrity": "sha512-uYYb1CwTXbd9NP/xTtgQZ5ivv6bpUjQu9VM98s3X78L3XRu00uJW5ZtmnLwyxhztpf5fSiRyDpFW7ZNCePlaPw==",
       "peer": true
     },
     "identity-obj-proxy": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nextcloud/logger": "^3.0.2",
     "@nextcloud/moment": "^1.3.1",
     "@nextcloud/router": "^3.0.1",
-    "@nextcloud/vue": "^8.11.3",
+    "@nextcloud/vue": "^8.12.0",
     "@quartzy/markdown-it-mentions": "^0.2.0",
     "@tiptap/core": "^2.3.2",
     "@tiptap/extension-blockquote": "^2.3.2",


### PR DESCRIPTION
Fixes flaky cypress SmartPicker test.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
