### PR TITLE
fix: smartpicker set links for selected text

### DIFF
--- a/src/components/Menu/ActionInsertLink.vue
+++ b/src/components/Menu/ActionInsertLink.vue
@@ -200,7 +200,7 @@ export default {
 			// Avoid issues when parsing urls later on in markdown that might be entered in an invalid format (e.g. "mailto: example@example.com")
 			const href = url.replaceAll(' ', '%20')
 			const chain = this.$editor.chain()
-			// Check if any text is selected, if not insert the lunk using the given text property
+			// Check if any text is selected, if not insert the link using the given text property
 			if (this.$editor.view.state?.selection.empty) {
 				chain.insertContent({
 					type: 'paragraph',
@@ -231,11 +231,12 @@ export default {
 		linkPicker() {
 			getLinkWithPicker(null, true)
 				.then(link => {
-					this.$editor
-						.chain()
-						.focus()
-						.insertContent(link + ' ')
-						.run()
+					const chain = this.$editor.chain()
+					if (this.$editor.view.state?.selection.empty) {
+						chain.focus().insertContent(link + ' ').run()
+					} else {
+						chain.setLink({ href: link }).focus().run()
+					}
 				})
 				.catch(error => {
 					console.error('Smart picker promise rejected', error)


### PR DESCRIPTION
### 📝 Summary

* Resolves: #4783 

If a text is selected, the smartpicker links the selected text. If nothing is selected, it inserts the link. 

#### 🖼️ Video
[Screencast from 05-27-2024 06:36:27 AM.webm](https://github.com/nextcloud/text/assets/32180937/0a4685de-272c-45d9-9b54-4f121c760c77)


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
