### PR TITLE
ci(cypress): Adapt to file name link being a button now

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -269,7 +269,7 @@ Cypress.Commands.add('getFileId', (fileName, params = {}) => {
 })
 
 Cypress.Commands.add('openFile', (fileName, params = {}) => {
-	cy.get(`[data-cy-files-list] tr[data-cy-files-list-row-name="${fileName}"] a[data-cy-files-list-row-name-link]`).click(params)
+	cy.get(`[data-cy-files-list] tr[data-cy-files-list-row-name="${fileName}"] [data-cy-files-list-row-name-link]`).click(params)
 })
 
 Cypress.Commands.add('openFileInShare', fileName => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -198,7 +198,7 @@ Cypress.Commands.add('moveFile', (path, destinationPath) => {
 // For files wait for preview to load and release lock
 Cypress.Commands.add('waitForPreview', name => {
 	cy.getFile(name)
-		.scrollIntoView()
+		.scrollIntoView({ offset: { top: -200 } })
 	cy.getFile(name)
 		.find('.files-list__row-icon img')
 		.should('be.visible')


### PR DESCRIPTION
Another run for green CI

Upstream fix:
- [x] https://github.com/nextcloud/server/pull/47015

Additionally change selector and scroll file list entry into view before trying to assert it