### PR TITLE
fix: Only inject styles where needed

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,6 @@ import { createAppConfig } from '@nextcloud/vite-config'
 import { webpackStats } from 'rollup-plugin-webpack-stats'
 import path from 'path'
 
-const ENTRIES_TO_INCLUDE_CSS = ['text', 'public', 'viewer', 'editors']
-
 const config = createAppConfig({
 	text: path.join(__dirname, 'src', 'main.js'),
 	files: path.join(__dirname, 'src', 'files.js'),
@@ -16,9 +14,7 @@ const config = createAppConfig({
 	init: path.join(__dirname, 'src', 'init.js'),
 }, {
 	inlineCSS: {
-		jsAssetsFilterFunction: ({ name }) => {
-			return ENTRIES_TO_INCLUDE_CSS.includes(name)
-		}
+		relativeCSSInjection: true,
 	},
 	config: {
 		resolve: {
@@ -33,6 +29,7 @@ const config = createAppConfig({
 			webpackStats(),
 		],
 		build: {
+			cssCodeSplit: true,
 			rollupOptions: {
 				output: {
 					manualChunks: (id) => {


### PR DESCRIPTION
### 📝 Summary

Without this all styles are copied and injected in each entry point.

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
