### PR TITLE
fix(ci): build on main again

### DIFF
--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       # implemented since 28, once branched off, add your stable branch here
-      # disabled as vite builds are non-deterministic - main
+      - main
       - stable29
       - stable28
 
@@ -43,7 +43,18 @@ jobs:
         run: |
           git config --local user.email "nextcloud-command@users.noreply.github.com"
           git config --local user.name "nextcloud-command"
+
+      - name: Get last commit message if it was not a recompile
+        id: last_commit
+        run: |
+          {
+            echo'MESSAGE<<EOF'
+            git log -1 --pretty=%s | grep -v '^chore(assets): recompile assets$'
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
       - name: Install dependencies & build
+        if: steps.last_commit.outputs.MESSAGE != ''
         env:
           CYPRESS_INSTALL_BINARY: 0
         run: |


### PR DESCRIPTION
Only build if last commit was not recompiling assets already

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
