### PR TITLE
fix(vite): dedupe vue to only use one version of it

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,9 @@ const config = createAppConfig({
 		}
 	},
 	config: {
+		resolve: {
+			dedupe: ['vue'],
+		},
 		css: {
 			modules: {
 				localsConvention: 'camelCase',


### PR DESCRIPTION
When building locally against linked nextcloud-vue, custom reference widgets didn't load since we migrated to vite as builder and module bundler.

Apparently this was because webpack before didn't use modules but vite now does. So apparently the two vue dependencies from nextcloud-vue and text are suddenly treated as separate modules and have separate states.

Adding `vue` to `resolve.dedupe` in the vite config solves, as it forces vite to only use vue from the root project (text).

Fixes: #5958

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
