### PR TITLE
fix(locks): only lock when editing

### DIFF
--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -164,9 +164,11 @@ class ApiService {
 			$lockInfo = null;
 		}
 
-		$isLocked = $this->documentService->lock($file->getId());
-		if (!$isLocked) {
-			$readOnly = true;
+		if (!$readOnly) {
+			$isLocked = $this->documentService->lock($file->getId());
+			if (!$isLocked) {
+				$readOnly = true;
+			}
 		}
 
 		return new DataResponse([


### PR DESCRIPTION
### 📝 Summary

Read only shares should not lock a document.

Prevent file sync conflicts when nobody is editing.

See #5862.



### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
