### PR TITLE
fix(sync): Disable browser broadcast

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -392,6 +392,7 @@ export default {
 				fileId: this.fileId,
 				queue: this.$queue,
 				initialSession: this.initialSession,
+				disableBC: true,
 			})
 			this.$providers.push(syncServiceProvider)
 			this.forceRecreate = false


### PR DESCRIPTION
Ensure the browser broadcast does not lead to out of sync docs.

If a tab fails to send a step over the network
it may still distributes it to a different tab / window
via the browser broadcast.

That other window will include the step in the yjs history
without forwarding it to other parties.

From that point on all changes in the second tab
will depend on the step that other clients did not receive.

Therefore these changes will not be applied at other parties.

To prevent this scenario disable browser broadcast completely.
