### PR TITLE
Allow viewing of attachments when shared by mail 

### DIFF
--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -504,7 +504,7 @@ class AttachmentService {
 		// is the file shared with this token?
 		try {
 			$share = $this->shareManager->getShareByToken($shareToken);
-            if (in_array($share->getShareType(), [IShare::TYPE_LINK, IShare::TYPE_EMAIL])) {
+			if (in_array($share->getShareType(), [IShare::TYPE_LINK, IShare::TYPE_EMAIL])) {
 				// shared file or folder?
 				if ($share->getNodeType() === 'file') {
 					$textFile = $share->getNode();

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -504,7 +504,7 @@ class AttachmentService {
 		// is the file shared with this token?
 		try {
 			$share = $this->shareManager->getShareByToken($shareToken);
-			if ($share->getShareType() === IShare::TYPE_LINK) {
+            if (in_array($share->getShareType(), [IShare::TYPE_LINK, IShare::TYPE_EMAIL])) {
 				// shared file or folder?
 				if ($share->getNodeType() === 'file') {
 					$textFile = $share->getNode();


### PR DESCRIPTION
### 📝 Summary

* Resolves: https://github.com/nextcloud/text/issues/6023

Attachments in text files shared by mail can now be viewed and no longer return an error.

### 🏁 Checklist

- [X] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [X] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits