### PR TITLE
fix(attachments): Uploading of attachments from public shares

### DIFF
--- a/lib/Controller/AttachmentController.php
+++ b/lib/Controller/AttachmentController.php
@@ -109,7 +109,7 @@ class AttachmentController extends ApiController implements ISessionAwareControl
 	#[NoAdminRequired]
 	#[PublicPage]
 	#[RequireDocumentSession]
-	public function uploadAttachment(string $shareToken = ''): DataResponse {
+	public function uploadAttachment(string $token = ''): DataResponse {
 		$documentId = $this->getSession()->getDocumentId();
 
 		try {
@@ -120,8 +120,8 @@ class AttachmentController extends ApiController implements ISessionAwareControl
 					throw new Exception('Could not read file');
 				}
 				$newFileName = $file['name'];
-				if ($shareToken) {
-					$uploadResult = $this->attachmentService->uploadAttachmentPublic($documentId, $newFileName, $newFileResource, $shareToken);
+				if ($token) {
+					$uploadResult = $this->attachmentService->uploadAttachmentPublic($documentId, $newFileName, $newFileResource, $token);
 				} else {
 					$userId = $this->getSession()->getUserId();
 					$uploadResult = $this->attachmentService->uploadAttachment($documentId, $newFileName, $newFileResource, $userId);

--- a/src/components/Editor/MediaHandler.vue
+++ b/src/components/Editor/MediaHandler.vue
@@ -110,8 +110,8 @@ export default {
 
 			return Promise.all(uploadPromises)
 				.catch(error => {
-					logger.error('Uploading multiple images failed', { error })
-					showError(error?.response?.data?.error || error.message)
+					logger.error('Uploading multiple attachments failed', { error })
+					showError(t('text', 'Uploading multiple attachments failed.'))
 				})
 				.then(() => {
 					this.state.isUploadingAttachments = false
@@ -128,8 +128,8 @@ export default {
 					)
 				})
 				.catch((error) => {
-					logger.error('Uploading image failed', { error })
-					showError(error?.response?.data?.error)
+					logger.error('Uploading attachment failed', { error })
+					showError(t('text', 'Uploading attachment failed.'))
 				})
 				.then(() => {
 					this.state.isUploadingAttachments = false
@@ -156,8 +156,8 @@ export default {
 					null, response.data?.dirname,
 				)
 			}).catch((error) => {
-				logger.error('Failed to insert image path', { error })
-				showError(error?.response?.data?.error || error.message)
+				logger.error('Failed to insert from Files', { error })
+				showError(t('text', 'Failed to insert from Files'))
 			}).then(() => {
 				this.state.isUploadingAttachments = false
 			})

--- a/src/services/SessionApi.js
+++ b/src/services/SessionApi.js
@@ -147,7 +147,7 @@ export class Connection {
 			+ '?documentId=' + encodeURIComponent(this.#document.id)
 			+ '&sessionId=' + encodeURIComponent(this.#session.id)
 			+ '&sessionToken=' + encodeURIComponent(this.#session.token)
-			+ '&shareToken=' + encodeURIComponent(this.#options.shareToken || '')
+			+ '&token=' + encodeURIComponent(this.#options.shareToken || '')
 		return this.#post(url, formData, {
 			headers: {
 				'Content-Type': 'multipart/form-data',


### PR DESCRIPTION
The session middleware expects the share token as param `token`.

Fixes: #6206

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
