### PR TITLE
feat: Add toggle for editor line length per user

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -16,7 +16,8 @@ use OCP\IRequest;
 
 class SettingsController extends Controller {
 	public const ACCEPTED_KEYS = [
-		'workspace_enabled'
+		'workspace_enabled',
+		'is_full_width_editor'
 	];
 
 	public function __construct(
@@ -31,7 +32,7 @@ class SettingsController extends Controller {
 	/**
 	 * @throws \OCP\PreConditionNotMetException
 	 *
-	 * @psalm-return DataResponse<200|400, array{workspace_enabled?: mixed, message?: 'Invalid config key'}, array<never, never>>
+	 * @psalm-return DataResponse<200|400, array{workspace_enabled?: mixed, is_full_width_editor?: mixed, message?: 'Invalid config key'}, array<never, never>>
 	 */
 	#[NoAdminRequired]
 	public function updateConfig(string $key, int|string $value): DataResponse {

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -44,4 +44,8 @@ class ConfigService {
 		return $this->appConfig->getValueBool(Application::APP_NAME, 'notify_push');
 
 	}
+
+	public function isFullWidthEditor(?string $userId): bool {
+		return $this->config->getUserValue($userId, Application::APP_NAME, 'is_full_width_editor', '0') === '1';
+	}
 }

--- a/lib/Service/InitialStateProvider.php
+++ b/lib/Service/InitialStateProvider.php
@@ -77,6 +77,11 @@ class InitialStateProvider {
 			'notify_push',
 			$this->configService->isNotifyPushSyncEnabled(),
 		);
+
+		$this->initialState->provideInitialState(
+			'is_full_width_editor',
+			$this->configService->isFullWidthEditor($this->userId),
+		);
 	}
 
 	public function provideFileId(int $fileId): void {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -48,7 +48,8 @@
 							:dirty="dirty"
 							:sessions="filteredSessions"
 							:sync-error="syncError"
-							:has-connection-issue="hasConnectionIssue" />
+							:has-connection-issue="hasConnectionIssue"
+							@editor-width-change="handleEditorWidthChange" />
 						<slot name="header" />
 					</MenuBar>
 					<div v-else class="menubar-placeholder" />
@@ -321,12 +322,21 @@ export default {
 				},
 			}
 		},
+		editorMaxWidth() {
+			return loadState('text', 'is_full_width_editor', false) ? '100%' : '80ch'
+		},
 	},
 	watch: {
 		displayed() {
 			this.$nextTick(() => {
 				this.contentWrapper = this.$refs.contentWrapper
 			})
+		},
+		editorMaxWidth: {
+			immediate: true,
+			handler(newWidth) {
+				this.updateEditorWidth(newWidth)
+			},
 		},
 	},
 	mounted() {
@@ -860,6 +870,19 @@ export default {
 			})
 			this.translateModal = false
 		},
+
+		handleEditorWidthChange(newWidth) {
+			this.updateEditorWidth(newWidth)
+			this.$nextTick(() => {
+				if (this.$editor) {
+					this.$editor.view.updateState(this.$editor.view.state)
+					this.$editor.commands.focus()
+				}
+			})
+		},
+		updateEditorWidth(newWidth) {
+			document.documentElement.style.setProperty('--text-editor-max-width', newWidth)
+		},
 	},
 }
 </script>
@@ -931,75 +954,75 @@ export default {
 </style>
 
 <style lang="scss">
-	@import './../css/variables';
-	@import './../css/style';
-	@import './../css/print';
+@import './../css/variables';
+@import './../css/style';
+@import './../css/print';
 
-	.text-editor__wrapper {
-		@import './../css/prosemirror';
+.text-editor__wrapper {
+	@import './../css/prosemirror';
 
-		// relative position for the alignment of the menububble
-		.text-editor__main {
-			&.draggedOver {
-				background-color: var(--color-primary-element-light);
-			}
-			.text-editor__content-wrapper {
-				position: relative;
-			}
+	// relative position for the alignment of the menububble
+	.text-editor__main {
+		&.draggedOver {
+			background-color: var(--color-primary-element-light);
+		}
+		.text-editor__content-wrapper {
+			position: relative;
 		}
 	}
+}
 
-	.text-editor__wrapper.has-conflicts > .editor {
-		width: 50%;
+.text-editor__wrapper.has-conflicts > .editor {
+	width: 50%;
+}
+
+.text-editor__wrapper.has-conflicts > .content-wrapper {
+	width: 50%;
+	#read-only-editor {
+		margin: 0px auto;
+		padding-top: 50px;
+		overflow: initial;
+	}
+}
+
+@keyframes spin {
+	0% { transform: rotate(0deg); }
+	100% { transform: rotate(360deg); }
+}
+
+/* Give a remote user a caret */
+.collaboration-cursor__caret {
+	position: relative;
+	margin-left: -1px;
+	margin-right: -1px;
+	border-left: 1px solid #0D0D0D;
+	border-right: 1px solid #0D0D0D;
+	word-break: normal;
+	pointer-events: none;
+}
+
+/* Render the username above the caret */
+.collaboration-cursor__label {
+	position: absolute;
+	top: -1.4em;
+	left: -1px;
+	font-size: 12px;
+	font-style: normal;
+	font-weight: 600;
+	line-height: normal;
+	user-select: none;
+	color: #0D0D0D;
+	padding: 0.1rem 0.3rem;
+	border-radius: 3px 3px 3px 0;
+	white-space: nowrap;
+	opacity: 0;
+
+	&.collaboration-cursor__label__active {
+		opacity: 1;
 	}
 
-	.text-editor__wrapper.has-conflicts > .content-wrapper {
-		width: 50%;
-		#read-only-editor {
-			margin: 0px auto;
-			padding-top: 50px;
-			overflow: initial;
-		}
+	&:not(.collaboration-cursor__label__active) {
+		transition: opacity 0.2s 5s;
 	}
-
-	@keyframes spin {
-		0% { transform: rotate(0deg); }
-		100% { transform: rotate(360deg); }
-	}
-
-	/* Give a remote user a caret */
-	.collaboration-cursor__caret {
-		position: relative;
-		margin-left: -1px;
-		margin-right: -1px;
-		border-left: 1px solid #0D0D0D;
-		border-right: 1px solid #0D0D0D;
-		word-break: normal;
-		pointer-events: none;
-	}
-
-	/* Render the username above the caret */
-	.collaboration-cursor__label {
-		position: absolute;
-		top: -1.4em;
-		left: -1px;
-		font-size: 12px;
-		font-style: normal;
-		font-weight: 600;
-		line-height: normal;
-		user-select: none;
-		color: #0D0D0D;
-		padding: 0.1rem 0.3rem;
-		border-radius: 3px 3px 3px 0;
-		white-space: nowrap;
-		opacity: 0;
-
-		&.collaboration-cursor__label__active {
-			opacity: 1;
-		}
-
-		&:not(.collaboration-cursor__label__active) {
-			transition: opacity 0.2s 5s;
-		}
-	}
+}
 </style>

--- a/src/components/Editor/Status.vue
+++ b/src/components/Editor/Status.vue
@@ -15,7 +15,8 @@
 				</template>
 			</NcButton>
 		</div>
-		<SessionList :sessions="sessions">
+		<SessionList :sessions="sessions"
+			@editor-width-change="onEditorWidthChange">
 			<p slot="lastSaved" class="last-saved">
 				{{ t('text', 'Last saved') }}: {{ lastSavedString }}
 			</p>
@@ -72,7 +73,9 @@ export default {
 		},
 		sessions: {
 			type: Object,
-			default: () => { return {} },
+			default: () => {
+				return {}
+			},
 		},
 	},
 
@@ -128,35 +131,38 @@ export default {
 				this.$syncService.forceSave()
 			}
 		},
+		onEditorWidthChange(newWidth) {
+			this.$emit('editor-width-change', newWidth)
+		},
 	},
 }
 </script>
 
 <style scoped lang="scss">
-	.text-editor__session-list {
-		display: flex;
+.text-editor__session-list {
+	display: flex;
 
-		input, div {
-			vertical-align: middle;
-			margin-left: 3px;
-		}
+	input, div {
+		vertical-align: middle;
+		margin-left: 3px;
 	}
+}
 
-	.save-status {
-		border-radius: 50%;
-		color: var(--color-text-lighter);
-		display: inline-flex;
-		justify-content: center;
-		padding: 0;
-		height: var(--default-clickable-area);
-		width: var(--default-clickable-area);
+.save-status {
+	border-radius: 50%;
+	color: var(--color-text-lighter);
+	display: inline-flex;
+	justify-content: center;
+	padding: 0;
+	height: var(--default-clickable-area);
+	width: var(--default-clickable-area);
 
-		&:hover {
-			background-color: var(--color-background-hover);
-		}
+	&:hover {
+		background-color: var(--color-background-hover);
 	}
+}
 
-	.last-saved {
-		padding: 6px;
-	}
+.last-saved {
+	padding: 6px;
+}
 </style>


### PR DESCRIPTION
### 📝 Summary

Fixes #4024

After some direct alignment with designers, we basically want to offer a per user setting to allow users changing between a full line length and a compact line length display mode.

#### 🖼️ Screenshots

| 🏚️ Before | 🏡 After |
|--|--|
| ![default](https://github.com/user-attachments/assets/fc154d9e-767f-413e-a125-930dcafb9cdf) | ![full-width](https://github.com/user-attachments/assets/0e06a864-710e-45b8-84ac-d413102124bb) |

B | A

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### Follow up

- [ ] Hide the toggle for line length in collectives as it has its own option
- [ ] Discuss if moving the toggle to the action menu makes sense