### PR TITLE
Fix: compute number of icons in menubar based on `--default-clickable-area`

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -5,6 +5,7 @@
 
 <template>
 	<div id="editor-container"
+		ref="el"
 		data-text-el="editor-container"
 		class="text-editor"
 		tabindex="-1"
@@ -69,7 +70,7 @@
 </template>
 
 <script>
-import Vue, { set } from 'vue'
+import Vue, { ref, set, watch } from 'vue'
 import { mapState } from 'vuex'
 import { getCurrentUser } from '@nextcloud/auth'
 import { loadState } from '@nextcloud/initial-state'
@@ -77,7 +78,7 @@ import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { Collaboration } from '@tiptap/extension-collaboration'
 import Autofocus from '../extensions/Autofocus.js'
 import { Doc } from 'yjs'
-import { useResizeObserver } from '@vueuse/core'
+import { useElementSize } from '@vueuse/core'
 
 import {
 	EDITOR,
@@ -135,6 +136,7 @@ export default {
 		setContent,
 		store,
 	],
+
 	provide() {
 		const val = {}
 
@@ -219,6 +221,17 @@ export default {
 			default: false,
 		},
 	},
+
+	setup() {
+		const el = ref(null)
+		const { width } = useElementSize(el)
+		watch(width, value => {
+			const maxWidth = Math.floor(value) - 36
+			el.value.style.setProperty('--widget-full-width', `${maxWidth}px`)
+		})
+		return { el, width }
+	},
+
 	data() {
 		return {
 			IDLE_TIMEOUT,
@@ -324,14 +337,6 @@ export default {
 		subscribe('text:image-node:add', this.onAddImageNode)
 		subscribe('text:image-node:delete', this.onDeleteImageNode)
 		this.emit('update:loaded', true)
-		useResizeObserver(this.$el, (entries) => {
-			window.requestAnimationFrame(() => {
-				const entry = entries[0]
-				const { width } = entry.contentRect
-				const maxWidth = width - 36
-				this.$el.style.setProperty('--widget-full-width', `${maxWidth}px`)
-			})
-		})
 		subscribe('text:translate-modal:show', this.showTranslateModal)
 	},
 	created() {


### PR DESCRIPTION
### 📝 Summary

* Follow up for #5990 
* Also use setup function to handle `vueuse` tools properly.
* Use `useElementSize` as it's exactly what we need. `useResizeObserver` is overly generic.


#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud/text/assets/97337118/c12d8146-d585-4c24-908d-ad384925a5d3) | ![grafik](https://github.com/nextcloud/text/assets/97337118/81ef2941-95e2-4590-877b-68ef22fa9f1e)
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
