### PR TITLE
fix(ci): handle grep with no results gracefully

### DIFF
--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           {
             echo 'MESSAGE<<EOF'
-            git log -1 --pretty=%s | grep -v '^chore(assets): recompile assets$'
+            git log -1 --pretty=%s | grep -v '^chore(assets): recompile assets$' || test $? -eq 1
             echo 'EOF'
           } >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
`grep` will return an exit code of 1 if no result was found.

Check for that and let the job continue.

In case of errors grep will return a higher exit code and the job will abort as intended.


#### 🖼️ Screenshots

🏚️ Before

![grafik](https://github.com/nextcloud/text/assets/97337118/de6e2375-e0f3-45f1-8e76-dd85dfd06fc0)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
