### PR TITLE
fix(LinkBubble): Don't open bubble at initialization and on remote changes

### DIFF
--- a/cypress/e2e/initial.spec.js
+++ b/cypress/e2e/initial.spec.js
@@ -32,10 +32,11 @@ describe('Test state loading of documents', function() {
 					.find('h2').should('contain', 'Hello world')
 
 				cy.getMenu().should('be.visible')
-				cy.getActionEntry('undo').should('be.visible').click()
+				cy.getActionEntry('undo').should('be.disabled')
+
 				cy.getContent()
-					.should('contain', 'Hello world')
-					.find('h2').should('contain', 'Hello world')
+					.type('New content')
+				cy.getActionEntry('undo').should('not.be.disabled')
 			})
 	})
 

--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -160,9 +160,6 @@ describe('Workspace', function() {
 		cy.get('.file-picker [data-filename="test.md"]').click()
 		cy.get('.dialog__actions button.button-vue--vue-primary').click()
 
-		cy.getEditor()
-			.find('a')
-
 		cy.getContent()
 			.type('{leftArrow}')
 

--- a/src/components/Link/LinkBubbleView.vue
+++ b/src/components/Link/LinkBubbleView.vue
@@ -228,7 +228,11 @@ export default {
 		},
 
 		removeLink() {
-			this.editor.chain().unsetLink().focus().run()
+			this.editor.chain()
+				.hideLinkBubble()
+				.unsetLink()
+				.focus()
+				.run()
 			this.stopEdit()
 		},
 	},

--- a/src/plugins/LinkBubblePluginView.js
+++ b/src/plugins/LinkBubblePluginView.js
@@ -101,12 +101,14 @@ class LinkBubblePluginView {
 		}
 		this.createTooltip()
 		if (active?.mark) {
-			this.updateTooltip(view, active)
+			setTimeout(() => {
+				this.updateTooltip(view, active)
+			}, 100)
 		} else {
+			this.removeEventListeners()
 			setTimeout(() => {
 				this.tippy?.hide()
 			}, 100)
-			this.removeEventListeners()
 		}
 	}
 

--- a/src/plugins/LinkBubblePluginView.js
+++ b/src/plugins/LinkBubblePluginView.js
@@ -92,11 +92,7 @@ class LinkBubblePluginView {
 
 	update(view, oldState) {
 		const { active } = this.plugin.getState(view.state)
-		const { active: oldActive } = this.plugin.getState(oldState)
 		if (view.composing) {
-			return
-		}
-		if (active === oldActive) {
 			return
 		}
 		this.createTooltip()

--- a/src/plugins/links.js
+++ b/src/plugins/links.js
@@ -71,7 +71,9 @@ export function linkBubble(options) {
 		appendTransaction: (transactions, oldState, state) => {
 			const sameSelection = oldState?.selection.eq(state.selection)
 			const sameDoc = oldState?.doc.eq(state.doc)
-			if (sameSelection && sameDoc) {
+			// Prevent bubble from opening at editor initialisation
+			const initLoad = oldState?.doc.content.size === 2
+			if (initLoad || (sameSelection && sameDoc)) {
 				return
 			}
 			const active = activeLinkFromSelection(state)

--- a/src/plugins/links.js
+++ b/src/plugins/links.js
@@ -54,7 +54,7 @@ export function linkBubble(options) {
 			init: () => ({ active: null }),
 			apply: (tr, cur) => {
 				const meta = tr.getMeta(linkBubbleKey)
-				if (meta && meta.active !== cur.active) {
+				if (meta) {
 					return { ...cur, active: meta.active }
 				} else {
 					return cur

--- a/src/plugins/links.js
+++ b/src/plugins/links.js
@@ -69,11 +69,17 @@ export function linkBubble(options) {
 		}),
 
 		appendTransaction: (transactions, oldState, state) => {
+			// Don't open bubble at editor initialisation
+			if (oldState?.doc.content.size === 2) {
+				return
+			}
+
+			// Don't open bubble if neither selection nor doc changed
 			const sameSelection = oldState?.selection.eq(state.selection)
 			const sameDoc = oldState?.doc.eq(state.doc)
-			// Prevent bubble from opening at editor initialisation
-			const initLoad = oldState?.doc.content.size === 2
-			if (initLoad || (sameSelection && sameDoc)) {
+			// Don't open bubble on changes by other session members
+			const noHistory = !transactions.some(tr => tr.meta.addToHistory)
+			if (sameSelection && (noHistory || sameDoc)) {
 				return
 			}
 			const active = activeLinkFromSelection(state)


### PR DESCRIPTION
Fixes: #5855
Fixes: nextcloud/collectives#1296

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
