### PR TITLE
fix(PreviewOptions): Set buttons position to absolute

### DIFF
--- a/src/components/Editor/PreviewOptions.vue
+++ b/src/components/Editor/PreviewOptions.vue
@@ -82,7 +82,7 @@ export default {
 
 <style lang="scss" scoped>
 
-[data-text-preview-options] {
+div[data-text-preview-options] {
 	position: absolute;
 	left: -44px;
 }


### PR DESCRIPTION
### 📝 Summary

This probably broke with the migration to vite, because the CSS selector was not specific enough.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud/text/assets/3582805/b5942479-4481-409f-b7b1-f5ed0adf37e6) | ![grafik](https://github.com/nextcloud/text/assets/3582805/4e9fc107-e179-4645-aec5-d3f4eff89504)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
