### PR TITLE
feat(attachments): add support for creating new attachments

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -18,6 +18,8 @@ return [
 		['name' => 'Attachment#insertAttachmentFile', 'url' => '/attachment/filepath', 'verb' => 'POST'],
 		/** @see Controller\AttachmentController::uploadAttachment() */
 		['name' => 'Attachment#uploadAttachment', 'url' => '/attachment/upload', 'verb' => 'POST'],
+		/** @see Controller\AttachmentController::createAttachment() */
+		['name' => 'Attachment#createAttachment', 'url' => '/attachment/create', 'verb' => 'POST'],
 		/** @see Controller\AttachmentController::getImageFile() */
 		['name' => 'Attachment#getImageFile', 'url' => '/image', 'verb' => 'GET'],
 		/** @see Controller\AttachmentController::getMediaFile() */

--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -12,6 +12,7 @@ const attachmentFileNameToId = {}
 
 const ACTION_UPLOAD_LOCAL_FILE = 'insert-attachment-upload'
 const ACTION_INSERT_FROM_FILES = 'insert-attachment-insert'
+const ACTION_CREATE_NEW_TEXT_FILE = 'insert-attachment-add-text-0'
 
 /**
  * @param {string} name name of file
@@ -277,6 +278,19 @@ describe('Test all attachment insertion methods', () => {
 		cy.getEditor().find('[data-component="image-view"]')
 			.should('have.length', 3)
 		cy.closeFile()
+	})
+
+	it('Create a new text file as an attachment', () => {
+		cy.visit('/apps/files')
+		cy.openFile('test.md')
+
+		cy.log('Create a new text file as an attachment')
+		const requestAlias = 'create-attachment-request'
+		cy.intercept({ method: 'POST', url: '**/text/attachment/create' }).as(requestAlias)
+		clickOnAttachmentAction(ACTION_CREATE_NEW_TEXT_FILE)
+			.then(() => {
+				return waitForRequestAndCheckAttachment(requestAlias, undefined, false)
+			})
 	})
 
 	it('test if attachment files are in the attachment folder', () => {

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -332,6 +332,35 @@ class AttachmentService {
 	}
 
 	/**
+	 * create a new file in the attachment folder
+	 *
+	 * @param int $documentId
+	 * @param string $userId
+	 *
+	 * @return array
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 * @throws InvalidPathException
+	 * @throws NoUserException
+	 */
+	public function createAttachmentFile(int $documentId, string $newFileName, string $userId): array {
+		$textFile = $this->getTextFile($documentId, $userId);
+		if (!$textFile->isUpdateable()) {
+			throw new NotPermittedException('No write permissions');
+		}
+		$saveDir = $this->getAttachmentDirectoryForFile($textFile, true);
+		$fileName = self::getUniqueFileName($saveDir, $newFileName);
+		$newFile = $saveDir->newFile($fileName);
+		return [
+			'name' => $fileName,
+			'dirname' => $saveDir->getName(),
+			'id' => $newFile->getId(),
+			'documentId' => $newFile->getId(),
+			'mimetype' => $newFile->getMimetype(),
+		];
+	}
+
+	/**
 	 * @param File $originalFile
 	 * @param Folder $saveDir
 	 * @param File $textFile

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -352,10 +352,10 @@ class AttachmentService {
 		$fileName = self::getUniqueFileName($saveDir, $newFileName);
 		$newFile = $saveDir->newFile($fileName);
 		return [
-			'name' => $fileName,
+			'name' => $newFile->getName(),
 			'dirname' => $saveDir->getName(),
 			'id' => $newFile->getId(),
-			'documentId' => $newFile->getId(),
+			'documentId' => $textFile->getId(),
 			'mimetype' => $newFile->getMimetype(),
 		];
 	}
@@ -581,16 +581,17 @@ class AttachmentService {
 					// this only happens if the attachment dir was deleted by the user while editing the document
 					return 0;
 				}
-				$attachmentsByName = [];
-				foreach ($attachmentDir->getDirectoryListing() as $attNode) {
-					$attachmentsByName[$attNode->getName()] = $attNode;
-				}
-
+				$contentAttachmentFileIds = self::getAttachmentIdsFromContent($textFile->getContent());
 				$contentAttachmentNames = self::getAttachmentNamesFromContent($textFile->getContent(), $fileId);
 
-				$toDelete = array_diff(array_keys($attachmentsByName), $contentAttachmentNames);
-				foreach ($toDelete as $name) {
-					$attachmentsByName[$name]->delete();
+				$toDelete = array_filter($attachmentDir->getDirectoryListing(),
+					function ($node) use ($contentAttachmentFileIds, $contentAttachmentNames) {
+						return !in_array($node->getName(), $contentAttachmentNames) &&
+							!in_array($node->getId(), $contentAttachmentFileIds);
+					}
+				);
+				foreach ($toDelete as $node) {
+					$node->delete();
 				}
 				return count($toDelete);
 			}
@@ -598,6 +599,26 @@ class AttachmentService {
 		return 0;
 	}
 
+	/**
+	 * Get attachment file ids listed in the markdown file content
+	 *
+	 * @param string $content
+	 *
+	 * @return array
+	 */
+	public static function getAttachmentIdsFromContent(string $content): array {
+		$matches = [];
+		// matches [ANY_CONSIDERED_CORRECT_BY_PHP-MARKDOWN](ANY_URL/f/FILE_ID[ (preview)]) and captures FILE_ID
+		preg_match_all(
+			'/\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[\])*\])*\])*\])*\])*\])*\]\(\S+\/f\/(\d+)(?: \(preview\))?\)/',
+			$content,
+			$matches,
+			PREG_SET_ORDER
+		);
+		return array_map(static function (array $match) {
+			return intval($match[1]);
+		}, $matches);
+	}
 
 	/**
 	 * Get attachment file names listed in the markdown file content

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -608,9 +608,9 @@ class AttachmentService {
 	 */
 	public static function getAttachmentIdsFromContent(string $content): array {
 		$matches = [];
-		// matches [ANY_CONSIDERED_CORRECT_BY_PHP-MARKDOWN](ANY_URL/f/FILE_ID[ (preview)]) and captures FILE_ID
+		// matches [ANY_CONSIDERED_CORRECT_BY_PHP-MARKDOWN](ANY_URL/f/FILE_ID and captures FILE_ID
 		preg_match_all(
-			'/\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[\])*\])*\])*\])*\])*\])*\]\(\S+\/f\/(\d+)(?: \(preview\))?\)/',
+			'/\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[(?>[^\[\]]+|\[\])*\])*\])*\])*\])*\])*\]\(\S+\/f\/(\d+)/',
 			$content,
 			$matches,
 			PREG_SET_ORDER

--- a/src/components/Editor/MediaHandler.provider.js
+++ b/src/components/Editor/MediaHandler.provider.js
@@ -6,6 +6,7 @@
 export const STATE_UPLOADING = Symbol('state:uploading-state')
 export const ACTION_ATTACHMENT_PROMPT = Symbol('editor:action:attachment-prompt')
 export const ACTION_CHOOSE_LOCAL_ATTACHMENT = Symbol('editor:action:upload-attachment')
+export const ACTION_CREATE_ATTACHMENT = Symbol('editor:action:create-attachment')
 
 export const useUploadingStateMixin = {
 	inject: {
@@ -27,5 +28,11 @@ export const useActionAttachmentPromptMixin = {
 export const useActionChooseLocalAttachmentMixin = {
 	inject: {
 		$callChooseLocalAttachment: { from: ACTION_CHOOSE_LOCAL_ATTACHMENT, default: () => {} },
+	},
+}
+
+export const useActionCreateAttachmentMixin = {
+	inject: {
+		$callCreateAttachment: { from: ACTION_CREATE_ATTACHMENT, default: () => (template) => {} },
 	},
 }

--- a/src/components/Menu/ActionAttachmentUpload.vue
+++ b/src/components/Menu/ActionAttachmentUpload.vue
@@ -34,12 +34,25 @@
 			</template>
 			{{ t('text', 'Insert from Files') }}
 		</NcActionButton>
+		<NcActionButton v-for="(template, index) in templates"
+			:key="`${template.app}-${index}`"
+			close-after-click
+			:disabled="isUploadingAttachments"
+			:data-text-action-entry="`${actionEntry.key}-add-${template.app}-${index}`"
+			@click="createAttachment(template)">
+			<template #icon>
+				<NcIconSvgWrapper v-if="template.iconSvgInline" :svg="template.iconSvgInline" />
+				<Plus v-else />
+			</template>
+			{{ template.actionLabel }}
+		</NcActionButton>
 	</NcActions>
 </template>
 
 <script>
-import { NcActions, NcActionButton } from '@nextcloud/vue'
-import { Loading, Folder, Upload } from '../icons.js'
+import { NcActions, NcActionButton, NcIconSvgWrapper } from '@nextcloud/vue'
+import { loadState } from '@nextcloud/initial-state'
+import { Loading, Folder, Upload, Plus } from '../icons.js'
 import { useIsPublicMixin, useEditorUpload } from '../Editor.provider.js'
 import { BaseActionEntry } from './BaseActionEntry.js'
 import { useMenuIDMixin } from './MenuBar.provider.js'
@@ -47,6 +60,7 @@ import {
 	useActionAttachmentPromptMixin,
 	useUploadingStateMixin,
 	useActionChooseLocalAttachmentMixin,
+	useActionCreateAttachmentMixin,
 } from '../Editor/MediaHandler.provider.js'
 
 export default {
@@ -54,9 +68,11 @@ export default {
 	components: {
 		NcActions,
 		NcActionButton,
+		NcIconSvgWrapper,
 		Loading,
 		Folder,
 		Upload,
+		Plus,
 	},
 	extends: BaseActionEntry,
 	mixins: [
@@ -65,6 +81,7 @@ export default {
 		useActionAttachmentPromptMixin,
 		useUploadingStateMixin,
 		useActionChooseLocalAttachmentMixin,
+		useActionCreateAttachmentMixin,
 		useMenuIDMixin,
 	],
 	computed: {
@@ -75,6 +92,14 @@ export default {
 		},
 		isUploadingAttachments() {
 			return this.$uploadingState.isUploadingAttachments
+		},
+		templates() {
+			return loadState('files', 'templates', [])
+		},
+	},
+	methods: {
+		createAttachment(template) {
+			this.$callCreateAttachment(template)
 		},
 	},
 }

--- a/src/components/Menu/ActionAttachmentUpload.vue
+++ b/src/components/Menu/ActionAttachmentUpload.vue
@@ -34,23 +34,26 @@
 			</template>
 			{{ t('text', 'Insert from Files') }}
 		</NcActionButton>
-		<NcActionButton v-for="(template, index) in templates"
-			:key="`${template.app}-${index}`"
-			close-after-click
-			:disabled="isUploadingAttachments"
-			:data-text-action-entry="`${actionEntry.key}-add-${template.app}-${index}`"
-			@click="createAttachment(template)">
-			<template #icon>
-				<NcIconSvgWrapper v-if="template.iconSvgInline" :svg="template.iconSvgInline" />
-				<Plus v-else />
-			</template>
-			{{ template.actionLabel }}
-		</NcActionButton>
+		<template v-if="templates.length">
+			<NcActionSeparator />
+			<NcActionButton v-for="(template, index) in templates"
+				:key="`${template.app}-${index}`"
+				close-after-click
+				:disabled="isUploadingAttachments"
+				:data-text-action-entry="`${actionEntry.key}-add-${template.app}-${index}`"
+				@click="createAttachment(template)">
+				<template #icon>
+					<NcIconSvgWrapper v-if="template.iconSvgInline" :svg="template.iconSvgInline" />
+					<Plus v-else />
+				</template>
+				{{ template.actionLabel }}
+			</NcActionButton>
+		</template>
 	</NcActions>
 </template>
 
 <script>
-import { NcActions, NcActionButton, NcIconSvgWrapper } from '@nextcloud/vue'
+import { NcActions, NcActionSeparator, NcActionButton, NcIconSvgWrapper } from '@nextcloud/vue'
 import { loadState } from '@nextcloud/initial-state'
 import { Loading, Folder, Upload, Plus } from '../icons.js'
 import { useIsPublicMixin, useEditorUpload } from '../Editor.provider.js'
@@ -67,6 +70,7 @@ export default {
 	name: 'ActionAttachmentUpload',
 	components: {
 		NcActions,
+		NcActionSeparator,
 		NcActionButton,
 		NcIconSvgWrapper,
 		Loading,

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -64,6 +64,7 @@ import MDI_Upload from 'vue-material-design-icons/Upload.vue'
 import MDI_Warn from 'vue-material-design-icons/Alert.vue'
 import MDI_Web from 'vue-material-design-icons/Web.vue'
 import MDI_TranslateVariant from 'vue-material-design-icons/TranslateVariant.vue'
+import MDI_Plus from 'vue-material-design-icons/Plus.vue'
 
 const DEFAULT_ICON_SIZE = 20
 
@@ -148,3 +149,4 @@ export const UnfoldMoreHorizontal = makeIcon(MDI_UnfoldMoreHorizontal)
 export const Upload = makeIcon(MDI_Upload)
 export const Warn = makeIcon(MDI_Warn)
 export const Web = makeIcon(MDI_Web)
+export const Plus = makeIcon(MDI_Plus)

--- a/src/services/SessionApi.js
+++ b/src/services/SessionApi.js
@@ -168,6 +168,15 @@ export class Connection {
 		})
 	}
 
+	createAttachment(template) {
+		return this.#post(_endpointUrl('attachment/create'), {
+			documentId: this.#document.id,
+			sessionId: this.#session.id,
+			sessionToken: this.#session.token,
+			fileName: `${template.app}${template.extension}`,
+		})
+	}
+
 	insertAttachmentFile(filePath) {
 		return this.#post(_endpointUrl('attachment/filepath'), {
 			documentId: this.#document.id,

--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -351,6 +351,10 @@ class SyncService {
 		return this.#connection.insertAttachmentFile(filePath)
 	}
 
+	createAttachment(template) {
+		return this.#connection.createAttachment(template)
+	}
+
 	on(event, callback) {
 		this._bus.on(event, callback)
 		return this

--- a/tests/unit/Service/AttachmentServiceTest.php
+++ b/tests/unit/Service/AttachmentServiceTest.php
@@ -42,6 +42,33 @@ class AttachmentServiceTest extends \PHPUnit\Framework\TestCase {
 		}
 	}
 
+	public function testGetAttachmentIdsFromContent() {
+		$urls = [
+			'www.example.com',
+			'http://example.com',
+			'https://www.example.com/path/to/page',
+			'http://sub.domain.co.uk/index.php',
+			'https://1.2.3.4:8080/path',
+			'http://localhost:3000/',
+			'https://[2001:db8::1]/ipv6-check',
+		];
+
+		$id = 1;
+		$content = "some content\n";
+		foreach (self::$attachmentNames as $name) {
+			$linkText = preg_replace('/[[\]]/', '', $name);
+			foreach ($urls as $url) {
+				$addon = $id % 2 ? ' (preview)' : '';
+				$content .= "[{$linkText}]({$url}/f/{$id}{$addon})\n";
+				$id++;
+			}
+		}
+		$content .= 'some content';
+
+		$computedIds = AttachmentService::getAttachmentIdsFromContent($content);
+		$this->assertEquals(range(1, $id - 1), $computedIds);
+	}
+
 	public function testGetUniqueFileName() {
 		$fileNameList = [
 			'foo.png',


### PR DESCRIPTION
These changes enable users to create and insert new attachment files directly from within the editor.

### 📝 Summary

- Introduced a new endpoint (`Attachment#createAttachment`) to create attachment files via POST requests.
- Added `createAttachment` method in `AttachmentService` to handle file creation logic with permission checks.
- Updated `MediaHandler.vue` and `MediaHandler.provider.js` to integrate the new attachment creation functionality in the editor.
- Enhanced `ActionAttachmentUpload.vue` to support dynamic attachment creation from file app templates.
- Extended `SessionApi.js` with a `createAttachment` method to interface with the new API endpoint.

#### 🖼️ Screenshots

![text-create-attachment](https://github.com/user-attachments/assets/795e054f-99c7-4320-a45c-a2de95f2db9f)

### :ballot_box_with_check: Todo

* [x] The [attachment cleanup](https://github.com/nextcloud/text/blob/main/lib/Service/AttachmentService.php#L544) does not wipe the files because it thinks the attachments were removed from the text content.
* [x] Tests ensure we don't accidentally break creating new files as attachments.
* [x] Check with design if it makes sense to visually separate the attachments section and the embedding new content section.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
