### PR TITLE
fix: Ignore pushes of update steps for read only sessions

### DIFF
--- a/lib/YjsMessage.php
+++ b/lib/YjsMessage.php
@@ -82,4 +82,17 @@ class YjsMessage {
 		return $syncType;
 	}
 
+	/**
+	 * Based on https://github.com/yjs/y-protocols/blob/master/PROTOCOL.md#handling-read-only-users
+	 */
+	public function isUpdate(): bool {
+		if ($this->getYjsMessageType() === self::YJS_MESSAGE_SYNC) {
+			if (in_array($this->getYjsSyncType(), [self::YJS_MESSAGE_SYNC_STEP2, self::YJS_MESSAGE_SYNC_UPDATE])) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 }


### PR DESCRIPTION
My suggestion for now would be to block any update steps for read only sessions according to what is described in the y.js protocol docs.

https://github.com/yjs/y-protocols/blob/master/PROTOCOL.md#handling-read-only-users

Ideally we'd of course also prevent sending those in the frontend code, but for now this seems the most reasonable quick fix.
