### PR TITLE
fix: Only insert smart picker result as preview if it is a valid URL

### DIFF
--- a/src/components/Suggestion/LinkPicker/suggestions.js
+++ b/src/components/Suggestion/LinkPicker/suggestions.js
@@ -44,6 +44,14 @@ const isValidMarkdown = (content) => {
 	}
 }
 
+const isValidUrl = (url) => {
+	try {
+		return Boolean(new URL(url))
+	} catch (e) {
+		return false
+	}
+}
+
 const sortImportantFirst = (list) => {
 	return [
 		...list.filter(e => important.indexOf(e.key) > -1),
@@ -77,9 +85,11 @@ export default () => createSuggestions({
 		}
 		getLinkWithPicker(props.providerId, true)
 			.then(link => {
-				if (hasMarkdownSyntax(link) && isValidMarkdown(link)) {
+				const isUrl = isValidUrl(link)
+				if (!isUrl) {
+					const isMarkdown = hasMarkdownSyntax(link) && isValidMarkdown(link)
 					// Insert markdown content (e.g. from `text_templates` app)
-					const content = markdownit.render(link)
+					const content = isMarkdown ? markdownit.render(link) : link
 					editor
 						.chain()
 						.focus()


### PR DESCRIPTION
Otherwise if the result from an assistant smart picker action is not considered markdown it would insert it as a broken link. We should only use the link node type instead if we actually have a valid URL.


