### PR TITLE
fix(ViewerComponent): use MarkdownContentEditor for readonly views

### DIFF
--- a/cypress/e2e/versions.spec.js
+++ b/cypress/e2e/versions.spec.js
@@ -34,12 +34,12 @@ describe('Versions', () => {
 			cy.get('[data-files-versions-versions-list] li a').should('have.length', 3)
 
 			cy.get('[data-files-versions-versions-list] li a').eq(1).click()
-			cy.get('.viewer__content #read-only-editor')
+			cy.getContent()
 				.find('h1')
 				.should('contain.text', 'V2')
 
 			cy.get('[data-files-versions-versions-list] li a').eq(2).click()
-			cy.get('.viewer__content #read-only-editor')
+			cy.getContent()
 				.find('h1')
 				.should('contain.text', 'V1')
 
@@ -68,12 +68,12 @@ describe('Versions', () => {
 			cy.get('[data-files-versions-versions-list] li a').should('have.length', 3)
 
 			cy.get('[data-files-versions-versions-list] li a').eq(1).click()
-			cy.get('.viewer__content #read-only-editor')
+			cy.getContent()
 				.find('h1')
 				.should('contain.text', 'V2')
 
 			cy.get('[data-files-versions-versions-list] li a').eq(2).click()
-			cy.get('.viewer__content #read-only-editor')
+			cy.getContent()
 				.find('h1')
 				.should('contain.text', 'V1')
 
@@ -113,7 +113,7 @@ describe('Versions', () => {
 				.should('contain', 'Compare to current version')
 				.click()
 
-			cy.get('.viewer__content #read-only-editor')
+			cy.getContent()
 				.find('h1')
 				.should('contain.text', '#V1')
 

--- a/src/components/Editor/MarkdownContentEditor.vue
+++ b/src/components/Editor/MarkdownContentEditor.vue
@@ -8,10 +8,12 @@
 		:show-outline-outside="showOutlineOutside"
 		@outline-toggled="outlineToggled">
 		<MainContainer>
-			<MenuBar v-if="!readOnly" :autohide="false" />
-			<slot v-else name="readonlyBar">
-				<ReadonlyBar />
-			</slot>
+			<template v-if="showMenuBar">
+				<MenuBar v-if="!readOnly" :autohide="false" />
+				<slot v-else name="readonlyBar">
+					<ReadonlyBar />
+				</slot>
+			</template>
 			<ContentContainer />
 		</MainContainer>
 	</Wrapper>
@@ -74,6 +76,10 @@ export default {
 		shareToken: {
 			type: String,
 			default: null,
+		},
+		showMenuBar: {
+			type: Boolean,
+			default: true,
 		},
 		showOutlineOutside: {
 			type: Boolean,
@@ -175,6 +181,7 @@ export default {
 }
 </script>
 
-<style scoped>
-
+<style lang="scss">
+@import './../../css/prosemirror';
+@import './../../css/print';
 </style>

--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -17,7 +17,11 @@
 		id="editor-container"
 		data-text-el="editor-container"
 		class="text-editor source-viewer">
-		<Component :is="readerComponent" :content="content" />
+		<Component :is="readerComponent"
+			:content="content"
+			:file-id="fileid"
+			:read-only="true"
+			:show-menu-bar="false" />
 		<NcButton v-if="isEmbedded" class="toggle-interactive" @click="toggleEdit">
 			{{ t('text', 'Edit') }}
 			<template #icon>
@@ -33,7 +37,7 @@ import axios from '@nextcloud/axios'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import PlainTextReader from './PlainTextReader.vue'
-import RichTextReader from './RichTextReader.vue'
+import MarkdownContentEditor from './Editor/MarkdownContentEditor.vue'
 import { translate, translatePlural } from '@nextcloud/l10n'
 
 import { getSharingToken } from '../helpers/token.js'
@@ -47,8 +51,8 @@ export default {
 	components: {
 		NcButton: Vue.extend(NcButton),
 		PencilIcon: Vue.extend(PencilIcon),
-		RichTextReader: Vue.extend(RichTextReader),
 		PlainTextReader: Vue.extend(PlainTextReader),
+		MarkdownContentEditor: Vue.extend(MarkdownContentEditor),
 		Editor: getEditorInstance,
 	},
 	provide() {
@@ -112,7 +116,7 @@ export default {
 
 		/** @return {boolean} */
 		readerComponent() {
-			return this.mime === 'text/markdown' ? RichTextReader : PlainTextReader
+			return this.mime === 'text/markdown' ? MarkdownContentEditor : PlainTextReader
 		},
 	},
 


### PR DESCRIPTION
Also pass the `fileId` to the component. This adds support for displaying images and attachments in the read-only view.

Fixes: #6267

I tested this PR with
* Text in Text (via preview link) in Viewer
* Text in Talk (via preview link)
* Text in Collectives (both view and edit mode)

The editor CSS includes (`prosemirror.css` and `print.css`) were missing in `MarkdownContentEditor`, which resulted in broken view in Talk - probably because that was the only scenario where no second editor was loaded that the same time.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/5933b19b-79e5-46ca-8a2a-9f5e3021456b) | ![grafik](https://github.com/user-attachments/assets/b6b9b0e4-5ff2-475e-b208-ca2aa07944ff)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
