### PR TITLE
ci(cypress): Fix file list link selector

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -275,7 +275,7 @@ Cypress.Commands.add('getFileId', (fileName, params = {}) => {
 })
 
 Cypress.Commands.add('openFile', (fileName, params = {}) => {
-	cy.get(`[data-cy-files-list] tr[data-cy-files-list-row-name="${fileName}"] a[data-cy-files-list-row-name-link]`).click(params)
+	cy.get(`[data-cy-files-list] tr[data-cy-files-list-row-name="${fileName}"] [data-cy-files-list-row-name-link]`).click(params)
 })
 
 Cypress.Commands.add('openFileInShare', fileName => {


### PR DESCRIPTION
Selector changed with https://github.com/nextcloud/server/commit/4ebea3db3a6e3ec72502b283f1dfbe842d75dbf0 5 days ago

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
