### PR TITLE
[stable29] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25934,9 +25934,9 @@
       }
     },
     "node_modules/requirejs": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.7.tgz",
+      "integrity": "sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -49356,9 +49356,9 @@
       "peer": true
     },
     "requirejs": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.7.tgz",
+      "integrity": "sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==",
       "dev": true
     },
     "requirejs-config-file": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 6 vulnerabilities found in your project.

## Updated dependencies
* [requirejs](#user-content-requirejs)
## Fixed vulnerabilities

### requirejs <a href="#user-content-requirejs" id="requirejs">#</a>
* jrburke requirejs vulnerable to prototype pollution
* Severity: **high**
* Reference: [https://github.com/advisories/GHSA-x3m3-4wpv-5vgc](https://github.com/advisories/GHSA-x3m3-4wpv-5vgc)
* Affected versions: <=2.3.6
* Package usage:
  * `node_modules/requirejs`