### PR TITLE
test(cypress): Fix selector for new button in files app

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -425,7 +425,7 @@ Cypress.Commands.add('createDescription', (buttonLabel = 'Add folder description
 		.as('addDescription')
 
 	cy.get('[data-cy-files-list] tr[data-cy-files-list-row-name="Readme.md"]').should('not.exist')
-	cy.get('[data-cy-upload-picker] button.action-item__menutoggle').click()
+	cy.get('[data-cy-files-content-breadcrumbs] [data-cy-upload-picker] button.action-item__menutoggle').click()
 	cy.get('li.upload-picker__menu-entry button').contains(buttonLabel).click()
 
 	cy.wait('@addDescription')


### PR DESCRIPTION
Make it more specific to only select the button in breadcrumbs. In empty folders, there's a similar button in the emptycontent now.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
