### PR TITLE
Reset all sessions (in occ command and on upgrade)

### DIFF
--- a/lib/Migration/ResetSessionsBeforeYjs.php
+++ b/lib/Migration/ResetSessionsBeforeYjs.php
@@ -2,54 +2,43 @@
 
 namespace OCA\Text\Migration;
 
-use OCA\Text\Db\SessionMapper;
+use OCA\Text\Db\Document;
 use OCA\Text\Service\DocumentService;
 use OCP\IAppConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class ResetSessionsBeforeYjs implements IRepairStep {
-	private IAppConfig $config;
-	private SessionMapper $sessionMapper;
-	private DocumentService $documentService;
-
-	public function __construct(IAppConfig $config,
-		SessionMapper $sessionMapper,
-		DocumentService $documentService) {
-		$this->config = $config;
-		$this->sessionMapper = $sessionMapper;
-		$this->documentService = $documentService;
+	public function __construct(private IAppConfig $config,
+		private DocumentService $documentService) {
 	}
 
 	/**
 	 * @return string
 	 */
 	public function getName(): string {
-		return 'Force-reset all Text sessions before Yjs migration';
+		return 'Force-reset all Text document sessions';
 	}
 
-	/**
-	 * @param IOutput $output
-	 *
-	 * @return void
-	 */
 	public function run(IOutput $output): void {
 		$appVersion = $this->config->getValueString('text', 'installed_version');
 
-		if (!$appVersion || version_compare($appVersion, '3.7.2') !== -1) {
+		if (!$appVersion || version_compare($appVersion, '4.0.1') !== -1) {
 			return;
 		}
 
-		$sessions = $this->sessionMapper->findAllDocuments();
-		if (!$sessions) {
+		$fileIds = array_map(static function (Document $document) {
+			return $document->getId();
+		}, $this->documentService->getAll());
+
+		if (!$fileIds) {
 			return;
 		}
 
-		$output->startProgress(count($sessions));
-		foreach ($sessions as $session) {
-			$documentId = $session->getDocumentId();
-			$this->documentService->unlock($documentId);
-			$this->documentService->resetDocument($documentId, true);
+		$output->startProgress(count($fileIds));
+		foreach ($fileIds as $fileId) {
+			$this->documentService->unlock($fileId);
+			$this->documentService->resetDocument($fileId, true);
 			$output->advance();
 		}
 		$output->finishProgress();


### PR DESCRIPTION
### 📝 Summary

* feat(reset): Add `--all` option to `text:reset` occ command
* fix(reset): Reset all document sessions on upgrades from 4.0.0 or below
* Fixes: #5420
* Fixes: nextcloud/collectives#1270

:warning: Reminder: Versions and version comparison need adjustments when backporting to stable branches.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
