### PR TITLE
perf: Reduce polling interval for read only users

### DIFF
--- a/src/services/PollingBackend.js
+++ b/src/services/PollingBackend.js
@@ -28,6 +28,12 @@ const FETCH_INTERVAL_MAX = 5000
 const FETCH_INTERVAL_SINGLE_EDITOR = 5000
 
 /**
+ * Interval to check for changes for read only users
+ * @type {number}
+ */
+const FETCH_INTERVAL_READ_ONLY = 30000
+
+/**
  * Interval to fetch for changes when a browser window is considered invisible by the
  * page visibility API https://developer.mozilla.org/de/docs/Web/API/Page_Visibility_API
  *
@@ -120,7 +126,9 @@ class PollingBackend {
 			}
 			const disconnect = Date.now() - COLLABORATOR_DISCONNECT_TIME
 			const alive = sessions.filter((s) => s.lastContact * 1000 > disconnect)
-			if (alive.length < 2) {
+			if (this.#syncService.connection.state.document.readOnly) {
+				this.maximumReadOnlyTimer()
+			} else if (alive.length < 2) {
 				this.maximumRefetchTimer()
 			} else {
 				this.increaseRefetchTimer()
@@ -191,6 +199,10 @@ class PollingBackend {
 
 	maximumRefetchTimer() {
 		this.#fetchInterval = FETCH_INTERVAL_SINGLE_EDITOR
+	}
+
+	maximumReadOnlyTimer() {
+		this.#fetchInterval = FETCH_INTERVAL_READ_ONLY
 	}
 
 	visibilitychange() {


### PR DESCRIPTION
Reduce the polling interval for sync requests on read only sessions to 30s.

This is a quick fix, a proper way of doing that would be to actually add the read only state to the session data for each session joined. That way we could dynamically adjust the sync interval depending on if there are other users with editing permission in the document or not.

Especially useful if you have documents that have high viewing traffic as our app tutorials