### PR TITLE
feat(debug): Expose yjs debug function in editor API

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -343,6 +343,7 @@ export default {
 		subscribe('text:image-node:delete', this.onDeleteImageNode)
 		this.emit('update:loaded', true)
 		subscribe('text:translate-modal:show', this.showTranslateModal)
+		this.setupEditorDebug()
 	},
 	created() {
 		this.$ydoc = new Doc()
@@ -761,6 +762,54 @@ export default {
 			console.debug(markdownItHtml)
 			logger.debug('HTML, as rendered in the browser by Tiptap')
 			console.debug(editor.getHTML())
+		},
+
+		/**
+		 * Setup OCA.Text.debugYjs() and expose editor component in OCA.Text.editorComponents
+		 */
+		setupEditorDebug() {
+			if (!window.OCA.Text) {
+				window.OCA.Text = {}
+			}
+			if (!window.OCA.Text.editorComponents) {
+				window.OCA.Text.editorComponents = []
+			}
+			window.OCA.Text.editorComponents.push(this)
+
+			if (!window.OCA.Text.debugYjs) {
+				window.OCA.Text.debugYjs = () => {
+					const intro = 'Editor Yjs debug data. Copy the objects above that start with "fileId".'
+					const introChrome = '- In Chrome, select "Copy" at the end of the line.'
+					const introFirefox = '- In Firefox, right-click on the object and select "Copy object".'
+					const styleBold = 'font-weight: bold;'
+					const styleItalic = 'font-weight: normal; font-style: italic;'
+
+					for (const editorComponent of window.OCA.Text.editorComponents) {
+						console.warn(JSON.stringify(editorComponent.debugYjsData(), null, ' '))
+					}
+
+					console.warn('%c%s\n%c%s\n%s', styleBold, intro, styleItalic, introChrome, introFirefox)
+				}
+			}
+		},
+
+		/**
+		 * Helper method to debug yjs issues
+		 */
+		debugYjsData() {
+			const yjsData = {
+				fileId: this.fileId,
+				filePath: this.relativePath,
+				clientId: this.$ydoc.clientID,
+				pendingStructs: this.$ydoc.store.pendingStructs,
+				clientVectors: [],
+				documentState: this.$syncService.getDocumentState(),
+			}
+			for (const client of this.$ydoc.store.clients.values()) {
+				yjsData.clientVectors.push(client.at(-1).id)
+			}
+
+			return yjsData
 		},
 
 		outlineToggled(visible) {

--- a/src/editor.js
+++ b/src/editor.js
@@ -132,6 +132,18 @@ class TextEditorEmbed {
 		this.#getEditorComponent().$editor.commands.focus()
 	}
 
+	debugYjs() {
+		const yjsData = this.#getEditorComponent().debugYjsData()
+
+		const intro = 'Editor Yjs debug data. Copy the object below that starts with "clientId".'
+		const introChrome = '- In Chrome, select "Copy" at the end of the line.'
+		const introFirefox = '- In Firefox, right-click on the object and select "Copy object".'
+		const styleBold = 'font-weight: bold;'
+		const styleItalic = 'font-weight: normal; font-style: italic;'
+		console.warn(JSON.stringify(yjsData, null, ' '))
+		console.warn('%c%s\n%c%s\n%s', styleBold, intro, styleItalic, introChrome, introFirefox)
+	}
+
 	#registerDebug() {
 		if (window?._oc_debug) {
 			this.vm = this.#vm


### PR DESCRIPTION
Should make it easier to debug sync issues.

### Screenshot

Screenshot Firefox | Screenshot Chromium
--- | ---
![2024-11-06T12:32:38,426154186+01:00](https://github.com/user-attachments/assets/49a54658-f478-495c-beef-d826ec60627d) |![2024-11-06T12:38:10,598435570+01:00](https://github.com/user-attachments/assets/495195a8-773f-4452-b0fc-3868d0b08635)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits