### PR TITLE
fix(attachments): Don't require document session for getting attachments

### DIFF
--- a/lib/Controller/AttachmentController.php
+++ b/lib/Controller/AttachmentController.php
@@ -70,7 +70,7 @@ class AttachmentController extends ApiController implements ISessionAwareControl
 	#[PublicPage]
 	#[RequireDocumentSessionOrUserOrShareToken]
 	public function getAttachmentList(string $shareToken = ''): DataResponse {
-		$documentId = $this->getDocument()->getId();
+		$documentId = $this->getDocumentId();
 		try {
 			$session = $this->getSession();
 		} catch (InvalidSessionException) {
@@ -178,7 +178,7 @@ class AttachmentController extends ApiController implements ISessionAwareControl
 	#[RequireDocumentSessionOrUserOrShareToken]
 	public function getImageFile(string $imageFileName, string $shareToken = '',
 		int $preferRawImage = 0): DataResponse|DataDownloadResponse {
-		$documentId = $this->getDocument()->getId();
+		$documentId = $this->getDocumentId();
 
 		try {
 			if ($shareToken) {
@@ -212,7 +212,7 @@ class AttachmentController extends ApiController implements ISessionAwareControl
 	#[NoCSRFRequired]
 	#[RequireDocumentSessionOrUserOrShareToken]
 	public function getMediaFile(string $mediaFileName, string $shareToken = ''): DataResponse|DataDownloadResponse {
-		$documentId = $this->getDocument()->getId();
+		$documentId = $this->getDocumentId();
 
 		try {
 			if ($shareToken) {
@@ -243,7 +243,7 @@ class AttachmentController extends ApiController implements ISessionAwareControl
 	#[NoCSRFRequired]
 	#[RequireDocumentSessionOrUserOrShareToken]
 	public function getMediaFilePreview(string $mediaFileName, string $shareToken = '') {
-		$documentId = $this->getDocument()->getId();
+		$documentId = $this->getDocumentId();
 
 		try {
 			if ($shareToken) {

--- a/lib/Controller/ISessionAwareController.php
+++ b/lib/Controller/ISessionAwareController.php
@@ -13,6 +13,8 @@ use OCA\Text\Db\Session;
 interface ISessionAwareController {
 	public function getSession(): Session;
 	public function setSession(Session $session): void;
+	public function getDocumentId(): int;
+	public function setDocumentId(int $documentId): void;
 	public function getDocument(): Document;
 	public function setDocument(Document $document): void;
 	public function getUserId(): string;

--- a/lib/Controller/TSessionAwareController.php
+++ b/lib/Controller/TSessionAwareController.php
@@ -15,11 +15,16 @@ use OCA\Text\Exception\InvalidSessionException;
 
 trait TSessionAwareController {
 	private ?Session $textSession = null;
+	private ?int $documentId = null;
 	private ?Document $document = null;
 	private ?string $userId = null;
 
 	public function setSession(?Session $session): void {
 		$this->textSession = $session;
+	}
+
+	public function setDocumentId(int $documentId): void {
+		$this->documentId = $documentId;
 	}
 
 	public function setDocument(?Document $document): void {
@@ -30,6 +35,9 @@ trait TSessionAwareController {
 		$this->userId = $userId;
 	}
 
+	/**
+	 * @throws InvalidSessionException
+	 */
 	public function getSession(): Session {
 		if ($this->textSession === null) {
 			throw new InvalidSessionException();
@@ -38,6 +46,20 @@ trait TSessionAwareController {
 		return $this->textSession;
 	}
 
+	/**
+	 * @throws InvalidSessionException
+	 */
+	public function getDocumentId(): int {
+		if ($this->documentId === null) {
+			throw new InvalidSessionException();
+		}
+
+		return $this->documentId;
+	}
+
+	/**
+	 * @throws InvalidSessionException
+	 */
 	public function getDocument(): Document {
 		if ($this->document === null) {
 			throw new InvalidSessionException();
@@ -46,6 +68,9 @@ trait TSessionAwareController {
 		return $this->document;
 	}
 
+	/**
+	 * @throws InvalidSessionException
+	 */
 	public function getUserId(): string {
 		if ($this->userId === null) {
 			throw new InvalidSessionException();

--- a/lib/Middleware/SessionMiddleware.php
+++ b/lib/Middleware/SessionMiddleware.php
@@ -105,6 +105,7 @@ class SessionMiddleware extends Middleware {
 		}
 
 		$controller->setSession($session);
+		$controller->setDocumentId($documentId);
 		$controller->setDocument($document);
 		if (!$shareToken) {
 			$controller->setUserId($session->getUserId());
@@ -138,12 +139,7 @@ class SessionMiddleware extends Middleware {
 			throw new InvalidSessionException();
 		}
 
-		$document = $this->documentService->getDocument($documentId);
-		if (!$document) {
-			throw new InvalidSessionException();
-		}
-
-		$controller->setDocument($document);
+		$controller->setDocumentId($documentId);
 	}
 
 	public function afterException($controller, $methodName, \Exception $exception): JSONResponse|Response {


### PR DESCRIPTION
In editors with a user or share token we don't want to depend on a document session for fetching attachments.

This fixes fetching attachments in editors without a document session but with a user session or share token, e.g. in view mode of the Collectives app.

Fixes: nextcloud/collectives#1201

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
