### PR TITLE
fix(test): increase timeout

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -169,11 +169,19 @@ jobs:
           curl -v http://localhost:8081/index.php/login
           cat data/nextcloud.log
 
+      - uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 114
+          install-dependencies: true
+          install-chromedriver: true
+          chromedriver-version: 114
+      - run: chrome --version
+
       - name: Run E2E cypress tests
         run: |
           cd 'apps/${{ env.APP_NAME }}'
           npx wait-on $CYPRESS_baseUrl
-          npx cypress run --record false --config defaultCommandTimeout=10000,video=false
+          npx cypress run --record false --config defaultCommandTimeout=10000,video=false --browser chrome
         env:
           # https://github.com/cypress-io/github-action/issues/124
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}

--- a/cypress/e2e/nodes/ImageView.spec.js
+++ b/cypress/e2e/nodes/ImageView.spec.js
@@ -127,7 +127,7 @@ describe('Image View', () => {
 			cy.openFile(fileName)
 
 			cy.getContent()
-				.find('[data-component="image-view"][data-src=".attachments.123/github.png"] img')
+				.find('[data-component="image-view"][data-src=".attachments.123/github.png"] img', { timeout: 20000 })
 				.click()
 
 			cy.get('.modal__content img')
@@ -140,7 +140,7 @@ describe('Image View', () => {
 			cy.openFile(fileName)
 
 			cy.getContent()
-				.find('[data-component="image-view"][data-src=".attachments.123/file.txt.gz"] img')
+				.find('[data-component="image-view"][data-src=".attachments.123/file.txt.gz"] img', { timeout: 20000 })
 				.click()
 
 			const downloadsFolder = Cypress.config('downloadsFolder')

--- a/cypress/e2e/nodes/ImageView.spec.js
+++ b/cypress/e2e/nodes/ImageView.spec.js
@@ -128,7 +128,7 @@ describe('Image View', () => {
 
 			cy.getContent()
 				.find('[data-component="image-view"][data-src=".attachments.123/github.png"] img', { timeout: 20000 })
-				.click()
+				.click({ force: true })
 
 			cy.get('.modal__content img')
 				.should('have.attr', 'src')
@@ -141,7 +141,7 @@ describe('Image View', () => {
 
 			cy.getContent()
 				.find('[data-component="image-view"][data-src=".attachments.123/file.txt.gz"] img', { timeout: 20000 })
-				.click()
+				.click({ force: true })
 
 			const downloadsFolder = Cypress.config('downloadsFolder')
 			cy.log(`downloadsFolder: ${downloadsFolder}`)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -324,8 +324,8 @@ Cypress.Commands.add('getModal', () => {
 
 Cypress.Commands.add('getEditor', { prevSubject: 'optional' }, (subject) => {
 	return subject
-		? cy.wrap(subject).find('[data-text-el="editor-container"]')
-		: cy.get('[data-text-el="editor-container"]')
+		? cy.wrap(subject).find('[data-text-el="editor-container"]', { timeout: 20000 })
+		: cy.get('[data-text-el="editor-container"]', { timeout: 20000 })
 })
 
 Cypress.Commands.add('getMenu', { prevSubject: 'optional' }, (subject) => {


### PR DESCRIPTION
Should fix `ImageView.spec.js`. The issue seemed to be that the elements were loading, but too slowly and the Cypress commands timed out. Adding a longer timeout should be reasonable enough.