### PR TITLE
fix: Ensure WebsocketPolyfill always has the latest session state and version

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -566,7 +566,7 @@ export default {
 		},
 
 		onSync({ steps, document }) {
-			this.hasConnectionIssue = !this.$providers[0].wsconnected || this.$syncService.pushError > 0
+			this.hasConnectionIssue = this.$syncService.backend.fetcher === 0 || !this.$providers[0].wsconnected || this.$syncService.pushError > 0
 			this.$nextTick(() => {
 				this.emit('sync-service:sync')
 			})

--- a/src/services/WebSocketPolyfill.js
+++ b/src/services/WebSocketPolyfill.js
@@ -34,15 +34,11 @@ export default function initWebSocketPolyfill(syncService, fileId, initialSessio
 			this.#notifyPushBus?.on('notify_push', this.#onNotifyPush.bind(this))
 			this.url = url
 			logger.debug('WebSocketPolyfill#constructor', { url, fileId, initialSession })
-			if (syncService.hasActiveConnection) {
-				setTimeout(() => this.onopen?.(), 0)
-			}
 			this.#registerHandlers({
 				opened: ({ version, session }) => {
-					this.#version = version
 					logger.debug('opened ', { version, session })
+					this.#version = version
 					this.#session = session
-					this.onopen?.()
 				},
 				loaded: ({ version, session, content }) => {
 					logger.debug('loaded ', { version, session })
@@ -60,7 +56,16 @@ export default function initWebSocketPolyfill(syncService, fileId, initialSessio
 					}
 				},
 			})
-			syncService.open({ fileId, initialSession })
+
+			syncService.open({ fileId, initialSession }).then((data) => {
+				if (syncService.hasActiveConnection) {
+					const { version, session } = data
+					this.#version = version
+					this.#session = session
+
+					this.onopen?.()
+				}
+			})
 		}
 
 		#registerHandlers(handlers) {

--- a/src/tests/services/WebsocketPolyfill.spec.js
+++ b/src/tests/services/WebsocketPolyfill.spec.js
@@ -8,21 +8,21 @@ import initWebSocketPolyfill from '../../services/WebSocketPolyfill.js'
 describe('Init function', () => {
 
 	it('returns a websocket polyfill class', () => {
-		const syncService = { on: jest.fn(), open: jest.fn() }
+		const syncService = { on: jest.fn(), open: jest.fn(() => Promise.resolve({ version: 123, session: {} })) }
 		const Polyfill = initWebSocketPolyfill(syncService)
 		const websocket = new Polyfill('url')
 		expect(websocket).toBeInstanceOf(Polyfill)
 	})
 
 	it('registers handlers', () => {
-		const syncService = { on: jest.fn(), open: jest.fn() }
+		const syncService = { on: jest.fn(), open: jest.fn(() => Promise.resolve({ version: 123, session: {} })) }
 		const Polyfill = initWebSocketPolyfill(syncService)
 		const websocket = new Polyfill('url')
 		expect(syncService.on).toHaveBeenCalled()
 	})
 
 	it('opens sync service', () => {
-		const syncService = { on: jest.fn(), open: jest.fn() }
+		const syncService = { on: jest.fn(), open: jest.fn(() => Promise.resolve({ version: 123, session: {} })) }
 		const fileId = 123
 		const initialSession = { }
 		const Polyfill = initWebSocketPolyfill(syncService, fileId, initialSession)
@@ -33,7 +33,7 @@ describe('Init function', () => {
 	it('sends steps to sync service', async () => {
 		const syncService = {
 			on: jest.fn(),
-			open: jest.fn(),
+			open: jest.fn(() => Promise.resolve({ version: 123, session: {} })),
 			sendSteps: async getData => getData(),
 		}
 		const queue = [ 'initial' ]
@@ -51,9 +51,10 @@ describe('Init function', () => {
 	})
 
 	it('handles early reject', async () => {
+		jest.spyOn(console, 'error').mockImplementation(() => {})
 		const syncService = {
 			on: jest.fn(),
-			open: jest.fn(),
+			open: jest.fn(() => Promise.resolve({ version: 123, session: {} })),
 			sendSteps: jest.fn().mockRejectedValue('error before reading steps in sync service'),
 		}
 		const queue = [ 'initial' ]
@@ -69,9 +70,10 @@ describe('Init function', () => {
 	})
 
 	it('handles reject after reading data', async () => {
+		jest.spyOn(console, 'error').mockImplementation(() => {})
 		const syncService = {
 			on: jest.fn(),
-			open: jest.fn(),
+			open: jest.fn(() => Promise.resolve({ version: 123, session: {} })),
 			sendSteps: jest.fn().mockImplementation( async getData => {
 				getData()
 				throw 'error when sending in sync service'
@@ -90,9 +92,10 @@ describe('Init function', () => {
 	})
 
 	it('queue survives a close', async () => {
+		jest.spyOn(console, 'error').mockImplementation(() => {})
 		const syncService = {
 			on: jest.fn(),
-			open: jest.fn(),
+			open: jest.fn(() => Promise.resolve({ version: 123, session: {} })),
 			sendSteps: jest.fn().mockImplementation( async getData => {
 				getData()
 				throw 'error when sending in sync service'


### PR DESCRIPTION
## Steps to reproduce

- Have an active sync session
- Block requests to /sync with 401
- Wait for push to fail and have no version

## What happened

If the sync request was failing and the websocket polyfill was reinitialized there was no event emitted by the syncService to set the current session state, version on the new instance again. This lead to push requests missing the current version in the request data.




