### PR TITLE
chore: Extract CSS instead of injecting

### DIFF
--- a/lib/DirectEditing/TextDirectEditor.php
+++ b/lib/DirectEditing/TextDirectEditor.php
@@ -144,6 +144,7 @@ class TextDirectEditor implements IEditor {
 			$this->initialStateProvider->provideDirectEditToken($token->getToken());
 			$this->initialStateProvider->provideState();
 			Util::addScript('text', 'text-text');
+			Util::addStyle('text', 'text-text');
 			return new TemplateResponse('text', 'main', [], 'base');
 		} catch (InvalidPathException $e) {
 		} catch (NotFoundException $e) {

--- a/lib/Listeners/FilesLoadAdditionalScriptsListener.php
+++ b/lib/Listeners/FilesLoadAdditionalScriptsListener.php
@@ -30,6 +30,9 @@ class FilesLoadAdditionalScriptsListener implements IEventListener {
 
 		\OCP\Util::addInitScript('text', 'text-init');
 		\OCP\Util::addScript('text', 'text-files');
+		// Add associated styles
+		\OCP\Util::addStyle('text', 'text-init');
+		\OCP\Util::addStyle('text', 'text-files');
 
 		$this->initialStateProvider->provideState();
 	}

--- a/lib/Listeners/FilesSharingLoadAdditionalScriptsListener.php
+++ b/lib/Listeners/FilesSharingLoadAdditionalScriptsListener.php
@@ -29,6 +29,7 @@ class FilesSharingLoadAdditionalScriptsListener implements IEventListener {
 		}
 
 		Util::addScript('text', 'text-public');
+		Util::addStyle('text', 'text-public');
 
 		$this->initialStateProvider->provideState();
 		$node = $event->getShare()->getNode();

--- a/lib/Listeners/LoadEditorListener.php
+++ b/lib/Listeners/LoadEditorListener.php
@@ -35,5 +35,6 @@ class LoadEditorListener implements \OCP\EventDispatcher\IEventListener {
 
 		$this->initialStateProvider->provideState();
 		Util::addScript('text', 'text-editors');
+		Util::addStyle('text', 'text-editors');
 	}
 }

--- a/lib/Listeners/LoadViewerListener.php
+++ b/lib/Listeners/LoadViewerListener.php
@@ -32,6 +32,7 @@ class LoadViewerListener implements IEventListener {
 			return;
 		}
 		Util::addScript('text', 'text-viewer', 'viewer');
+		Util::addStyle('text', 'text-viewer');
 		$this->eventDispatcher->dispatchTyped(new RenderReferenceEvent());
 
 		$this->initialStateProvider->provideState();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,6 @@ import { createAppConfig } from '@nextcloud/vite-config'
 import { webpackStats } from 'rollup-plugin-webpack-stats'
 import path from 'path'
 
-const ENTRIES_TO_INCLUDE_CSS = ['text', 'public', 'viewer', 'editors']
-
 const config = createAppConfig({
 	text: path.join(__dirname, 'src', 'main.js'),
 	files: path.join(__dirname, 'src', 'files.js'),
@@ -15,11 +13,7 @@ const config = createAppConfig({
 	editors: path.join(__dirname, 'src', 'editor.js'),
 	init: path.join(__dirname, 'src', 'init.js'),
 }, {
-	inlineCSS: {
-		jsAssetsFilterFunction: ({ name }) => {
-			return ENTRIES_TO_INCLUDE_CSS.includes(name)
-		}
-	},
+	createEmptyCSSEntryPoints: true,
 	config: {
 		resolve: {
 			dedupe: ['vue'],
@@ -33,6 +27,7 @@ const config = createAppConfig({
 			webpackStats(),
 		],
 		build: {
+			cssCodeSplit: true,
 			rollupOptions: {
 				output: {
 					manualChunks: (id) => {


### PR DESCRIPTION
### 📝 Summary

This will create a CSS file per entry point instead of injecting the CSS. Dynamic chunks will still import their CSS by them self.

Alternative for #6025 

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
