### PR TITLE
test(cy): Fix ImageView native tests

### DIFF
--- a/cypress/e2e/nodes/ImageView.spec.js
+++ b/cypress/e2e/nodes/ImageView.spec.js
@@ -16,6 +16,7 @@ describe('Image View', () => {
 		cy.createFolder('child-folder')
 		cy.uploadFile('github.png', 'image/png')
 		cy.uploadFile('github.png', 'image/png', 'child-folder/github.png')
+
 	})
 
 	beforeEach(() => {
@@ -110,11 +111,8 @@ describe('Image View', () => {
 	describe('native attachments', () => {
 		before(() => {
 			cy.login(user)
-			cy.visit('/apps/files')
 			const fileName = 'native attachments.md'
-			cy.createMarkdown(fileName, '# open image in modal\n\n ![git](.attachments.123/github.png)\n\n ![file.txt.gz](.attachments.123/file.txt.gz)')
-
-			cy.getFileId(fileName).then((fileId) => {
+			cy.createFile(fileName, '# open image in modal\n\n ![git](.attachments.123/github.png)\n\n ![file.txt.gz](.attachments.123/file.txt.gz)').then((fileId) => {
 				const attachmentsFolder = `.attachments.${fileId}`
 				cy.createFolder(attachmentsFolder)
 				cy.uploadFile('github.png', 'image/png', `${attachmentsFolder}/github.png`)


### PR DESCRIPTION
Use `createFile` instead of `createMarkdown` in `before()` block. No idea why, but it fixes the tests reliably.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
