### PR TITLE
fix(cy): adjust share test to api change

### DIFF
--- a/cypress/e2e/share.spec.js
+++ b/cypress/e2e/share.spec.js
@@ -128,7 +128,7 @@ describe('Open test.md in viewer', function() {
 
 	it('Share a file with download disabled shows an error', function() {
 		cy.shareFileToUser('test.md', recipient, {
-			attributes: '[{"scope":"permissions","key":"download","enabled":false}]',
+			attributes: '[{"scope":"permissions","key":"download","value":false}]',
 		}).then(() => {
 			cy.login(recipient)
 			cy.visit('/apps/files')


### PR DESCRIPTION
### 📝 Summary

`enabled` is now `value`.
See https://github.com/nextcloud/server/pull/46007.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- Tests are fixed with this.
- No docs needed.