### PR TITLE
fix(CodeBlock): Fix visibleFocus and pasting in code blocks

### DIFF
--- a/src/nodes/CodeBlockView.vue
+++ b/src/nodes/CodeBlockView.vue
@@ -69,7 +69,6 @@
 		<div :class="{'split-view': showCode && showPreview }">
 			<pre v-show="showCode" class="split-view__code"><NodeViewContent spellcheck="false"
 				as="code"
-				tabindex="-1"
 				:contenteditable="isEditable" /></pre>
 			<div v-show="showPreview"
 				ref="preview"


### PR DESCRIPTION
Fixes: #5695

The `tabindex` was introduced with commit 2c9e7a0, but I was not able to reproduce a problem with tab navigation and/or focus trap after removing it.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
