### PR TITLE
fix(editor): use reactive `hasEditor` in template

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -59,7 +59,7 @@
 				:content="syncError.data.outsideChange"
 				:is-rich-editor="isRichEditor" />
 		</Wrapper>
-		<Assistant v-if="$editor" />
+		<Assistant v-if="hasEditor" />
 		<Translate :show="translateModal"
 			:content="translateContent"
 			@insert-content="translateInsert"


### PR DESCRIPTION
`$editor` is not (meant to be) reactive.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- no tests
- no docs