### PR TITLE
feat: Increase line width to 80 characters

### DIFF
--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -4,6 +4,6 @@
  */
 
 :root {
-	--text-editor-max-width: 670px
+	--text-editor-max-width: 80ch
 }
 


### PR DESCRIPTION
### 📝 Summary

After discussion with designers we wanted to slightly increase the line width of text documents. This is basically the same width as talk uses now for messages which is 80 character width.

Browser support for the ch unit seems sufficient: https://caniuse.com/ch-unit


#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="2559" alt="Screenshot 2024-10-11 at 09 11 43" src="https://github.com/user-attachments/assets/b0a106f2-d94b-4836-a0f9-38b90ccc75dc"> | <img width="2560" alt="Screenshot 2024-10-11 at 09 11 56" src="https://github.com/user-attachments/assets/c71071b2-39e2-42f8-b775-e54dfc5a4d39">

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
