### PR TITLE
Keep base version etag during reload

### DIFF
--- a/cypress/e2e/sync.spec.js
+++ b/cypress/e2e/sync.spec.js
@@ -19,10 +19,10 @@ describe('Sync', () => {
 		cy.intercept({ method: 'POST', url: '**/apps/text/session/*/sync' }).as('sync')
 		cy.intercept({ method: 'POST', url: '**/apps/text/session/*/save' }).as('save')
 		cy.openTestFile()
-		cy.wait('@sync')
+		cy.wait('@sync', { timeout: 10000 })
 		cy.getContent().find('h2').should('contain', 'Hello world')
 		cy.getContent().type('{moveToEnd}* Saving the doc saves the doc state{enter}')
-		cy.wait('@sync')
+		cy.wait('@sync', { timeout: 10000 })
 	})
 
 	it('saves the actual file and document state', () => {

--- a/cypress/e2e/sync.spec.js
+++ b/cypress/e2e/sync.spec.js
@@ -47,22 +47,11 @@ describe('Sync', () => {
 	})
 
 	it('recovers from a short lost connection', () => {
-		let reconnect = false
-		cy.intercept('**/apps/text/session/*/*', (req) => {
-			if (reconnect) {
-				req.continue()
-				req.alias = 'alive'
-			} else {
-				req.destroy()
-				req.alias = 'dead'
-			}
-		}).as('sessionRequests')
+		cy.intercept('**/apps/text/session/*/*', req => req.destroy()).as('dead')
 		cy.wait('@dead', { timeout: 30000 })
 		cy.get('#editor-container .document-status', { timeout: 30000 })
 			.should('contain', 'Document could not be loaded.')
-			.then(() => {
-				reconnect = true
-			})
+		cy.intercept('**/apps/text/session/*/*', req => req.continue()).as('alive')
 		cy.wait('@alive', { timeout: 30000 })
 		cy.intercept({ method: 'POST', url: '**/apps/text/session/*/sync' })
 			.as('syncAfterRecovery')
@@ -78,6 +67,26 @@ describe('Sync', () => {
 			.then(name => cy.downloadFile(`/${name}.md`))
 			.its('data')
 			.should('include', 'after the lost connection')
+	})
+
+	it('reconnects via button after a short lost connection', () => {
+		cy.intercept('**/apps/text/session/*/*', req => req.destroy()).as('dead')
+		cy.wait('@dead', { timeout: 30000 })
+		cy.get('#editor-container .document-status', { timeout: 30000 })
+			.should('contain', 'Document could not be loaded.')
+		cy.get('#editor-container .document-status')
+			.find('.button.primary').click()
+		cy.intercept('**/apps/text/session/*/*', req => {
+			if (req.url.endsWith('create')) {
+				req.alias = 'create'
+			}
+			req.continue()
+		}).as('alive')
+		cy.wait('@alive', { timeout: 30000 })
+		cy.wait('@create', { timeout: 10000 })
+			.its('request.body')
+			.should('have.property', 'baseVersionEtag')
+			.should('not.be.empty')
 	})
 
 	it('recovers from a lost and closed connection', () => {
@@ -111,7 +120,7 @@ describe('Sync', () => {
 			.should('include', 'after the lost connection')
 	})
 
-	it('shows warning when document session got cleaned up', () => {
+	it('asks to reload page when document session got cleaned up', () => {
 		cy.get('.save-status button')
 			.click()
 		cy.wait('@save')

--- a/cypress/e2e/sync.spec.js
+++ b/cypress/e2e/sync.spec.js
@@ -76,12 +76,15 @@ describe('Sync', () => {
 			.should('contain', 'Document could not be loaded.')
 		cy.get('#editor-container .document-status')
 			.find('.button.primary').click()
-		cy.intercept('**/apps/text/session/*/*', req => {
-			if (req.url.endsWith('create')) {
-				req.alias = 'create'
-			}
-			req.continue()
-		}).as('alive')
+		cy.get('.toastify').should('contain', 'Connection failed.')
+		cy.get('.toastify', { timeout: 30000 }).should('not.exist')
+		cy.get('#editor-container .document-status', { timeout: 30000 })
+			.should('contain', 'Document could not be loaded.')
+		// bring back the network connection
+		cy.intercept('**/apps/text/session/*/*', req => { req.continue() }).as('alive')
+		cy.intercept('**/apps/text/session/*/create').as('create')
+		cy.get('#editor-container .document-status')
+			.find('.button.primary').click()
 		cy.wait('@alive', { timeout: 30000 })
 		cy.wait('@create', { timeout: 10000 })
 			.its('request.body')

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -664,14 +664,11 @@ export default {
 
 		async close() {
 			if (this.currentSession && this.$syncService) {
-				try {
-					await this.$syncService.close()
-					this.unlistenSyncServiceEvents()
-					this.currentSession = null
-					this.$syncService = null
-				} catch (e) {
-					// Ignore issues closing the session since those might happen due to network issues
-				}
+				await this.$syncService.close()
+				this.unlistenSyncServiceEvents()
+				this.$syncService = null
+				// disallow editing while still showing the content
+				this.readOnly = true
 			}
 			if (this.$editor) {
 				try {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -373,7 +373,7 @@ export default {
 				guestName,
 				shareToken: this.shareToken,
 				filePath: this.relativePath,
-				baseVersionEtag: this.$syncService?.baseVersionEtag,
+				baseVersionEtag: this.$baseVersionEtag,
 				forceRecreate: this.forceRecreate,
 				serialize: this.isRichEditor
 					? (content) => createMarkdownSerializer(this.$editor.schema).serialize(content ?? this.$editor.state.doc)
@@ -487,7 +487,7 @@ export default {
 			})
 		},
 
-		onLoaded({ documentSource, documentState }) {
+		onLoaded({ document, documentSource, documentState }) {
 			if (documentState) {
 				applyDocumentState(this.$ydoc, documentState, this.$providers[0])
 				// distribute additional state that may exist locally
@@ -500,6 +500,7 @@ export default {
 				this.setInitialYjsState(documentSource, { isRichEditor: this.isRichEditor })
 			}
 
+			this.$baseVersionEtag = document.baseVersionEtag
 			this.hasConnectionIssue = false
 			const language = extensionHighlight[this.fileExtension] || this.fileExtension;
 

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -354,12 +354,12 @@ export default {
 		}
 		unsubscribe('text:image-node:add', this.onAddImageNode)
 		unsubscribe('text:image-node:delete', this.onDeleteImageNode)
+		unsubscribe('text:translate-modal:show', this.showTranslateModal)
 		if (this.dirty) {
 			const timeout = new Promise((resolve) => setTimeout(resolve, 2000))
 			await Promise.any([timeout, this.$syncService.save()])
 		}
-		this.$providers.forEach(p => p.destroy())
-		unsubscribe('text:translate-modal:show', this.showTranslateModal)
+		this.close()
 	},
 	methods: {
 		initSession() {
@@ -383,8 +383,6 @@ export default {
 
 			this.listenSyncServiceEvents()
 
-			this.$providers.forEach(p => p?.destroy())
-			this.$providers = []
 			const syncServiceProvider = createSyncServiceProvider({
 				ydoc: this.$ydoc,
 				syncService: this.$syncService,
@@ -432,7 +430,7 @@ export default {
 		reconnect() {
 			this.contentLoaded = false
 			this.hasConnectionIssue = false
-			this.close().then(this.initSession)
+			this.disconnect().then(this.initSession)
 			this.idle = false
 		},
 
@@ -662,14 +660,19 @@ export default {
 			await this.$syncService.save()
 		},
 
+		async disconnect() {
+			await this.$syncService.close()
+			this.unlistenSyncServiceEvents()
+			this.$providers.forEach(p => p?.destroy())
+			this.$providers = []
+			this.$syncService = null
+			// disallow editing while still showing the content
+			this.readOnly = true
+		},
+
 		async close() {
-			if (this.currentSession && this.$syncService) {
-				await this.$syncService.close()
-				this.unlistenSyncServiceEvents()
-				this.$syncService = null
-				// disallow editing while still showing the content
-				this.readOnly = true
-			}
+			await this.$syncService.sendRemainingSteps(this.$queue)
+			await this.disconnect()
 			if (this.$editor) {
 				try {
 					this.unlistenEditorEvents()

--- a/src/components/Editor/GuestNameDialog.vue
+++ b/src/components/Editor/GuestNameDialog.vue
@@ -55,12 +55,12 @@ export default {
 		},
 	},
 	beforeMount() {
-		this.guestName = this.$syncService.connection.session.guestName
+		this.guestName = this.$syncService.guestName
 		this.updateBufferedGuestName()
 	},
 	methods: {
 		setGuestName() {
-			const previousGuestName = this.$syncService.connection.session.guestName
+			const previousGuestName = this.$syncService.guestName
 			this.$syncService.updateSession(this.guestName).then(() => {
 				localStorage.setItem('nick', this.guestName)
 				this.updateBufferedGuestName()

--- a/src/helpers/yjs.js
+++ b/src/helpers/yjs.js
@@ -81,6 +81,26 @@ export function applyUpdateMessage(ydoc, updateMessage, origin = 'origin') {
 }
 
 /**
+ * Get the steps for sending to the server
+ *
+ * @param {object[]} queue - queue for the outgoing steps
+ */
+export function getSteps(queue) {
+	return queue.map(s => encodeArrayBuffer(s))
+		.filter(s => s < 'AQ')
+}
+
+/**
+ * Encode the latest awareness message for sending
+ *
+ * @param {object[]} queue - queue for the outgoing steps
+ */
+export function getAwareness(queue) {
+	return queue.map(s => encodeArrayBuffer(s))
+		.findLast(s => s > 'AQ') || ''
+}
+
+/**
  * Log y.js messages with their type and initiator call stack
  *
  * @param {string} step - Y.js message

--- a/src/services/PollingBackend.js
+++ b/src/services/PollingBackend.js
@@ -126,7 +126,7 @@ class PollingBackend {
 			}
 			const disconnect = Date.now() - COLLABORATOR_DISCONNECT_TIME
 			const alive = sessions.filter((s) => s.lastContact * 1000 > disconnect)
-			if (this.#syncService.connection.state.document.readOnly) {
+			if (this.#syncService.isReadOnly) {
 				this.maximumReadOnlyTimer()
 			} else if (alive.length < 2) {
 				this.maximumRefetchTimer()

--- a/src/services/SessionApi.js
+++ b/src/services/SessionApi.js
@@ -161,9 +161,12 @@ export class Connection {
 	}
 
 	close() {
-		const promise = this.#post(this.#url(`session/${this.#document.id}/close`), this.#defaultParams)
-		this.closed = true
-		return promise
+		return this.#post(
+			this.#url(`session/${this.#document.id}/close`),
+			this.#defaultParams,
+		).then(() => {
+			this.closed = true
+		})
 	}
 
 	// To be used in Cypress tests only

--- a/src/services/SessionApi.js
+++ b/src/services/SessionApi.js
@@ -84,6 +84,10 @@ export class Connection {
 		}
 	}
 
+	get isClosed() {
+		return this.closed
+	}
+
 	get #defaultParams() {
 		return {
 			documentId: this.#document.id,

--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -10,7 +10,7 @@ import debounce from 'debounce'
 
 import PollingBackend from './PollingBackend.js'
 import SessionApi, { Connection } from './SessionApi.js'
-import { encodeArrayBuffer } from '../helpers/base64.ts'
+import { getSteps, getAwareness } from '../helpers/yjs.js'
 import { logger } from '../helpers/logger.js'
 
 /**
@@ -276,10 +276,8 @@ class SyncService {
 			return
 		}
 		let outbox = []
-		const steps = queue.map(s => encodeArrayBuffer(s))
-			.filter(s => s < 'AQ')
-		const awareness = queue.map(s => encodeArrayBuffer(s))
-			.findLast(s => s > 'AQ') || ''
+		const steps = getSteps(queue)
+		const awareness = getAwareness(queue)
 		return this.sendStepsNow(() => {
 			const data = { steps, awareness, version: this.version }
 			outbox = [...queue]

--- a/src/services/WebSocketPolyfill.js
+++ b/src/services/WebSocketPolyfill.js
@@ -4,7 +4,8 @@
  */
 
 import { logger } from '../helpers/logger.js'
-import { encodeArrayBuffer, decodeArrayBuffer } from '../helpers/base64.ts'
+import { decodeArrayBuffer } from '../helpers/base64.ts'
+import { getSteps, getAwareness } from '../helpers/yjs.js'
 
 /**
  *
@@ -69,8 +70,8 @@ export default function initWebSocketPolyfill(syncService, fileId, initialSessio
 			let outbox = []
 			return syncService.sendSteps(() => {
 				const data = {
-					steps: this.#steps,
-					awareness: this.#awareness,
+					steps: getSteps(queue),
+					awareness: getAwareness(queue),
 					version: this.#version,
 				}
 				outbox = [...queue]
@@ -84,16 +85,6 @@ export default function initWebSocketPolyfill(syncService, fileId, initialSessio
 				)
 				return ret
 			}, err => logger.error(err))
-		}
-
-		get #steps() {
-			return queue.map(s => encodeArrayBuffer(s))
-				.filter(s => s < 'AQ')
-		}
-
-		get #awareness() {
-			return queue.map(s => encodeArrayBuffer(s))
-				.findLast(s => s > 'AQ') || ''
 		}
 
 		async close() {

--- a/src/services/WebSocketPolyfill.js
+++ b/src/services/WebSocketPolyfill.js
@@ -97,36 +97,11 @@ export default function initWebSocketPolyfill(syncService, fileId, initialSessio
 		}
 
 		async close() {
-			await this.#sendRemainingSteps()
 			Object.entries(this.#handlers)
 				.forEach(([key, value]) => syncService.off(key, value))
 			this.#handlers = []
-			syncService.close().then(() => {
-				this.onclose()
-			})
+			this.onclose()
 			logger.debug('Websocket closed')
-		}
-
-		#sendRemainingSteps() {
-			if (queue.length) {
-				let outbox = []
-				return syncService.sendStepsNow(() => {
-					const data = {
-						steps: this.#steps,
-						awareness: this.#awareness,
-						version: this.#version,
-					}
-					outbox = [...queue]
-					logger.debug('sending final steps ', data)
-					return data
-				})?.then(() => {
-					// only keep the steps that were not send yet
-					queue.splice(0,
-						queue.length,
-						...queue.filter(s => !outbox.includes(s)),
-					)
-				}, err => logger.error(err))
-			}
 		}
 
 	}


### PR DESCRIPTION
### 📝 Summary

`this.$syncService` is cleared during the `close` method.

However we need the `baseVersionEtag` to ensure the editing session
on the server
is still in sync with our local ydoc.

See https://github.com/nextcloud/text/issues/5724#issuecomment-2180699808 for a trace of the effect of this.

Also fixes #5726 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
