### PR TITLE
feat: Move search highlighting to editor API

### DIFF
--- a/cypress/component/editor/search.cy.js
+++ b/cypress/component/editor/search.cy.js
@@ -24,7 +24,7 @@ describe('editor search highlighting', () => {
 
 		const highlightedElements = document.querySelectorAll('span[data-text-el]')
 		expect(highlightedElements.length).to.equal(1)
-		expect(highlightedElements[0].innerText).to.equal(searchQuery)
+		verifyHighlights(highlightedElements, searchQuery)
 	})
 
 	it('can highlight multiple matches', () => {
@@ -33,9 +33,31 @@ describe('editor search highlighting', () => {
 
 		const highlightedElements = document.querySelectorAll('span[data-text-el]')
 		expect(highlightedElements.length).to.equal(16)
+		verifyHighlights(highlightedElements, searchQuery)
+	})
 
-		for (const element of highlightedElements) {
-			expect(element.innerText).to.equal(searchQuery)
-		}
+	it('can toggle highlight all', () => {
+		const searchQuery = 'quod'
+		let highlightedElements = []
+
+		// Highlight all occurrences 
+		editor.commands.setSearchQuery(searchQuery, true)
+		highlightedElements = document.querySelectorAll('span[data-text-el]')
+
+		expect(highlightedElements.length).to.equal(3)
+		verifyHighlights(highlightedElements, searchQuery)
+
+		// Highlight only first occurrence
+		editor.commands.setSearchQuery(searchQuery, false)
+		highlightedElements = document.querySelectorAll('span[data-text-el]')
+
+		expect(highlightedElements.length).to.equal(1)
+		verifyHighlights(highlightedElements, searchQuery)
 	})
 })
+
+function verifyHighlights(highlightedElements, searchQuery) {
+	for (const element of highlightedElements) {
+		expect(element.innerText.toLowerCase()).to.equal(searchQuery.toLowerCase())
+	}
+}

--- a/cypress/component/editor/search.cy.js
+++ b/cypress/component/editor/search.cy.js
@@ -18,11 +18,24 @@ describe('editor search highlighting', () => {
 		})
 	})
 
-	it('can highlight a search', () => {
+	it('can highlight a match', () => {
 		const searchQuery = 'Lorem ipsum dolor sit amet'
 		editor.commands.setSearchQuery(searchQuery)
 
-		const highlightedElement = document.querySelector('span[data-text-el]')
-		expect(highlightedElement.innerText).to.equal(searchQuery)
+		const highlightedElements = document.querySelectorAll('span[data-text-el]')
+		expect(highlightedElements.length).to.equal(1)
+		expect(highlightedElements[0].innerText).to.equal(searchQuery)
+	})
+
+	it('can highlight multiple matches', () => {
+		const searchQuery = 'et'
+		editor.commands.setSearchQuery(searchQuery)
+
+		const highlightedElements = document.querySelectorAll('span[data-text-el]')
+		expect(highlightedElements.length).to.equal(16)
+
+		for (const element of highlightedElements) {
+			expect(element.innerText).to.equal(searchQuery)
+		}
 	})
 })

--- a/cypress/component/editor/search.cy.js
+++ b/cypress/component/editor/search.cy.js
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 import { Editor } from '@tiptap/core'
 import { Document } from '@tiptap/extension-document'
 import { Text } from '@tiptap/extension-text'

--- a/cypress/component/editor/search.cy.js
+++ b/cypress/component/editor/search.cy.js
@@ -75,6 +75,11 @@ describe('editor search highlighting', () => {
 	})
 })
 
+/**
+ * Verifies the Nodes in the given NodeList match the search query
+ * @param {NodeList} highlightedElements - NodeList of highlighted elements
+ * @param {string} searchQuery - search query
+ */
 function verifyHighlights(highlightedElements, searchQuery) {
 	for (const element of highlightedElements) {
 		expect(element.innerText.toLowerCase()).to.equal(searchQuery.toLowerCase())

--- a/cypress/component/editor/search.cy.js
+++ b/cypress/component/editor/search.cy.js
@@ -1,0 +1,25 @@
+import { createCustomEditor } from '../../support/components.js'
+import Search from '../../../src/extensions/Search.js'
+
+describe('editor search highlighting', () => {
+	const editor = createCustomEditor({
+		content: 'lorem ipsum',
+		extensions: [Search],
+	})
+
+	before(() => {
+		editor.setOptions({
+			element: document.querySelector('div[data-cy-root]')
+		})
+	})
+
+	beforeEach(() => editor.createView())
+
+	it('can highlight a search', () => {
+		editor.commands.setSearchQuery('lorem')
+
+		const highlightElements = document.querySelector('span[data-text-el]')
+
+		expect(highlightElements)
+	})
+})

--- a/cypress/component/editor/search.cy.js
+++ b/cypress/component/editor/search.cy.js
@@ -27,7 +27,7 @@ describe('editor search highlighting', () => {
 		const searchQuery = 'Lorem ipsum dolor sit amet'
 		editor.commands.setSearchQuery(searchQuery)
 
-		const highlightedElements = document.querySelectorAll('span[data-text-el]')
+		const highlightedElements = document.querySelectorAll('span[data-text-el="search-decoration"]')
 		expect(highlightedElements).to.have.lengthOf(1)
 		verifyHighlights(highlightedElements, searchQuery)
 	})
@@ -36,7 +36,7 @@ describe('editor search highlighting', () => {
 		const searchQuery = 'quod'
 		editor.commands.setSearchQuery(searchQuery)
 
-		const highlightedElements = document.querySelectorAll('span[data-text-el]')
+		const highlightedElements = document.querySelectorAll('span[data-text-el="search-decoration"]')
 		expect(highlightedElements).to.have.lengthOf(3)
 		verifyHighlights(highlightedElements, searchQuery)
 	})
@@ -47,7 +47,7 @@ describe('editor search highlighting', () => {
 
 		// Highlight only first occurrence
 		editor.commands.setSearchQuery(searchQuery, false)
-		highlightedElements = document.querySelectorAll('span[data-text-el]')
+		highlightedElements = document.querySelectorAll('span[data-text-el="search-decoration"]')
 
 		expect(highlightedElements).to.have.lengthOf(1)
 		verifyHighlights(highlightedElements, searchQuery)
@@ -57,10 +57,10 @@ describe('editor search highlighting', () => {
 		const searchQuery = 'quod'
 
 		editor.commands.setSearchQuery(searchQuery, true)
-		const allHighlightedElements = document.querySelectorAll('span[data-text-el]')
+		const allHighlightedElements = document.querySelectorAll('span[data-text-el="search-decoration"]')
 
 		editor.commands.nextMatch()
-		const currentlyHighlightedElement = document.querySelectorAll('span[data-text-el]')
+		const currentlyHighlightedElement = document.querySelectorAll('span[data-text-el="search-decoration"]')
 
 		expect(currentlyHighlightedElement).to.have.lengthOf(1)
 		expect(allHighlightedElements[1]).to.deep.equal(currentlyHighlightedElement[0])
@@ -70,10 +70,10 @@ describe('editor search highlighting', () => {
 		const searchQuery = 'quod'
 
 		editor.commands.setSearchQuery(searchQuery, true)
-		const allHighlightedElements = document.querySelectorAll('span[data-text-el]')
+		const allHighlightedElements = document.querySelectorAll('span[data-text-el="search-decoration"]')
 
 		editor.commands.previousMatch()
-		const currentlyHighlightedElement = document.querySelectorAll('span[data-text-el]')
+		const currentlyHighlightedElement = document.querySelectorAll('span[data-text-el="search-decoration"]')
 
 		expect(currentlyHighlightedElement).to.have.lengthOf(1)
 		expect(allHighlightedElements[0]).to.deep.equal(currentlyHighlightedElement[0])

--- a/cypress/component/editor/search.cy.js
+++ b/cypress/component/editor/search.cy.js
@@ -1,25 +1,28 @@
-import { createCustomEditor } from '../../support/components.js'
+import { Editor } from '@tiptap/core'
+import { Document } from '@tiptap/extension-document'
+import { Text } from '@tiptap/extension-text'
 import Search from '../../../src/extensions/Search.js'
+import Paragraph from '../../../src/nodes/Paragraph.js'
+import HardBreak from '../../../src/nodes/HardBreak.js'
 
 describe('editor search highlighting', () => {
-	const editor = createCustomEditor({
-		content: 'lorem ipsum',
-		extensions: [Search],
-	})
+	let editor = null
 
 	before(() => {
-		editor.setOptions({
-			element: document.querySelector('div[data-cy-root]')
+		cy.fixture('lorem.txt').then((text) => {
+			editor = new Editor({
+				element: document.querySelector('div[data-cy-root]'),
+				content: text,
+				extensions: [Document, Text, Search, Paragraph, HardBreak],
+			})
 		})
 	})
 
-	beforeEach(() => editor.createView())
-
 	it('can highlight a search', () => {
-		editor.commands.setSearchQuery('lorem')
+		const searchQuery = 'Lorem ipsum dolor sit amet'
+		editor.commands.setSearchQuery(searchQuery)
 
-		const highlightElements = document.querySelector('span[data-text-el]')
-
-		expect(highlightElements)
+		const highlightedElement = document.querySelector('span[data-text-el]')
+		expect(highlightedElement.innerText).to.equal(searchQuery)
 	})
 })

--- a/cypress/component/editor/search.cy.js
+++ b/cypress/component/editor/search.cy.js
@@ -23,16 +23,16 @@ describe('editor search highlighting', () => {
 		editor.commands.setSearchQuery(searchQuery)
 
 		const highlightedElements = document.querySelectorAll('span[data-text-el]')
-		expect(highlightedElements.length).to.equal(1)
+		expect(highlightedElements).to.have.lengthOf(1)
 		verifyHighlights(highlightedElements, searchQuery)
 	})
 
 	it('can highlight multiple matches', () => {
-		const searchQuery = 'et'
+		const searchQuery = 'quod'
 		editor.commands.setSearchQuery(searchQuery)
 
 		const highlightedElements = document.querySelectorAll('span[data-text-el]')
-		expect(highlightedElements.length).to.equal(16)
+		expect(highlightedElements).to.have.lengthOf(3)
 		verifyHighlights(highlightedElements, searchQuery)
 	})
 
@@ -40,19 +40,38 @@ describe('editor search highlighting', () => {
 		const searchQuery = 'quod'
 		let highlightedElements = []
 
-		// Highlight all occurrences 
-		editor.commands.setSearchQuery(searchQuery, true)
-		highlightedElements = document.querySelectorAll('span[data-text-el]')
-
-		expect(highlightedElements.length).to.equal(3)
-		verifyHighlights(highlightedElements, searchQuery)
-
 		// Highlight only first occurrence
 		editor.commands.setSearchQuery(searchQuery, false)
 		highlightedElements = document.querySelectorAll('span[data-text-el]')
 
-		expect(highlightedElements.length).to.equal(1)
+		expect(highlightedElements).to.have.lengthOf(1)
 		verifyHighlights(highlightedElements, searchQuery)
+	})
+
+	it('can move to next occurrence', () => {
+		const searchQuery = 'quod'
+
+		editor.commands.setSearchQuery(searchQuery, true)
+		const allHighlightedElements = document.querySelectorAll('span[data-text-el]')
+
+		editor.commands.nextMatch()
+		const currentlyHighlightedElement = document.querySelectorAll('span[data-text-el]')
+
+		expect(currentlyHighlightedElement).to.have.lengthOf(1)
+		expect(allHighlightedElements[1]).to.deep.equal(currentlyHighlightedElement[0])
+	})
+
+	it('can move to previous occurrence', () => {
+		const searchQuery = 'quod'
+
+		editor.commands.setSearchQuery(searchQuery, true)
+		const allHighlightedElements = document.querySelectorAll('span[data-text-el]')
+
+		editor.commands.previousMatch()
+		const currentlyHighlightedElement = document.querySelectorAll('span[data-text-el]')
+
+		expect(currentlyHighlightedElement).to.have.lengthOf(1)
+		expect(allHighlightedElements[0]).to.deep.equal(currentlyHighlightedElement[0])
 	})
 })
 

--- a/cypress/fixtures/lorem.txt
+++ b/cypress/fixtures/lorem.txt
@@ -1,0 +1,7 @@
+<p>
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim aeque doleamus animo, cum corpore dolemus, fieri tamen permagna accessio potest, si aliquod aeternum et infinitum impendere malum nobis opinemur. Quod idem licet transferre in voluptatem, ut postea variari voluptas distinguique possit, augeri amplificarique non possit. At.
+</p>
+
+<p>
+	Ullus investigandi veri, nisi inveneris, et quaerendi defatigatio turpis est, cum esset accusata et vituperata ab Hortensio. Qui liber cum et mortem contemnit, qua qui est imbutus quietus esse numquam potest. Praeterea bona praeterita grata recordatione renovata delectant. Est autem situm in nobis ut et voluptates et dolores nasci fatemur e corporis voluptatibus et doloribus -- itaque concedo, quod modo dicebas, cadere.
+</p>

--- a/src/editor.js
+++ b/src/editor.js
@@ -5,6 +5,7 @@
 
 import Vue from 'vue'
 import store from './store/index.js'
+import { subscribe } from '@nextcloud/event-bus'
 import { EDITOR_UPLOAD, HOOK_MENTION_SEARCH, HOOK_MENTION_INSERT, ATTACHMENT_RESOLVER } from './components/Editor.provider.js'
 import { ACTION_ATTACHMENT_PROMPT } from './components/Editor/MediaHandler.provider.js'
 // eslint-disable-next-line import/no-unresolved, n/no-missing-import
@@ -56,6 +57,11 @@ class TextEditorEmbed {
 		return this
 	}
 
+	onSearch(onSearchCallback = () => {}) {
+	  subscribe('text:editor:search-results', onSearchCallback)
+	  return this
+	}
+
 	render(el) {
 		el.innerHTML = ''
 		const element = document.createElement('div')
@@ -75,6 +81,21 @@ class TextEditorEmbed {
 		// Call setContent for file based Editor
 		this.#getEditorComponent()?.setContent?.(content)
 		return this
+	}
+
+	setSearchQuery(query, matchAll) {
+		const editor = this.#getEditorComponent()?.$editor
+		editor.commands.setSearchQuery(query, matchAll)
+	}
+
+	searchNext() {
+		const editor = this.#getEditorComponent()?.$editor
+		editor.commands.nextMatch()
+	}
+
+	searchPrevious() {
+		const editor = this.#getEditorComponent()?.$editor
+		editor.commands.previousMatch()
 	}
 
 	async save() {
@@ -138,6 +159,7 @@ window.OCA.Text.createEditor = async function({
 	onFileInsert = undefined,
 	onMentionSearch = undefined,
 	onMentionInsert = undefined,
+	onSearch = undefined,
 }) {
 	const { default: MarkdownContentEditor } = await import(/* webpackChunkName: "editor" */'./components/Editor/MarkdownContentEditor.vue')
 	const { default: Editor } = await import(/* webpackChunkName: "editor" */'./components/Editor.vue')
@@ -212,5 +234,6 @@ window.OCA.Text.createEditor = async function({
 		.onLoaded(onLoaded)
 		.onUpdate(onUpdate)
 		.onOutlineToggle(onOutlineToggle)
+		.onSearch(onSearch)
 		.render(el)
 }

--- a/src/extensions/Search.js
+++ b/src/extensions/Search.js
@@ -4,7 +4,6 @@
  */
 
 import { Extension } from '@tiptap/core'
-import { subscribe } from '@nextcloud/event-bus'
 import searchDecorations from '../plugins/searchDecorations.js'
 import {
 	setSearchQuery,
@@ -15,20 +14,6 @@ import {
 
 export default Extension.create({
 	name: 'Search',
-
-	onCreate() {
-		subscribe('text:editor:search', ({ query, matchAll }) => {
-			this.editor.commands.setSearchQuery(query, matchAll)
-		})
-
-		subscribe('text:editor:search-next', () => {
-			this.editor.commands.nextMatch()
-		})
-
-		subscribe('text:editor:search-previous', () => {
-			this.editor.commands.previousMatch()
-		})
-	},
 
 	addCommands() {
 		return {

--- a/src/plugins/searchDecorations.js
+++ b/src/plugins/searchDecorations.js
@@ -37,8 +37,8 @@ export default function searchDecorations() {
 					})
 
 					emit('text:editor:search-results', {
-						results: (newSearch.query === '' ? null : total),
-						index,
+						totalMatches: (newSearch.query === '' ? null : total),
+						matchIndex: index,
 					})
 
 					return highlightResults(tr.doc, results)

--- a/src/tests/plugins/searchQuery.spec.js
+++ b/src/tests/plugins/searchQuery.spec.js
@@ -5,7 +5,7 @@
 import { searchQuery } from '../../plugins/searchQuery.js'
 import { Plugin, EditorState } from '@tiptap/pm/state'
 import { schema } from '@tiptap/pm/schema-basic'
-import { setSearchQuery, nextMatch } from '../../plugins/searchQuery.js'
+import { setSearchQuery, nextMatch, previousMatch } from '../../plugins/searchQuery.js'
 
 describe('searchQuery plugin', () => {
 	it('can set up plugin and state', () => {
@@ -59,6 +59,29 @@ describe('searchQuery plugin', () => {
 			query: 'lorem',   // search query should be the same
 			matchAll: false,  // matchAll is set to false
 			index: 1,         // index is incremented to the next match
+		})
+	})
+
+	it ('can accept previous match state', () => {
+		const { plugin, state } = pluginSetup()
+
+		const setSearch = setSearchQuery('lorem')(state)
+		const previousSearch = previousMatch()(state)
+
+		let newState = state.apply(setSearch)
+
+		expect(plugin.getState(newState)).toEqual({
+			query: 'lorem',
+			matchAll: true,
+			index: 0,
+		})
+		
+		newState = newState.apply(previousSearch)
+
+		expect(plugin.getState(newState)).toEqual({
+			query: 'lorem',
+			matchAll: false,
+			index: -1,
 		})
 	})
 })


### PR DESCRIPTION
### 📝 Summary

* Resolves: #6133 

Previously, Text would emit and subscribe to events using [@nextcloud/event-bus](https://github.com/nextcloud-libraries/nextcloud-event-bus) and other apps which wanted to use search highlighting would need to subscribe and emit their own corresponding events to trigger it. This was not ideal since it required apps to use some unknown / undocumented API for triggering search highlighting. This PR moves away from using the event bus for cross-app communication in this case, and allows apps to just call some search methods on the editor itself.

Please note, the event bus is still used in one area, but it is not used for cross-app communication in that case. It is used only for communicating with deeply-nested Prosemirror plugins and the editor class itself, and is thusly not exposed as something other apps can use. They must still use the editor API.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
