### PR TITLE
fix/sync error cleanup

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -566,7 +566,7 @@ export default {
 		},
 
 		onSync({ steps, document }) {
-			this.hasConnectionIssue = false
+			this.hasConnectionIssue = !this.$providers[0].wsconnected || this.$syncService.pushError > 0
 			this.$nextTick(() => {
 				this.emit('sync-service:sync')
 			})

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -335,6 +335,13 @@ export default {
 		subscribe('text:image-node:delete', this.onDeleteImageNode)
 		this.emit('update:loaded', true)
 		subscribe('text:translate-modal:show', this.showTranslateModal)
+
+		window.addEventListener('beforeunload', (e) => {
+			if (this.$queue.length > 0) {
+				e.preventDefault()
+				e.returnValue = t('text', 'Some changes have not been synced. You might loose your edits when leaving the page.')
+			}
+		})
 	},
 	created() {
 		this.$ydoc = new Doc()

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -559,7 +559,7 @@ export default {
 			this.document = document
 
 			this.syncError = null
-			const editable = !this.readOnly
+			const editable = !this.readOnly && !this.hasConnectionIssue
 			if (this.$editor.isEditable !== editable) {
 				this.$editor.setEditable(editable)
 			}

--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -77,6 +77,8 @@ class SyncService {
 
 		this.autosave = debounce(this._autosave.bind(this), AUTOSAVE_INTERVAL)
 
+		this.pushError = 0
+
 		return this
 	}
 
@@ -166,6 +168,7 @@ class SyncService {
 		}
 		return this.#connection.push(data)
 			.then((response) => {
+				this.pushError = 0
 				this.sending = false
 				this.emit('sync', {
 					steps: [],
@@ -175,6 +178,7 @@ class SyncService {
 			}).catch(err => {
 				const { response, code } = err
 				this.sending = false
+				this.pushError++
 				if (!response || code === 'ECONNABORTED') {
 					this.emit('error', { type: ERROR_TYPE.CONNECTION_FAILED, data: {} })
 				}

--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -90,8 +90,12 @@ class SyncService {
 		return this.#connection.session.guestName
 	}
 
+	get hasActiveConnection() {
+		return this.#connection && !this.#connection.isClosed
+	}
+
 	async open({ fileId, initialSession }) {
-		if (this.#connection && !this.#connection.isClosed) {
+		if (this.hasActiveConnection) {
 			// We're already connected.
 			return
 		}
@@ -305,7 +309,7 @@ class SyncService {
 		// Make sure to leave no pending requests behind.
 		this.autosave.clear()
 		this.backend?.disconnect()
-		if (!this.#connection || this.#connection.isClosed) {
+		if (!this.hasActiveConnection) {
 			return
 		}
 		return this.#connection.close()

--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -199,6 +199,8 @@ class SyncService {
 						this.emit('error', { type: ERROR_TYPE.PUSH_FAILURE, data: {} })
 						OC.Notification.showTemporary('Changes could not be sent yet')
 					}
+				} else {
+					this.emit('error', { type: ERROR_TYPE.PUSH_FAILURE, data: {} })
 				}
 				throw new Error('Failed to apply steps. Retry!', { cause: err })
 			})


### PR DESCRIPTION
- [ ] Refactor the general sync state into a defined data strcuture by splitting push/sync/save state and also remembering last success/failure time, number of failures. That way we have more control to show errors only if the issue persists and not immediately on flaky connections
- [ ] Indicate that local changes were not pushed to the server with a proper error message on the save indicator
  - [ ] Figure out if we can auto retry the push or if we want to let the user manually trigger it
- [ ] Avoid immediately setting the editor to read only
- [ ] Avoid saving the file as the user if there are unpushed steps
- [ ] Warn users when navigating away with unpushed steps
- [ ] File follow up issue for proper offline support, keeping changes in the browser storage and pushing later

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
