### PR TITLE
[stable26] fix: Apply checks on shares in the middleware

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -161,7 +161,7 @@ jobs:
           npm_package_name: ${{ env.APP_NAME }}
 
       - name: Upload test failure screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Upload screenshots
@@ -169,7 +169,7 @@ jobs:
           retention-days: 5
 
       - name: Upload nextcloud logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Upload nextcloud log

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -39,6 +39,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IPreview;
+use OCP\ISession;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IShare;
 use OCP\Util;
@@ -60,6 +61,10 @@ class AttachmentService {
 	 */
 	private $previewManager;
 	/**
+	 * @var ISession
+	 */
+	private $session;
+	/**
 	 * @var IMimeTypeDetector
 	 */
 	private $mimeTypeDetector;
@@ -67,10 +72,12 @@ class AttachmentService {
 	public function __construct(IRootFolder $rootFolder,
 								ShareManager $shareManager,
 								IPreview $previewManager,
+								ISession $session,
 								IMimeTypeDetector $mimeTypeDetector) {
 		$this->rootFolder = $rootFolder;
 		$this->shareManager = $shareManager;
 		$this->previewManager = $previewManager;
+		$this->session = $session;
 		$this->mimeTypeDetector = $mimeTypeDetector;
 	}
 
@@ -545,6 +552,27 @@ class AttachmentService {
 		try {
 			$share = $this->shareManager->getShareByToken($shareToken);
 			if ($share->getShareType() === IShare::TYPE_LINK) {
+
+				// check for password if required
+				/** @psalm-suppress RedundantConditionGivenDocblockType */
+				if ($share->getPassword() !== null) {
+					$shareId = $this->session->get('public_link_authenticated');
+					if ($share->getId() !== $shareId) {
+						throw new ShareNotFound();
+					}
+				}
+
+				// check read permission
+				if (($share->getPermissions() & Constants::PERMISSION_READ) !== Constants::PERMISSION_READ) {
+					throw new ShareNotFound();
+				}
+
+				// check download permission
+				$attributes = $share->getAttributes();
+				if ($attributes !== null && $attributes->getAttribute('permissions', 'download') === false) {
+					throw new ShareNotFound();
+				}
+
 				// shared file or folder?
 				if ($share->getNodeType() === 'file') {
 					$textFile = $share->getNode();


### PR DESCRIPTION
Backport #6487 - largely rewritten as in 26 there was no session middleware yet.


