### PR TITLE
fix(SmartPicker): Insert smart picker links as preview per default

### DIFF
--- a/cypress/e2e/nodes/Preview.spec.js
+++ b/cypress/e2e/nodes/Preview.spec.js
@@ -129,6 +129,21 @@ describe('Preview extension', { retries: 0 }, () => {
 
 	})
 
+	describe('insertPreview command', { retries: 0 }, () => {
+
+		it('is available in commands', () => {
+			expect(editor.commands).to.have.property('insertPreview')
+		})
+
+		it('inserts a preview', () => {
+			editor.commands.clearContent()
+			editor.commands.insertPreview('https://nextcloud.com')
+			editor.commands.setTextSelection(1)
+			expectPreview()
+		})
+
+	})
+
 	/**
 	 *  Expect a preview in the editor.
 	 */

--- a/src/components/Menu/ActionInsertLink.vue
+++ b/src/components/Menu/ActionInsertLink.vue
@@ -219,7 +219,7 @@ export default {
 				.then(link => {
 					const chain = this.$editor.chain()
 					if (this.$editor.view.state?.selection.empty) {
-						chain.focus().insertContent(link + ' ').run()
+						chain.focus().insertPreview(link).run()
 					} else {
 						chain.setLink({ href: link }).focus().run()
 					}

--- a/src/components/Suggestion/LinkPicker/suggestions.js
+++ b/src/components/Suggestion/LinkPicker/suggestions.js
@@ -86,7 +86,8 @@ export default () => createSuggestions({
 				editor
 					.chain()
 					.focus()
-					.insertContentAt(range, content + ' ')
+					.deleteRange(range)
+					.insertPreview(link)
 					.run()
 			})
 			.catch(error => {

--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -62,6 +62,7 @@ export default Node.create({
 		state.write('[')
 		state.text(node.textContent, false)
 		state.write(`](${node.attrs.href} (${node.attrs.title}))`)
+		state.closeBlock(node)
 	},
 
 	addCommands() {
@@ -84,13 +85,32 @@ export default Node.create({
 			 *
 			 */
 			unsetPreview: () => ({ state, chain }) => {
-				console.info(this.attributes)
 				return isActive(this.name, this.attributes, state)
 					&& chain()
 						.setNode('paragraph')
 						.run()
 			},
 
+			/**
+			 * Insert a preview for given link.
+			 *
+			 */
+			insertPreview: (link) => ({ state, chain }) => {
+				return chain()
+					.insertContent({
+						type: 'preview',
+						attrs: { href: link, title: 'preview' },
+						content: [{
+							type: 'text',
+							marks: [{
+								type: 'link',
+								attrs: { href: link },
+							}],
+							text: link,
+						}],
+					})
+					.run()
+			},
 		}
 	},
 })


### PR DESCRIPTION
### Summary

* Fixes: #5838

Behaviour:
* Inserts a link preview with smart picker from the toolbar if editor selection is empty
* Inserts a text link with smart picker from the toolbar if editor selection is *not* empty
* Always inserts a link preview with smart picker from `/` command as it's impossible to have ane editor selection when typing `/`

#### 🖼️ Screenshots

| 🏡 Screencast |
|--- |
| ![recording1](https://github.com/nextcloud/text/assets/3582805/7fa3c7fa-810c-410d-9601-d508ef0e33bf) |

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
