### PR TITLE
fix: Correctly set "new"-menu entry for folder description

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,10 +6,10 @@
 module.exports = {
 	root: true,
 	extends: [
-		'@nextcloud',
 		'@nextcloud/eslint-config/typescript',
 	],
 	rules: {
 		'@typescript-eslint/no-unused-vars': ['off'],
-	}
+		'import/no-unresolved': [1, { ignore: ['\\.svg\\?raw$'] }],
+	},
 }

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -3,20 +3,20 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { getCurrentUser } from '@nextcloud/auth'
+import { showSuccess, showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { Header, addNewFileMenuEntry, Permission, File, NewMenuEntryCategory } from '@nextcloud/files'
-import { imagePath } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
+import { imagePath } from '@nextcloud/router'
+import { dirname } from 'path'
 
 import { getSharingToken } from './token.js'
 import { openMimetypes } from './mime.js'
 import store from '../store/index.js'
-import { getCurrentUser } from '@nextcloud/auth'
-import { showSuccess, showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
-import { dirname } from 'path'
 
-import TextSvg from '@mdi/svg/svg/text.svg'
+import TextSvg from '@mdi/svg/svg/text.svg?raw'
 
 const FILE_ACTION_IDENTIFIER = 'Edit with text app'
 
@@ -118,8 +118,7 @@ export const addMenuRichWorkspace = () => {
 	addNewFileMenuEntry({
 		id: 'rich-workspace-init',
 		displayName: t('text', 'Add folder description'),
-		// FIXME Move back to other once https://github.com/nextcloud-libraries/nextcloud-upload/pull/1269 is available in server
-		category: NewMenuEntryCategory.CreateNew,
+		category: NewMenuEntryCategory.Other,
 		enabled(context) {
 			if (Number(context.attributes['rich-workspace-file'])) {
 				return false


### PR DESCRIPTION
### 📝 Summary

1. The bug in uploader library was fixed so we should set in on the "Other" section
2. The SVG must be imported with `?raw` otherwise it does not correctly include it.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/79ba2921-fcdd-4fcc-8fd9-9ccd71017934)|![image](https://github.com/user-attachments/assets/f6beca97-29bd-426f-8e29-558561b60503)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
