### PR TITLE
feat(editor): add "Open in new tab" option for link previews

### DIFF
--- a/src/components/Editor/PreviewOptions.vue
+++ b/src/components/Editor/PreviewOptions.vue
@@ -27,6 +27,14 @@
 				{{ t('text', 'Show link preview') }}
 			</NcActionRadio>
 			<NcActionSeparator />
+			<NcActionButton v-if="href"
+				close-after-click
+				@click="openLink">
+				<template #icon>
+					<OpenIcon :size="20" />
+				</template>
+				{{ t('text','Open in new tab') }}
+			</NcActionButton>
 			<NcActionButton close-after-click @click="deleteNode">
 				<template #icon>
 					<DeleteIcon :size="20" />
@@ -41,6 +49,7 @@
 import { NcActions, NcActionButton, NcActionRadio, NcActionCaption, NcActionSeparator } from '@nextcloud/vue'
 import DotsVerticalIcon from 'vue-material-design-icons/DotsVertical.vue'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import OpenIcon from 'vue-material-design-icons/OpenInNew.vue'
 
 export default {
 	name: 'PreviewOptions',
@@ -53,12 +62,18 @@ export default {
 		NcActionRadio,
 		NcActionSeparator,
 		DeleteIcon,
+		OpenIcon,
 	},
 
 	props: {
 		type: {
 			type: String,
 			required: true,
+		},
+		href: {
+			type: String,
+			required: false,
+			default: '',
 		},
 	},
 
@@ -78,6 +93,10 @@ export default {
 		},
 		deleteNode() {
 			this.$emit('delete')
+		},
+		openLink() {
+			if (!this.href) return
+			window.open(this.href, '_blank').focus()
 		},
 	},
 }

--- a/src/plugins/extractLinkParagraphs.js
+++ b/src/plugins/extractLinkParagraphs.js
@@ -20,16 +20,17 @@ export default function extractLinkParagraphs(doc) {
 				pos,
 				nodeSize: node.nodeSize,
 				type: 'text-only',
+				href: extractHref(node.firstChild),
 			}))
 		} else if (node.type.name === 'preview') {
 			paragraphs.push(Object.freeze({
 				pos,
 				nodeSize: node.nodeSize,
 				type: 'link-preview',
+				href: node.attrs.href,
 			}))
 		}
 	})
-
 	return paragraphs
 }
 

--- a/src/tests/plugins/extractLinkParagraphs.spec.js
+++ b/src/tests/plugins/extractLinkParagraphs.spec.js
@@ -9,8 +9,9 @@ import Preview from '../../nodes/Preview.js'
 import createCustomEditor from '../testHelpers/createCustomEditor.ts'
 
 describe('extractLinkParagraphs', () => {
-	const link = '<a href="https://nextcloud.com">Link</a>'
-	const preview = '<a href="https://nextcloud.com" title="preview">Link</a>'
+	const href = 'https://nextcloud.com'
+	const link = `<a href="${href}">Link</a>`
+	const preview = `<a href="${href}" title="preview">Link</a>`
 
 	it('returns an empty array for an empty doc', () => {
 		const doc = prepareDoc('')
@@ -23,7 +24,7 @@ describe('extractLinkParagraphs', () => {
 		const doc = prepareDoc(content)
 		const paragraphs = extractLinkParagraphs(doc)
 		expect(paragraphs).toEqual([
-			{ pos: 0, type: 'text-only', nodeSize: 6 },
+			{ href, pos: 0, type: 'text-only', nodeSize: 6 },
 		])
 	})
 
@@ -31,7 +32,7 @@ describe('extractLinkParagraphs', () => {
 		const doc = prepareDoc(preview)
 		const paragraphs = extractLinkParagraphs(doc)
 		expect(paragraphs).toEqual([
-			{ pos: 0, type: 'link-preview', nodeSize: 6 },
+			{ href, pos: 0, type: 'link-preview', nodeSize: 6 },
 		])
 	})
 
@@ -40,7 +41,7 @@ describe('extractLinkParagraphs', () => {
 		const doc = prepareDoc(content)
 		const paragraphs = extractLinkParagraphs(doc)
 		expect(paragraphs).toEqual([
-			{ pos: 0, type: 'text-only', nodeSize: 7 },
+			{ href, pos: 0, type: 'text-only', nodeSize: 7 },
 		])
 	})
 
@@ -50,8 +51,8 @@ describe('extractLinkParagraphs', () => {
 		const doc = prepareDoc(content)
 		const paragraphs = extractLinkParagraphs(doc)
 		expect(paragraphs).toEqual([
-			{ pos: 0, type: 'text-only', nodeSize: 6 },
-			{ pos: 6, type: 'text-only', nodeSize: 6 },
+			{ href, pos: 0, type: 'text-only', nodeSize: 6 },
+			{ href, pos: 6, type: 'text-only', nodeSize: 6 },
 		])
 	})
 
@@ -59,9 +60,10 @@ describe('extractLinkParagraphs', () => {
 		const content = `<p>${link}</p>${preview}`
 		const doc = prepareDoc(content)
 		const paragraphs = extractLinkParagraphs(doc)
+
 		expect(paragraphs).toEqual([
-			{ pos: 0, type: 'text-only', nodeSize: 6 },
-			{ pos: 6, type: 'link-preview', nodeSize: 6 },
+			{ href, pos: 0, type: 'text-only', nodeSize: 6 },
+			{ href, pos: 6, type: 'link-preview', nodeSize: 6 },
 		])
 	})
 


### PR DESCRIPTION
This update aims to improve accessibility to files added as previews in the text editor.

### 📝 Summary

- Enhanced `PreviewOptions.vue` to include a new "Open in new tab" button for link previews.
  - Introduced the `openLink` method to open the link in a new browser tab.
  - Added `OpenIcon` for the button to improve UI consistency.
  - New `href` prop added to handle link URLs dynamically.

- Updated `extractLinkParagraphs.js` to extract `href` attributes from nodes.
  - Ensures link previews include the necessary `href` for the "Open in new tab" action.

#### 🖼️ Screenshots

![text-open-option-link-preview](https://github.com/user-attachments/assets/3c69c77d-7151-4d5a-a283-9a80e1cf2ced)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
