### PR TITLE
perf: Lazy load optional dependencies

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { createAppConfig } from '@nextcloud/vite-config'
+import { webpackStats } from 'rollup-plugin-webpack-stats'
 import path from 'path'
-import { webpackStats } from 'rollup-plugin-webpack-stats';
 
 const ENTRIES_TO_INCLUDE_CSS = ['text', 'public', 'viewer', 'editors']
 
@@ -29,6 +29,18 @@ const config = createAppConfig({
 		plugins: [
 			webpackStats(),
 		],
+		build: {
+			rollupOptions: {
+				output: {
+					manualChunks: (id) => {
+						// Make the emoji related dependencies a custom chunk to reduce the size of the RichText chunk
+						if (id.includes('emoji-mart-vue') || id.includes('emoji-datasource')) {
+							return 'emoji-picker'
+						}
+					},
+				},
+			},
+		},
 	},
 })
 


### PR DESCRIPTION
### 📝 Summary

Currently mermaid JS is always imported, but mermaid JS is *huge* (6MiB code and 3MiB minified).
So instead this imports the mermaid module only if really required the first time.
This will reduce the default loading of the text app by ~1MiB gziped assets.

Also make a custom chunk for the emoji picker to split the nextcloud vue chunk into better loadable ones (2x 700kiB instead of 1500 kiB).


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
