### PR TITLE
chore(CI): Updating renovate-approve-merge.yml workflow from template

### DIFF
--- a/.github/workflows/renovate-approve-merge.yml
+++ b/.github/workflows/renovate-approve-merge.yml
@@ -33,13 +33,19 @@ jobs:
       contents: write
 
     steps:
-      - uses: mdecoleman/pr-branch-name@bab4c71506bcd299fb350af63bb8e53f2940a599 # v2.0.0
+      - name: Disabled on forks
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          echo 'Can not approve PRs from forks'
+          exit 1
+
+      - uses: mdecoleman/pr-branch-name@55795d86b4566d300d237883103f052125cc7508 # v3.0.0
         id: branchname
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # GitHub actions bot approve
-      - uses: hmarr/auto-approve-action@v3
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         if: startsWith(steps.branchname.outputs.branch, 'renovate/')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automated update of the renovate-approve-merge.yml workflow from https://github.com/nextcloud/.github