### PR TITLE
test(cypress): Downgrade to last cypress version that doesn't crash

### DIFF
--- a/cypress/e2e/SmartPicker.spec.js
+++ b/cypress/e2e/SmartPicker.spec.js
@@ -46,7 +46,7 @@ describe('Smart picker', () => {
 			.should('have.text', 'Hello World')
 	})
 
-	it.skip('Insert a link with the smart picker', () => {
+	it('Insert a link with the smart picker', () => {
 		cy.isolateTest({
 			sourceFile: fileName,
 		})
@@ -82,7 +82,7 @@ describe('Smart picker', () => {
 
 		cy.getContent()
 			.find('a')
-			.should('have.text', 'https://github.com')
+			.should('contain.text', 'https://github.com')
 
 	})
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "@vue/tsconfig": "^0.5.1",
         "@vue/vue2-jest": "^29.2.6",
         "@vueuse/core": "^10.11.0",
-        "cypress": "^13.13.1",
+        "cypress": "^13.6.2",
         "cypress-split": "^1.24.0",
         "cypress-visual-regression": "^5.0.0",
         "cypress-vite": "^1.5.0",
@@ -8744,21 +8744,21 @@
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "node_modules/cypress": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.1.tgz",
-      "integrity": "sha512-8F9UjL5MDUdgC/S5hr8CGLHbS5gGht5UOV184qc2pFny43fnkoaKxlzH/U6//zmGu/xRTaKimNfjknLT8+UDFg==",
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.2.tgz",
+      "integrity": "sha512-TW3bGdPU4BrfvMQYv1z3oMqj71YI4AlgJgnrycicmPZAXtvywVFZW9DAToshO65D97rCWfG/kqMFsYB6Kp91gQ==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.7.1",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -8776,7 +8776,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.1",
+        "is-ci": "^3.0.0",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -8790,7 +8790,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.3",
+        "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -8851,6 +8851,15 @@
       },
       "peerDependencies": {
         "vite": "^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/cypress/node_modules/@types/node": {
+      "version": "18.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
+      "integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -34378,19 +34387,20 @@
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "cypress": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.1.tgz",
-      "integrity": "sha512-8F9UjL5MDUdgC/S5hr8CGLHbS5gGht5UOV184qc2pFny43fnkoaKxlzH/U6//zmGu/xRTaKimNfjknLT8+UDFg==",
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.2.tgz",
+      "integrity": "sha512-TW3bGdPU4BrfvMQYv1z3oMqj71YI4AlgJgnrycicmPZAXtvywVFZW9DAToshO65D97rCWfG/kqMFsYB6Kp91gQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.7.1",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -34408,7 +34418,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.1",
+        "is-ci": "^3.0.0",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -34422,11 +34432,20 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.3",
+        "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.19.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
+          "integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@vue/tsconfig": "^0.5.1",
     "@vue/vue2-jest": "^29.2.6",
     "@vueuse/core": "^10.11.0",
-    "cypress": "^13.13.1",
+    "cypress": "^13.6.2",
     "cypress-split": "^1.24.0",
     "cypress-visual-regression": "^5.0.0",
     "cypress-vite": "^1.5.0",


### PR DESCRIPTION
Let's wait until https://github.com/cypress-io/cypress/issues/27415 got fixed upstream.