### PR TITLE
fix(sync): reuse open connection

### DIFF
--- a/cypress/e2e/sync.spec.js
+++ b/cypress/e2e/sync.spec.js
@@ -94,6 +94,7 @@ describe('Sync', () => {
 
 	it('recovers from a lost and closed connection', () => {
 		let reconnect = false
+		// block all requests until the session is closed and reopened
 		cy.intercept('**/apps/text/session/*/*', (req) => {
 			if (req.url.includes('close') || req.url.includes('create') || reconnect) {
 				req.continue()
@@ -107,6 +108,11 @@ describe('Sync', () => {
 		cy.wait('@sessionRequests', { timeout: 30000 })
 		cy.get('#editor-container .document-status', { timeout: 30000 })
 			.should('contain', 'Document could not be loaded.')
+
+		// Reconnect button works - it closes and reopens the session
+		cy.get('#editor-container .document-status a.button')
+			.contains('Reconnect')
+			.click()
 
 		cy.wait('@syncAfterRecovery', { timeout: 60000 })
 

--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -89,12 +89,14 @@ class SyncService {
 	}
 
 	async open({ fileId, initialSession }) {
-
+		if (this.#connection && !this.#connection.isClosed) {
+			// We're already connected.
+			return
+		}
 		const connect = initialSession
 			? Promise.resolve(new Connection({ data: initialSession }, {}))
 			: this._api.open({ fileId, baseVersionEtag: this.baseVersionEtag })
 				.catch(error => this._emitError(error))
-
 		this.#connection = await connect
 		if (!this.#connection) {
 			// Error was already emitted in connect


### PR DESCRIPTION
### 📝 Summary

Do not attempt to create a new connection
if there already is one and it is not closed.

If no messages are received for 30 seconds
yjs will open a new websocket.

Since we do not close the connection anymore from the websocket polyfill we also do not need to open it.

If the network connection has gone down
creating a new connection will fail anyway.

Once it comes back we will know if the session is still valid. Then we can either continue using it or reconnect.

This is part of #6050.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2024-07-16 11-40-43](https://github.com/user-attachments/assets/0599dfb2-af78-4675-b292-b7a010356bf4) | No error message anymore


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- No tests. We'd have to wait > 30sec. for yjs to consider the websocket closed and open it again.
- No documentation needed.