### PR TITLE
Fix headings papercuts

### DIFF
--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -227,6 +227,7 @@ export default {
 		background-color: var(--color-main-background-translucent);
 		backdrop-filter: var(--background-blur);
 		max-height: var(--default-clickable-area); // important for mobile so that the buttons are always inside the container
+		border-bottom: 1px solid var(--color-border);
 		padding-top:3px;
 		padding-bottom: 3px;
 

--- a/src/components/Menu/ReadonlyBar.vue
+++ b/src/components/Menu/ReadonlyBar.vue
@@ -49,6 +49,9 @@ export default defineComponent({
 <style scoped>
 .text-readonly-bar {
 	display: flex;
+	border-bottom: 1px solid var(--color-border);
+	padding-top: 3px;
+	padding-bottom: 3px;
 }
 .text-readonly-bar__entries {
 	display: flex;

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -26,9 +26,6 @@
 	outline: 2px solid #8cf;
 }
 
-/**
- * 
- */
 li.ProseMirror-selectednode {
 	outline: none;
 
@@ -77,7 +74,6 @@ li.ProseMirror-selectednode {
 
 [data-handler='text'] {
 	background-color: var(--color-main-background);
-	border-top: 3px solid var(--color-primary-element);
 	.modal-title {
 		font-weight: bold;
 	}


### PR DESCRIPTION
### 📝 Summary

Quick fixes from design feedback during conference:

* Remove blue top border in viewer, as it doesn't look nice with open sidebar.
* Add bottom border line to menubar. Better visual separation of menubar and editor content, especially when scrolling long content.

#### 🖼️ Screenshots

🏚️ Before logged in | 🏡 After logged in
---|---
![image](https://github.com/user-attachments/assets/b09907a2-7c3e-41fb-8139-33df66218beb) | ![image](https://github.com/user-attachments/assets/0baaacee-7c76-43c8-9a4e-d663b7ffeb3a)

🏚️ Before public read-only share | 🏡 After public read-only share
---| ---
![image](https://github.com/user-attachments/assets/91d94750-7de6-45f5-85b4-34bd6b7d9e36) | ![image](https://github.com/user-attachments/assets/53c30a2e-d9f8-4281-8e0f-bf7a57626696)



### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
