### PR TITLE
fix: Change search highlight color and border radius

### DIFF
--- a/src/plugins/searchDecorations.js
+++ b/src/plugins/searchDecorations.js
@@ -92,7 +92,7 @@ export function highlightResults(doc, results) {
 	results.forEach((result) => {
 		decorations.push(
 			Decoration.inline(result.from, result.to, {
-				style: 'background-color: #f8ff00; color: black; border-radius: 4px;',
+				style: 'background-color: #ead637; color: black; border-radius: 2px;',
 			}),
 		)
 	})


### PR DESCRIPTION
### 📝 Summary

Previously, the highlighting color for the new search highlighting in the Text app was too bright of a yellow, and had a 4px border radius. This pull request incorporates feedback from the design team and makes the highlighting color a bit less *dramatic* and halves the border radius (now 2px).

#### 🖼️ Screenshots

<details>
<summary>Before</summary>

![image](https://github.com/nextcloud/text/assets/23369449/826cc039-a2c5-422f-886c-a52c9c0d08b4)
</details>

<details>
<summary>After</summary>

![image](https://github.com/nextcloud/text/assets/23369449/c40e882b-e1fb-446e-ba33-c7d3a96d3627)
</details>

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
