### PR TITLE
test(cypress): Fix initial content undo test

### DIFF
--- a/cypress/e2e/initial.spec.js
+++ b/cypress/e2e/initial.spec.js
@@ -32,10 +32,11 @@ describe('Test state loading of documents', function() {
 					.find('h2').should('contain', 'Hello world')
 
 				cy.getMenu().should('be.visible')
-				cy.getActionEntry('undo').should('be.visible').click()
+				cy.getActionEntry('undo').should('be.disabled')
+
 				cy.getContent()
-					.should('contain', 'Hello world')
-					.find('h2').should('contain', 'Hello world')
+					.type('New content')
+				cy.getActionEntry('undo').should('not.be.disabled')
 			})
 	})
 


### PR DESCRIPTION
Undo button should be disabled after initial content got loaded and only get enabled after typing something.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
