### PR TITLE
fix(files): set focus on image description right after inserting

### DIFF
--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -262,6 +262,9 @@ export default {
 		},
 		onLoaded() {
 			this.loaded = true
+			this.$nextTick(() => {
+				this.$refs.altInput?.focus()
+			})
 		},
 		async updateEmbeddedImageList() {
 			this.embeddedImageList = []


### PR DESCRIPTION
### 📝 Summary

Set focus on image description right after inserting

* Part of: https://github.com/nextcloud/text/issues/6152
After inserting an attachment, focus should go after the the image -> to the image description

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-11-06 17-59-44](https://github.com/user-attachments/assets/f5ba5f4b-4e0a-4697-8a17-15749ac59fab) | ![Screenshot from 2024-11-06 17-59-54](https://github.com/user-attachments/assets/c13e0029-2e3a-4b78-b8c6-0db19483ff6a)

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
