### PR TITLE
fix(preview): prev token can be undefined in `isPreviewLinkInParagraph`

### DIFF
--- a/src/markdownit/preview.js
+++ b/src/markdownit/preview.js
@@ -27,7 +27,7 @@
  */
 function isPreviewLinkInParagraph(tokens, i) {
 	const [prev, cur, next] = tokens.slice(i - 1, i + 2)
-	return prev.type === 'paragraph_open'
+	return prev?.type === 'paragraph_open'
 		&& cur.type === 'inline'
 		&& cur.children
 		&& cur.children.length === 3


### PR DESCRIPTION
This fixes links and previews in read-only mode in Collectives.

Fixes: nextcloud/collectives#1231

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
