### PR TITLE
ci: Also commit css files during build

### DIFF
--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -77,6 +77,6 @@ jobs:
       - name: Add and commit
         if: steps.changes.outputs.CHANGED != ''
         run: |
-          git add --force js/
+          git add --force js/ css/
           git commit --signoff -m 'chore(assets): recompile assets'
           git push origin ${{ github.head_ref }}


### PR DESCRIPTION

### 📝 Summary

When extracting css files in https://github.com/nextcloud/text/pull/6026 we missed that those would also need to be committed to the repo as text is a shipped app.

Otherwise cloning text will not be enough to run it.

@mejo- This could also explain some failures in collectives as @enjeck has seen this in tables

