### PR TITLE
fix(attachments): Show proper error message at upload error

### DIFF
--- a/lib/Controller/AttachmentController.php
+++ b/lib/Controller/AttachmentController.php
@@ -23,6 +23,7 @@ use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\Files\IMimeTypeDetector;
+use OCP\Files\InvalidPathException;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\Util;
@@ -133,6 +134,10 @@ class AttachmentController extends ApiController implements ISessionAwareControl
 				}
 			}
 			return new DataResponse(['error' => 'No uploaded file'], Http::STATUS_BAD_REQUEST);
+		} catch (InvalidPathException $e) {
+			$this->logger->error('Upload error', ['exception' => $e]);
+			$error = $e->getMessage() ?: 'Upload error';
+			return new DataResponse(['error' => $error], Http::STATUS_BAD_REQUEST);
 		} catch (Exception $e) {
 			$this->logger->error('Upload error', ['exception' => $e]);
 			return new DataResponse(['error' => 'Upload error'], Http::STATUS_BAD_REQUEST);

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -16,6 +16,7 @@ use OCA\Text\Db\Session;
 use OCP\Constants;
 use OCP\Files\File;
 use OCP\Files\Folder;
+use OCP\Files\IFilenameValidator;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
@@ -35,7 +36,8 @@ class AttachmentService {
 		private ShareManager $shareManager,
 		private IPreview $previewManager,
 		private IMimeTypeDetector $mimeTypeDetector,
-		private IURLGenerator $urlGenerator) {
+		private IURLGenerator $urlGenerator,
+		private IFilenameValidator $filenameValidator) {
 	}
 
 	/**
@@ -263,6 +265,7 @@ class AttachmentService {
 		}
 		$saveDir = $this->getAttachmentDirectoryForFile($textFile, true);
 		$fileName = self::getUniqueFileName($saveDir, $newFileName);
+		$this->filenameValidator->validateFilename($fileName);
 		$savedFile = $saveDir->newFile($fileName, $newFileResource);
 		return [
 			'name' => $fileName,
@@ -293,6 +296,7 @@ class AttachmentService {
 		$textFile = $this->getTextFilePublic($documentId, $shareToken);
 		$saveDir = $this->getAttachmentDirectoryForFile($textFile, true);
 		$fileName = self::getUniqueFileName($saveDir, $newFileName);
+		$this->filenameValidator->validateFilename($fileName);
 		$savedFile = $saveDir->newFile($fileName, $newFileResource);
 		return [
 			'name' => $fileName,

--- a/src/components/Editor/MediaHandler.vue
+++ b/src/components/Editor/MediaHandler.vue
@@ -129,7 +129,11 @@ export default {
 				})
 				.catch((error) => {
 					logger.error('Uploading attachment failed', { error })
-					showError(t('text', 'Uploading attachment failed.'))
+					if (error.response?.data.error) {
+						showError(t('text', 'Uploading attachment failed: {error}', { error: error.response.data.error }))
+					} else {
+						showError(t('text', 'Uploading attachment failed.'))
+					}
 				})
 				.then(() => {
 					this.state.isUploadingAttachments = false


### PR DESCRIPTION
Fixes: #6269

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/73428254-31cf-4ffe-ade2-efbb223ff8ac) | ![grafik](https://github.com/user-attachments/assets/718b3064-acdc-4a6f-8fca-0c3a643747b1)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
