### PR TITLE
fix(LinkBubble): Fix logic to detect transactions without history

### DIFF
--- a/src/components/Link/LinkBubbleView.vue
+++ b/src/components/Link/LinkBubbleView.vue
@@ -229,6 +229,7 @@ export default {
 
 		removeLink() {
 			this.editor.chain()
+				// Explicitly hide bubble to prevent flickering before it's removed
 				.hideLinkBubble()
 				.unsetLink()
 				.focus()

--- a/src/plugins/links.js
+++ b/src/plugins/links.js
@@ -78,7 +78,7 @@ export function linkBubble(options) {
 			const sameSelection = oldState?.selection.eq(state.selection)
 			const sameDoc = oldState?.doc.eq(state.doc)
 			// Don't open bubble on changes by other session members
-			const noHistory = !transactions.some(tr => tr.meta.addToHistory)
+			const noHistory = transactions.every(tr => tr.meta.addToHistory === false)
 			if (sameSelection && (noHistory || sameDoc)) {
 				return
 			}


### PR DESCRIPTION
Fixes updating the link bubble when link got edited.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
