### PR TITLE
fix(search): Add data attribute to search decoration

### DIFF
--- a/src/plugins/searchDecorations.js
+++ b/src/plugins/searchDecorations.js
@@ -130,6 +130,7 @@ export function highlightResults(doc, results) {
 	results.forEach((result) => {
 		decorations.push(
 			Decoration.inline(result.from, result.to, {
+				'data-text-el': 'search-decoration',
 				style: 'background-color: #ead637; color: black; border-radius: 2px;',
 			}),
 		)


### PR DESCRIPTION
This allows to get the element and scroll it into view, e.g. by Collectives.
