### PR TITLE
[stable30] fix(addContent): only process addExtensions once

### DIFF
--- a/src/mixins/setContent.js
+++ b/src/mixins/setContent.js
@@ -34,7 +34,7 @@ export default {
 			const editor = createEditor({
 				enableRichEditing: isRichEditor,
 			})
-			const json = generateJSON(html, editor.extensionManager.extensions)
+			const json = generateJSON(html, editor.options.extensions)
 
 			const doc = Node.fromJSON(editor.schema, json)
 			const getBaseDoc = (doc) => {


### PR DESCRIPTION
Backport #6602.

Use `editor.options.extensions`.
This only includes the extensions that were configured
when instantiating the editor.
It does not include the extensions these extensions added.

`generateJSON` will process the provided extensions
and add extensions according to their `addExtensions` field.

Before we used `editor.editorManager.extensions`
which includes all extensions used in the editor
including those added by other extensions.
This lead to `generateJSON` adding the same extensions again
which resulted in a warning.
