### PR TITLE
fix(files): Reduce spacing between image and description a bit

### DIFF
--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -43,7 +43,7 @@
 								</NcButton>
 							</div>
 						</div>
-						<div v-else contenteditable="false">
+						<div v-else class="media" contenteditable="false">
 							<img v-show="loaded"
 								:src="imageUrl"
 								:alt="alt"
@@ -407,6 +407,8 @@ export default {
 	display: flex;
 	align-items: center;
 	justify-content: left;
+	padding-bottom: 0;
+
 	.media__wrapper {
 		display: flex;
 		border: 2px solid var(--color-border);


### PR DESCRIPTION
### 📝 Summary

* Resolves part of https://github.com/nextcloud/text/issues/6152
Reduce spacing between image and description a bit

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-11-07 11-40-49](https://github.com/user-attachments/assets/dee4af56-8198-42dd-a320-cd65aec9bbd3) |![Screenshot from 2024-11-07 11-38-32](https://github.com/user-attachments/assets/84f3e808-836d-4a50-8627-4a99f7f985b3)

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
