### PR TITLE
fix(vite): set `NODE_ENV` in `package.json` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "module": "dist/index.js",
   "main": "dist/index.js",
   "scripts": {
-    "build": "NODE_OPTIONS='--max-old-space-size=4096' vite --mode production build",
-    "dev": "NODE_OPTIONS='--max-old-space-size=4096' vite --mode development build",
-    "watch": "NODE_OPTIONS='--max-old-space-size=8192' vite --mode development build --watch",
+    "build": "NODE_ENV=production NODE_OPTIONS='--max-old-space-size=4096' vite --mode production build",
+    "dev": "NODE_ENV=development NODE_OPTIONS='--max-old-space-size=4096' vite --mode development build",
+    "watch": "NODE_ENV=development NODE_OPTIONS='--max-old-space-size=8192' vite --mode development build --watch",
     "lint": "tsc && eslint --ext .js,.vue src cypress",
     "lint:fix": "tsc && eslint --ext .js,.vue src cypress --fix",
     "stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css css/*.scss",


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
