### PR TITLE
enh(make): clean-git even if js or css directory do not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,6 @@ clean-dev:
 	rm -rf node_modules
 
 clean-git:
-	rm -r js/
-	rm -r css/
+	rm -rf js/
+	rm -rf css/
 	git checkout -- js/ css/


### PR DESCRIPTION
## Before

If either the `css` or the `js` directories did not exist
`make clean-git` failed without cleaning up the dirs.

## After

`make clean-git` will run even if one of the dirs is missing.

