### PR TITLE
chore(deps): Upgrade cypress to 13.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "@vue/tsconfig": "^0.5.1",
         "@vue/vue2-jest": "^29.2.6",
         "@vueuse/core": "^10.11.0",
-        "cypress": "^13.6.2",
+        "cypress": "^13.6.4",
         "cypress-split": "^1.24.0",
         "cypress-visual-regression": "^5.0.0",
         "cypress-vite": "^1.5.0",
@@ -8769,15 +8769,14 @@
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "node_modules/cypress": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.2.tgz",
-      "integrity": "sha512-TW3bGdPU4BrfvMQYv1z3oMqj71YI4AlgJgnrycicmPZAXtvywVFZW9DAToshO65D97rCWfG/kqMFsYB6Kp91gQ==",
+      "version": "13.6.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.4.tgz",
+      "integrity": "sha512-pYJjCfDYB+hoOoZuhysbbYhEmNW7DEDsqn+ToCLwuVowxUXppIWRr7qk4TVRIU471ksfzyZcH+mkoF0CQUKnpw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -8876,15 +8875,6 @@
       },
       "peerDependencies": {
         "vite": "^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/cypress/node_modules/@types/node": {
-      "version": "18.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
-      "integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -34593,14 +34583,13 @@
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "cypress": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.2.tgz",
-      "integrity": "sha512-TW3bGdPU4BrfvMQYv1z3oMqj71YI4AlgJgnrycicmPZAXtvywVFZW9DAToshO65D97rCWfG/kqMFsYB6Kp91gQ==",
+      "version": "13.6.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.4.tgz",
+      "integrity": "sha512-pYJjCfDYB+hoOoZuhysbbYhEmNW7DEDsqn+ToCLwuVowxUXppIWRr7qk4TVRIU471ksfzyZcH+mkoF0CQUKnpw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -34643,15 +34632,6 @@
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "18.19.41",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
-          "integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@vue/tsconfig": "^0.5.1",
     "@vue/vue2-jest": "^29.2.6",
     "@vueuse/core": "^10.11.0",
-    "cypress": "^13.6.2",
+    "cypress": "^13.6.4",
     "cypress-split": "^1.24.0",
     "cypress-visual-regression": "^5.0.0",
     "cypress-vite": "^1.5.0",


### PR DESCRIPTION
This release should still work without crashing the browser.
