### PR TITLE
[draft] [stable28] perf(rich_workspace): only add property for parent

### DIFF
--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -100,6 +100,11 @@ class WorkspacePlugin extends ServerPlugin {
 			return;
 		}
 
+		// Only return the property for the parent node and ignore it for further in depth nodes
+		if ($propFind->getDepth() !== $this->server->getHTTPDepth()) {
+			return;
+		}
+
 		$file = null;
 		$owner = $this->userId ?? $node->getFileInfo()->getStorage()->getOwner('');
 		/** @var Folder[] $nodes */
@@ -113,7 +118,6 @@ class WorkspacePlugin extends ServerPlugin {
 			}
 		}
 
-		// Only return the property for the parent node and ignore it for further in depth nodes
 		$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($file) {
 			if ($file instanceof File) {
 				return $file->getContent();


### PR DESCRIPTION
Draft on 28, just because I was investigating on 28. I'll recreate on main soon

### 📝 Summary

#### Steps to reproduce

1. Add 300-500 s3 external storages and mount to root subfolder
2. Enable text
3. See 10-15s loading time on `/apps/files/files` for PROPFIND request. On real instance it could be up to 90 seconds for 300 storages

| s3  | 28   | 27       |
|-----|------|----------|
| 0   | 0.1s | 0.1s     |
| 100 | 3s   | 0.2s     |
| 200 | 6s   | 0.5s     |
| 300 | 9s   | 0.9s     |
| 400 | 12s  | 1-2s     | 
| 500 | 15s  | 1.1-2.4s |

#### A problem

There is a new `<nc:rich_workspace>` property for each Node in the response.

After disabling Text or disabling `rich_workspace` the problem disappears.

### 🚧 TODO

- [x] only add property for parent ignoring deep nodes as it was in past

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
