### PR TITLE
fix(mermaid): No custom link handling for links in mermaid diagrams

### DIFF
--- a/src/plugins/links.js
+++ b/src/plugins/links.js
@@ -158,6 +158,11 @@ export function linkClicking() {
 				click: (view, event) => {
 					const linkEl = event.target.closest('a')
 					if (event.button === 0 && linkEl) {
+						// No special handling in mermaid diagrams to not break links there
+						if (linkEl.closest('svg[id^="mermaid-view"]')) {
+							return false
+						}
+
 						event.preventDefault()
 						if (isLinkToSelfWithHash(linkEl.attributes.href?.value)) {
 							// Open anchor links directly


### PR DESCRIPTION
This fixes clicking links in mermaid diagrams in Collectives. See the issue that gets fixed by this for a reproducer.

Fixes: nextcloud/collectives#1135

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
