### PR TITLE
fix: Reset session if file rename changes mimetype from/to markdown

### DIFF
--- a/cypress/e2e/changeMimetype.spec.js
+++ b/cypress/e2e/changeMimetype.spec.js
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { randUser } from '../utils/index.js'
+
+const user = randUser()
+
+describe('Changing mimetype from/to markdown resets document session', function() {
+	before(function() {
+		// Init user
+		cy.createUser(user)
+		cy.login(user)
+		cy.uploadFile('empty.md', 'text/markdown', 'test1.md')
+		cy.uploadFile('empty.txt', 'text/plain', 'test2.txt')
+	})
+	beforeEach(function() {
+		cy.login(user)
+		cy.visit('/apps/files')
+	})
+
+	it('Rename from md to txt', function() {
+		cy.openFile('test1.md')
+		cy.getContent()
+			.type('## Hello world')
+		cy.closeFile()
+
+		cy.moveFile('test1.md', 'test1.txt')
+		cy.visit('/apps/files')
+
+		cy.openFile('test1.txt')
+		cy.getContent()
+			.find('pre')
+			.should('contain', '## Hello world')
+	})
+
+	it('Rename from txt to md', function() {
+		cy.openFile('test2.txt')
+		cy.getContent()
+			.type('Hello world')
+		cy.closeFile()
+
+		cy.moveFile('test2.txt', 'test2.md')
+		cy.visit('/apps/files')
+
+		cy.openFile('test2.md')
+		cy.getContent()
+			.should('contain', 'Hello world')
+	})
+})

--- a/lib/Listeners/BeforeNodeRenamedListener.php
+++ b/lib/Listeners/BeforeNodeRenamedListener.php
@@ -8,20 +8,23 @@ declare(strict_types=1);
 
 namespace OCA\Text\Listeners;
 
+use Exception;
 use OCA\Text\Service\AttachmentService;
+use OCA\Text\Service\DocumentService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
 use OCP\Files\File;
+use Psr\Log\LoggerInterface;
 
 /**
  * @template-implements IEventListener<Event|BeforeNodeRenamedEvent>
  */
 class BeforeNodeRenamedListener implements IEventListener {
-	private AttachmentService $attachmentService;
-
-	public function __construct(AttachmentService $attachmentService) {
-		$this->attachmentService = $attachmentService;
+	public function __construct(
+		private readonly AttachmentService $attachmentService,
+		private readonly DocumentService $documentService,
+		private readonly LoggerInterface $logger) {
 	}
 
 	public function handle(Event $event): void {
@@ -30,10 +33,24 @@ class BeforeNodeRenamedListener implements IEventListener {
 		}
 		$source = $event->getSource();
 		$target = $event->getTarget();
-		if ($source instanceof File
-			&& $source->getMimeType() === 'text/markdown'
-			&& $target instanceof File
-		) {
+
+		if (!($source instanceof File && $target instanceof File)) {
+			return;
+		}
+
+		$sourceIsMarkdown = $source->getMimeType() === 'text/markdown';
+		$targetIsMarkdown = pathinfo($target->getPath(), PATHINFO_EXTENSION) === 'md'; // NonExistingFile has no `getMimetype()`
+
+		// Reset document state if mimetype changes from/to markdown as this means another editor is loaded
+		if ($sourceIsMarkdown xor $targetIsMarkdown) {
+			try {
+				$this->documentService->resetDocument($source->getId(), true);
+			} catch (Exception $e) {
+				$this->logger->error($e->getMessage(), ['exception' => $e]);
+			}
+		}
+
+		if ($sourceIsMarkdown) {
 			$this->attachmentService->moveAttachments($source, $target);
 		}
 	}


### PR DESCRIPTION
For the event target file, we cannot use `getMimetype()` or `getExtension()` as it's a node of type `NonExistingFile`.

Fixes: #5736

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
