### PR TITLE
No conflict dialogue in read only

### DIFF
--- a/cypress/e2e/conflict.spec.js
+++ b/cypress/e2e/conflict.spec.js
@@ -30,11 +30,8 @@ variants.forEach(function({ fixture, mime }) {
 			cy.uploadFile('frontmatter.md', mime, fileName)
 			// just a read only session opened
 			cy.shareFile(`/${fileName}`)
-				.then((token) => {
-					cy.visit(`/s/${token}`)
-				})
-			cy.get('.text-editor__main')
-				.should('contain', 'Heading')
+				.then(token => cy.visit(`/s/${token}`))
+			cy.getContent().should('contain', 'Heading')
 			cy.intercept({ method: 'POST', url: '**/session/*/push' })
 				.as('push')
 			cy.wait('@push')
@@ -45,12 +42,9 @@ variants.forEach(function({ fixture, mime }) {
 			cy.get('#editor-container .document-status a.button')
 				.contains('Reload')
 				.click()
-			getWrapper()
-				.should('not.exist')
-			cy.getContent()
-				.should('contain', 'Hello world')
-			cy.getContent()
-				.should('not.contain', 'Heading')
+			getWrapper().should('not.exist')
+			cy.getContent().should('contain', 'Hello world')
+			cy.getContent().should('not.contain', 'Heading')
 		})
 
 		it('displays conflicts', function() {
@@ -77,14 +71,11 @@ variants.forEach(function({ fixture, mime }) {
 			cy.openFile(fileName)
 			cy.get('[data-cy="resolveThisVersion"]').click()
 
-			getWrapper()
-				.should('not.exist')
+			getWrapper().should('not.exist')
 			cy.get('[data-cy="resolveThisVersion"]')
 				.should('not.exist')
-			cy.get('.text-editor__main')
-				.should('contain', 'Hello world')
-			cy.get('.text-editor__main')
-				.should('contain', 'cruel conflicting')
+			cy.getContent().should('contain', 'Hello world')
+			cy.getContent().should('contain', 'cruel conflicting')
 		})
 
 		it('resolves conflict using server version', function() {
@@ -94,16 +85,13 @@ variants.forEach(function({ fixture, mime }) {
 			cy.get('[data-cy="resolveServerVersion"]')
 				.click()
 
-			getWrapper()
-				.should('not.exist')
+			getWrapper().should('not.exist')
 			cy.get('[data-cy="resolveThisVersion"]')
 				.should('not.exist')
 			cy.get('[data-cy="resolveServerVersion"]')
 				.should('not.exist')
-			cy.get('.text-editor__main')
-				.should('contain', 'Hello world')
-			cy.get('.text-editor__main')
-				.should('not.contain', 'cruel conflicting')
+			cy.getContent().should('contain', 'Hello world')
+			cy.getContent().should('not.contain', 'cruel conflicting')
 		})
 
 		it('hides conflict in read only session', function() {
@@ -113,10 +101,8 @@ variants.forEach(function({ fixture, mime }) {
 					cy.logout()
 					cy.visit(`/s/${token}`)
 				})
-			cy.get('.text-editor__main')
-				.should('contain', 'cruel conflicting')
-			getWrapper()
-				.should('not.exist')
+			cy.getContent().should('contain', 'cruel conflicting')
+			getWrapper().should('not.exist')
 		})
 
 	})

--- a/cypress/e2e/conflict.spec.js
+++ b/cypress/e2e/conflict.spec.js
@@ -15,7 +15,7 @@ const variants = [
 variants.forEach(function({ fixture, mime }) {
 	const fileName = fixture
 	describe(`${mime} (${fileName})`, function() {
-		const getWrapper = () => cy.get('.viewer__content .text-editor__wrapper.has-conflicts')
+		const getWrapper = () => cy.get('.text-editor__wrapper.has-conflicts')
 
 		before(() => {
 			initUserAndFiles(user, fileName)
@@ -23,6 +23,34 @@ variants.forEach(function({ fixture, mime }) {
 
 		beforeEach(function() {
 			cy.login(user)
+		})
+
+		it('no actual conflict - just reload', function() {
+			// start with different content
+			cy.uploadFile('frontmatter.md', mime, fileName)
+			// just a read only session opened
+			cy.shareFile(`/${fileName}`)
+				.then((token) => {
+					cy.visit(`/s/${token}`)
+				})
+			cy.get('.text-editor__main')
+				.should('contain', 'Heading')
+			cy.intercept({ method: 'POST', url: '**/session/*/push' })
+				.as('push')
+			cy.wait('@push')
+			cy.uploadFile(fileName, mime)
+			cy.get('#editor-container .document-status', { timeout: 30000 })
+				.should('contain', 'session has expired')
+			// Reload button works
+			cy.get('#editor-container .document-status a.button')
+				.contains('Reload')
+				.click()
+			getWrapper()
+				.should('not.exist')
+			cy.getContent()
+				.should('contain', 'Hello world')
+			cy.getContent()
+				.should('not.contain', 'Heading')
 		})
 
 		it('displays conflicts', function() {
@@ -77,6 +105,20 @@ variants.forEach(function({ fixture, mime }) {
 			cy.get('.text-editor__main')
 				.should('not.contain', 'cruel conflicting')
 		})
+
+		it('hides conflict in read only session', function() {
+			createConflict(fileName, mime)
+			cy.shareFile(`/${fileName}`)
+				.then((token) => {
+					cy.logout()
+					cy.visit(`/s/${token}`)
+				})
+			cy.get('.text-editor__main')
+				.should('contain', 'cruel conflicting')
+			getWrapper()
+				.should('not.exist')
+		})
+
 	})
 })
 

--- a/cypress/e2e/conflict.spec.js
+++ b/cypress/e2e/conflict.spec.js
@@ -23,20 +23,13 @@ variants.forEach(function({ fixture, mime }) {
 
 		beforeEach(function() {
 			cy.login(user)
-			cy.visit('/apps/files')
 		})
 
 		it('displays conflicts', function() {
+			createConflict(fileName, mime)
+
 			cy.openFile(fileName)
 
-			cy.log('Inspect editor')
-			cy.getContent()
-				.type('Hello you cruel conflicting world')
-			cy.uploadFile(fileName, mime)
-
-			cy.get('#viewer .modal-header button.header-close').click()
-			cy.get('#viewer').should('not.exist')
-			cy.openFile(fileName)
 			cy.get('.text-editor .document-status')
 				.should('contain', 'Document has been changed outside of the editor.')
 			getWrapper()
@@ -51,25 +44,15 @@ variants.forEach(function({ fixture, mime }) {
 		})
 
 		it('resolves conflict using current editing session', function() {
+			createConflict(fileName, mime)
+
 			cy.openFile(fileName)
-
-			cy.log('Inspect editor')
-			cy.getContent()
-				.type('Hello you cruel conflicting world')
-			cy.uploadFile(fileName, mime)
-
-			cy.get('#viewer .modal-header button.header-close').click()
-			cy.get('#viewer').should('not.exist')
-			cy.openFile(fileName)
-
 			cy.get('[data-cy="resolveThisVersion"]').click()
 
 			getWrapper()
 				.should('not.exist')
-
 			cy.get('[data-cy="resolveThisVersion"]')
 				.should('not.exist')
-
 			cy.get('.text-editor__main')
 				.should('contain', 'Hello world')
 			cy.get('.text-editor__main')
@@ -77,17 +60,9 @@ variants.forEach(function({ fixture, mime }) {
 		})
 
 		it('resolves conflict using server version', function() {
+			createConflict(fileName, mime)
+
 			cy.openFile(fileName)
-
-			cy.log('Inspect editor')
-			cy.getContent()
-				.type('Hello you cruel conflicting world')
-			cy.uploadFile(fileName, mime)
-
-			cy.get('#viewer .modal-header button.header-close').click()
-			cy.get('#viewer').should('not.exist')
-			cy.openFile(fileName)
-
 			cy.get('[data-cy="resolveServerVersion"]')
 				.click()
 
@@ -97,7 +72,6 @@ variants.forEach(function({ fixture, mime }) {
 				.should('not.exist')
 			cy.get('[data-cy="resolveServerVersion"]')
 				.should('not.exist')
-
 			cy.get('.text-editor__main')
 				.should('contain', 'Hello world')
 			cy.get('.text-editor__main')
@@ -105,3 +79,14 @@ variants.forEach(function({ fixture, mime }) {
 		})
 	})
 })
+
+function createConflict(fileName, mime) {
+	cy.visit('/apps/files')
+	cy.openFile(fileName)
+	cy.log('Inspect editor')
+	cy.getContent()
+		.type('Hello you cruel conflicting world')
+	cy.uploadFile(fileName, mime)
+	cy.get('#viewer .modal-header button.header-close').click()
+	cy.get('#viewer').should('not.exist')
+}

--- a/lib/Listeners/BeforeNodeDeletedListener.php
+++ b/lib/Listeners/BeforeNodeDeletedListener.php
@@ -33,9 +33,12 @@ class BeforeNodeDeletedListener implements IEventListener {
 			return;
 		}
 		$node = $event->getNode();
-		if ($node instanceof File && $node->getMimeType() === 'text/markdown') {
-			$this->attachmentService->deleteAttachments($node);
-			$this->documentService->resetDocument($node->getId(), true);
+		if (!$node instanceof File) {
+			return;
 		}
+		if ($node->getMimeType() === 'text/markdown') {
+			$this->attachmentService->deleteAttachments($node);
+		}
+		$this->documentService->resetDocument($node->getId(), true);
 	}
 }

--- a/lib/Listeners/BeforeNodeWrittenListener.php
+++ b/lib/Listeners/BeforeNodeWrittenListener.php
@@ -14,7 +14,6 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\BeforeNodeWrittenEvent;
 use OCP\Files\File;
-use OCP\Files\NotFoundException;
 
 /**
  * @template-implements IEventListener<Event|BeforeNodeWrittenEvent>
@@ -31,19 +30,17 @@ class BeforeNodeWrittenListener implements IEventListener {
 			return;
 		}
 		$node = $event->getNode();
+		if (!$node instanceof File) {
+			return;
+		}
+		if ($this->documentService->isSaveFromText()) {
+			return;
+		}
+		// Reset document session to avoid manual conflict resolution if there's no unsaved steps
 		try {
-			if ($node instanceof File && $node->getMimeType() === 'text/markdown') {
-				if (!$this->documentService->isSaveFromText()) {
-					// Reset document session to avoid manual conflict resolution if there's no unsaved steps
-					try {
-						$this->documentService->resetDocument($node->getId());
-					} catch (DocumentHasUnsavedChangesException) {
-						// Do not throw during event handling in this is expected to happen
-					}
-				}
-			}
-		} catch (NotFoundException) {
-			// This might occur on new files when a NonExistingFile is passed and we cannot access the mimetype
+			$this->documentService->resetDocument($node->getId());
+		} catch (DocumentHasUnsavedChangesException) {
+			// Do not throw during event handling in this is expected to happen
 		}
 	}
 }

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -13,13 +13,14 @@
 		<DocumentStatus v-if="displayedStatus"
 			:idle="idle"
 			:lock="lock"
+			:is-resolving-conflict="isResolvingConflict"
 			:sync-error="syncError"
 			:has-connection-issue="hasConnectionIssue"
 			@reconnect="reconnect" />
 
 		<SkeletonLoading v-if="showLoadingSkeleton" />
 		<Wrapper v-if="displayed"
-			:sync-error="syncError"
+			:is-resolving-conflict="isResolvingConflict"
 			:has-connection-issue="hasConnectionIssue"
 			:content-loaded="contentLoaded"
 			:show-outline-outside="showOutlineOutside"
@@ -55,7 +56,7 @@
 				<ContentContainer v-show="contentLoaded"
 					ref="contentWrapper" />
 			</MainContainer>
-			<Reader v-if="hasSyncCollission"
+			<Reader v-if="isResolvingConflict"
 				:content="syncError.data.outsideChange"
 				:is-rich-editor="isRichEditor" />
 		</Wrapper>
@@ -257,6 +258,9 @@ export default {
 	computed: {
 		isRichWorkspace() {
 			return this.richWorkspace
+		},
+		isResolvingConflict() {
+			return this.hasSyncCollission && !this.readOnly
 		},
 		hasSyncCollission() {
 			return this.syncError && this.syncError.type === ERROR_TYPE.SAVE_COLLISSION

--- a/src/components/Editor/DocumentStatus.vue
+++ b/src/components/Editor/DocumentStatus.vue
@@ -34,7 +34,7 @@
 			</p>
 		</NcNoteCard>
 
-		<CollisionResolveDialog v-if="hasSyncCollission" :sync-error="syncError" />
+		<CollisionResolveDialog v-if="isResolvingConflict" :sync-error="syncError" />
 	</div>
 </template>
 
@@ -69,6 +69,10 @@ export default {
 		},
 
 		hasConnectionIssue: {
+			type: Boolean,
+			require: true,
+		},
+		isResolvingConflict: {
 			type: Boolean,
 			require: true,
 		},

--- a/src/components/Editor/Wrapper.vue
+++ b/src/components/Editor/Wrapper.vue
@@ -6,7 +6,7 @@
 <template>
 	<div class="text-editor__wrapper"
 		:class="{
-			'has-conflicts': hasSyncCollission,
+			'has-conflicts': isResolvingConflict,
 			'is-rich-workspace': $isRichWorkspace,
 			'is-rich-editor': $isRichEditor,
 		}">
@@ -42,9 +42,9 @@ export default {
 	},
 
 	props: {
-		syncError: {
-			type: Object,
-			default: null,
+		isResolvingConflict: {
+			type: Boolean,
+			require: true,
 		},
 		hasConnectionIssue: {
 			type: Boolean,
@@ -71,10 +71,6 @@ export default {
 		...mapState({
 			viewWidth: (state) => state.text.viewWidth,
 		}),
-
-		hasSyncCollission() {
-			return this.syncError && this.syncError.type === ERROR_TYPE.SAVE_COLLISSION
-		},
 		showOutline() {
 			return this.isAbleToShowOutline
 				? this.outline.visible


### PR DESCRIPTION
### 📝 Summary

* Resolves: #2388 
* Clear plaintext sessions when file is overwritten just like for markdown files.
* Do not show conflict dialogue in read only mode.


#### 🖼️ Screenshots

Scenario| 🏚️ Before | 🏡 After
---|---|---
:sunglasses:  no edits - plaintext | ![image](https://github.com/user-attachments/assets/9b051e11-4afd-4d0c-8a4a-d578fda60d62) |![image](https://github.com/user-attachments/assets/bbdba9cf-f7b7-4383-ab14-60123c095ab5) | !
:broken_heart: actual conflict | ![image](https://github.com/user-attachments/assets/49268efa-81d9-4945-a1d8-0b7d3f486140) | ![image](https://github.com/user-attachments/assets/c94e57fe-c178-4b05-b78b-fb090e10b249)



### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- No documentation required.