### PR TITLE
fix(sync): handle 502 (Bad Gateway) gracefully

### DIFF
--- a/src/services/PollingBackend.js
+++ b/src/services/PollingBackend.js
@@ -176,13 +176,10 @@ class PollingBackend {
 		} else if (e.response.status === 412) {
 			this.#syncService.emit('error', { type: ERROR_TYPE.LOAD_ERROR, data: e.response })
 			this.disconnect()
-		} else if (e.response.status === 403) {
+		} else if ([403, 404].includes(e.response.status)) {
 			this.#syncService.emit('error', { type: ERROR_TYPE.SOURCE_NOT_FOUND, data: {} })
 			this.disconnect()
-		} else if (e.response.status === 404) {
-			this.#syncService.emit('error', { type: ERROR_TYPE.SOURCE_NOT_FOUND, data: {} })
-			this.disconnect()
-		} else if (e.response.status === 503) {
+		} else if ([502, 503].includes(e.response.status)) {
 			this.increaseRefetchTimer()
 			this.#syncService.emit('error', { type: ERROR_TYPE.CONNECTION_FAILED, data: {} })
 			logger.error('Failed to fetch steps due to unavailable service', { error: e })


### PR DESCRIPTION
This is the proxies response when the request to the server fails.
It is often temporary - so it makes sense to keep trying.

Without this text will stop fetching changes from the server
on the first 502 it encounters.
