### PR TITLE
fix(files): Align vertically bottons in code block

### DIFF
--- a/src/nodes/CodeBlockView.vue
+++ b/src/nodes/CodeBlockView.vue
@@ -239,7 +239,7 @@ export default {
 	align-items: stretch;
 	position: absolute;
 	right: 12px;
-	margin-top: 4px;
+	margin-top: 9px;
 }
 
 .split-view {


### PR DESCRIPTION
### 📝 Summary

* Part of https://github.com/nextcloud/text/issues/6152
Code block should have reduced minimum height to align with the buttons

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-11-07 13-33-13](https://github.com/user-attachments/assets/97a754be-11e6-4c82-bae1-f1d0ad3a8b56) | ![Screenshot from 2024-11-08 10-58-09](https://github.com/user-attachments/assets/2c86a48a-38e8-4aaa-a043-6507af4824b3)


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
