### PR TITLE
test(cypress): More specific selector for viewer header in links test

### DIFF
--- a/cypress/e2e/nodes/Links.spec.js
+++ b/cypress/e2e/nodes/Links.spec.js
@@ -67,7 +67,9 @@ describe('test link marks', function() {
 				.find('.widget-default--name')
 				.contains('Nextcloud')
 
-			cy.get('[role="dialog"] h2.modal-header__name').click()
+			cy.get('[role="dialog"] h2.modal-header__name')
+				.contains(fileName)
+				.click()
 
 			cy.get('.link-view-bubble .widget-default')
 				.should('not.exist')


### PR DESCRIPTION
Fixes failing cypress test "link bubble -> closes the link bubble when clicking elsewhere".

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
