### PR TITLE
[stable29] fix: Avoid throwing exceptions during propfind

### DIFF
--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -31,9 +31,12 @@ use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Files\FilesHome;
 use OCA\Text\AppInfo\Application;
 use OCA\Text\Service\WorkspaceService;
+use OCP\Files\GenericFileException;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotPermittedException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
+use OCP\Lock\LockedException;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
@@ -115,9 +118,13 @@ class WorkspacePlugin extends ServerPlugin {
 
 		// Only return the property for the parent node and ignore it for further in depth nodes
 		$propFind->handle(self::WORKSPACE_PROPERTY, function () use ($file) {
-			if ($file instanceof File) {
-				return $file->getContent();
+			try {
+				if ($file instanceof File) {
+					return $file->getContent();
+				}
+			} catch (GenericFileException|NotPermittedException|LockedException) {
 			}
+
 			return '';
 		});
 		$propFind->handle(self::WORKSPACE_FILE_PROPERTY, function () use ($file) {


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/42663

Was already fixed on main with #5948 