### PR TITLE
fix: log ignored workspace propfind exceptions at debug

### DIFF
--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -99,8 +99,11 @@ class WorkspacePlugin extends ServerPlugin {
 				try {
 					$cachedContent = $file->getContent();
 					$cache->set($cacheKey, $cachedContent, 3600);
-				} catch (GenericFileException|NotPermittedException|LockedException) {
-					// Ignore
+				} catch (GenericFileException|NotPermittedException|LockedException $e) {
+					// Ignore but log when debugging
+					$this->logger->debug($e->getMessage(), [
+						'exception' => $e,
+					]);
 				} catch (Exception $e) {
 					$this->logger->error($e->getMessage(), [
 						'exception' => $e,


### PR DESCRIPTION
### 📝 Summary

In case needed to troubleshoot situations involving permissions, locking, etc. Addresses post-merger review comments:

https://github.com/nextcloud/text/pull/5948#discussion_r1699575302

https://github.com/nextcloud/text/pull/6155#discussion_r1699576172

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
