### PR TITLE
fix(ci): typo in update-node-dist workflow

### DIFF
--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -48,7 +48,7 @@ jobs:
         id: last_commit
         run: |
           {
-            echo'MESSAGE<<EOF'
+            echo 'MESSAGE<<EOF'
             git log -1 --pretty=%s | grep -v '^chore(assets): recompile assets$'
             echo 'EOF'
           } >> $GITHUB_OUTPUT


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
