### PR TITLE
fix(editorApi): Add support for a onCreate callback that gets content

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -514,6 +514,10 @@ export default {
 							session,
 							onCreate: ({ editor }) => {
 								this.$syncService.startSync()
+								const proseMirrorMarkdown = this.$syncService.serialize(editor.state.doc)
+								this.emit('create:content', {
+									markdown: proseMirrorMarkdown,
+								})
 							},
 							onUpdate: ({ editor }) => {
 								// this.debugContent(editor)

--- a/src/editor.js
+++ b/src/editor.js
@@ -36,6 +36,13 @@ class TextEditorEmbed {
 		return this.#vm.$children[0]
 	}
 
+	onCreate(onCreateCallback = () => {}) {
+		this.#vm.$on('create:content', (content) => {
+			onCreateCallback(content)
+		})
+		return this
+	}
+
 	onLoaded(onLoadedCallback = () => {}) {
 		this.#vm.$on('ready', () => {
 			onLoadedCallback()
@@ -153,6 +160,7 @@ window.OCA.Text.createEditor = async function({
 		props: null,
 	},
 
+	onCreate = ({ markdown }) => {},
 	onLoaded = () => {},
 	onUpdate = ({ markdown }) => {},
 	onOutlineToggle = (visible) => {},
@@ -231,6 +239,7 @@ window.OCA.Text.createEditor = async function({
 		store,
 	})
 	return new TextEditorEmbed(vm, data)
+		.onCreate(onCreate)
 		.onLoaded(onLoaded)
 		.onUpdate(onUpdate)
 		.onOutlineToggle(onOutlineToggle)


### PR DESCRIPTION
Required for Collectives to update the reader content with editor content on initial load (i.e. before first editor update happens).

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
