### PR TITLE
chore: Skip cypress major/minor on stable branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -102,6 +102,18 @@
       "enabled": false
     },
     {
+      "matchUpdateTypes": ["major", "minor"],
+      "matchPackageNames": [
+        "cypress",
+        "@nextcloud/cypress"
+      ],
+      "matchPackagePrefixes": [
+        "@cypress/"
+      ],
+      "matchBaseBranches": ["stable30", "stable29", "stable28", "stable27", "stable26"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["vue"],
       "allowedVersions": "<3"
     },


### PR DESCRIPTION
As the bump is not working, we can skip this one for now on stable branches. We'll see once cypress improves on main