### PR TITLE
perf: get folder node directly from dav node instead of getting it by id

### DIFF
--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace OCA\Text\DAV;
 
 use OC\Files\Node\File;
-use OC\Files\Node\Folder;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Files\FilesHome;
 use OCA\Text\AppInfo\Application;
@@ -77,16 +76,11 @@ class WorkspacePlugin extends ServerPlugin {
 			return;
 		}
 
-		$file = null;
-		$owner = $this->userId ?? $node->getFileInfo()->getStorage()->getOwner('');
-		$node = $this->rootFolder->getUserFolder($owner)->getFirstNodeById($node->getId());
-		if ($node instanceof Folder) {
-			/** @var File $file */
-			try {
-				$file = $this->workspaceService->getFile($node);
-			} catch (StorageNotAvailableException $e) {
-				// If a storage is not available we can for the propfind response assume that there is no rich workspace present
-			}
+		$node = $node->getNode();
+		try {
+			$file = $this->workspaceService->getFile($node);
+		} catch (StorageNotAvailableException $e) {
+			$file = null;
 		}
 
 		// Only return the property for the parent node and ignore it for further in depth nodes


### PR DESCRIPTION
### 📝 Summary

Should significantly improve the performance of the dav plugin

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
