### PR TITLE
fix(ci): stop building main assets for now

### DIFF
--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       # implemented since 28, once branched off, add your stable branch here
-      - main
+      # disabled as vite builds are non-deterministic - main
       - stable29
       - stable28
 


### PR DESCRIPTION
With vite our builds are not deteministic anymore. And our recompile job only checked if compiling the assets changed anything. If it does it pushes a commit.

So now it always pushes a commit.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
