### PR TITLE
fix(build): increase ram for faster npm run watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' vite --mode production build",
     "dev": "NODE_OPTIONS='--max-old-space-size=4096' vite --mode development build",
-    "watch": "NODE_OPTIONS='--max-old-space-size=4096' vite --mode development build --watch",
+    "watch": "NODE_OPTIONS='--max-old-space-size=8192' vite --mode development build --watch",
     "lint": "tsc && eslint --ext .js,.vue src cypress",
     "lint:fix": "tsc && eslint --ext .js,.vue src cypress --fix",
     "stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css css/*.scss",


### PR DESCRIPTION
Reduces build time for the second and following builds from > 100 sec. to approx 60 sec.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
