### PR TITLE
perf: Use generator/count query on cleanup tasks

### DIFF
--- a/lib/Command/ResetDocument.php
+++ b/lib/Command/ResetDocument.php
@@ -6,7 +6,6 @@
 
 namespace OCA\Text\Command;
 
-use OCA\Text\Db\Document;
 use OCA\Text\Exception\DocumentHasUnsavedChangesException;
 use OCA\Text\Service\DocumentService;
 use Symfony\Component\Console\Command\Command;
@@ -61,9 +60,7 @@ class ResetDocument extends Command {
 		}
 
 		if ($all) {
-			$fileIds = array_map(static function (Document $document) {
-				return $document->getId();
-			}, $this->documentService->getAll());
+			$fileIds = $this->documentService->getAll();
 		} else {
 			$fileIds = [$fileId];
 		}

--- a/lib/Cron/Cleanup.php
+++ b/lib/Cron/Cleanup.php
@@ -16,6 +16,7 @@ use OCA\Text\Service\DocumentService;
 use OCA\Text\Service\SessionService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
 class Cleanup extends TimedJob {
@@ -26,7 +27,9 @@ class Cleanup extends TimedJob {
 	public function __construct(ITimeFactory $time,
 		SessionService $sessionService,
 		DocumentService $documentService,
-		LoggerInterface $logger) {
+		LoggerInterface $logger,
+		private IConfig $config,
+	) {
 		parent::__construct($time);
 		$this->sessionService = $sessionService;
 		$this->documentService = $documentService;

--- a/lib/Cron/Cleanup.php
+++ b/lib/Cron/Cleanup.php
@@ -39,10 +39,8 @@ class Cleanup extends TimedJob {
 	 */
 	protected function run($argument): void {
 		$this->logger->debug('Run cleanup job for text documents');
-		$documents = $this->documentService->getAll();
-		foreach ($documents as $document) {
-			$allSessions = $this->sessionService->getAllSessions($document->getId());
-			if (count($allSessions) > 0) {
+		foreach ($this->documentService->getAll() as $document) {
+			if ($this->sessionService->countAllSessions($document->getId()) > 0) {
 				// Do not reset if there are any sessions left
 				// Inactive sessions will get removed further down and will trigger a reset next time
 				continue;

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -68,6 +68,17 @@ class SessionMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
+	public function countAll(int $documentId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id', 'color', 'document_id', 'last_awareness_message', 'last_contact', 'user_id', 'guest_name')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('document_id', $qb->createNamedParameter($documentId)));
+		$result = $qb->executeQuery();
+		$count = (int)$result->fetchOne();
+		$result->closeCursor();
+		return $count;
+	}
+
 	/**
 	 * @return Session[]
 	 *

--- a/lib/Migration/ResetSessionsBeforeYjs.php
+++ b/lib/Migration/ResetSessionsBeforeYjs.php
@@ -7,14 +7,15 @@
 
 namespace OCA\Text\Migration;
 
-use OCA\Text\Service\DocumentService;
+use OCA\Text\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class ResetSessionsBeforeYjs implements IRepairStep {
-	public function __construct(private IAppConfig $config,
-		private DocumentService $documentService) {
+	public function __construct(
+		private IAppConfig $config,
+	) {
 	}
 
 	/**
@@ -31,13 +32,7 @@ class ResetSessionsBeforeYjs implements IRepairStep {
 			return;
 		}
 
-		$output->startProgress($this->documentService->countAll());
-		foreach ($this->documentService->getAll() as $document) {
-			$fileId = $document->getId();
-			$this->documentService->unlock($fileId);
-			$this->documentService->resetDocument($fileId, true);
-			$output->advance();
-		}
-		$output->finishProgress();
+		// Set the timestamp of the upgrade to reset documents when the create request tries to obtain the state
+		$this->config->setValueInt(Application::APP_NAME, 'update_reset_before', time());
 	}
 }

--- a/lib/Migration/ResetSessionsBeforeYjs.php
+++ b/lib/Migration/ResetSessionsBeforeYjs.php
@@ -7,7 +7,6 @@
 
 namespace OCA\Text\Migration;
 
-use OCA\Text\Db\Document;
 use OCA\Text\Service\DocumentService;
 use OCP\IAppConfig;
 use OCP\Migration\IOutput;
@@ -32,16 +31,9 @@ class ResetSessionsBeforeYjs implements IRepairStep {
 			return;
 		}
 
-		$fileIds = array_map(static function (Document $document) {
-			return $document->getId();
-		}, $this->documentService->getAll());
-
-		if (!$fileIds) {
-			return;
-		}
-
-		$output->startProgress(count($fileIds));
-		foreach ($fileIds as $fileId) {
+		$output->startProgress($this->documentService->countAll());
+		foreach ($this->documentService->getAll() as $document) {
+			$fileId = $document->getId();
 			$this->documentService->unlock($fileId);
 			$this->documentService->resetDocument($fileId, true);
 			$output->advance();

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -428,7 +428,7 @@ class DocumentService {
 		}
 	}
 
-	public function getAll(): array {
+	public function getAll(): \Generator {
 		return $this->documentMapper->findAll();
 	}
 
@@ -641,5 +641,9 @@ class DocumentService {
 			));
 		} catch (NoLockProviderException | PreConditionNotMetException | NotFoundException $e) {
 		}
+	}
+
+	public function countAll(): int {
+		return $this->documentMapper->countAll();
 	}
 }

--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -106,6 +106,10 @@ class SessionService {
 		}, $sessions);
 	}
 
+	public function countAllSessions(int $documentId): int {
+		return $this->sessionMapper->countAll($documentId);
+	}
+
 	public function getActiveSessions(int $documentId): array {
 		$sessions = $this->sessionMapper->findAllActive($documentId);
 		return array_map(function (Session $session) {


### PR DESCRIPTION
Fix https://github.com/nextcloud/text/issues/5904

- [x] Avoid running out of memory when iterating over documents
- [ ] Think about a way to do the document cleanup later on as iterating over all documents and deleting the y.js state files is not feasible on larger instances
  - [x] Implemented this now for testing, in general this approach should work fine as we do set this value also for new file creation if no steps were pushed.
  - [ ] Would still need some testing and thinking if the reset on create could again cause problems