### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4677,9 +4677,9 @@
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.9.1.tgz",
-      "integrity": "sha512-DWUF6NG08/bZDWw0jCeotSTvpkyqZTi4meJPomG9Wzs/Ol7mEwlNCsCViD999g0+IjyXFatBk4DfUq1YDDu++Q==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.10.2.tgz",
+      "integrity": "sha512-KAh2bvYcixJ3RFv2P05kPNLAJ4uW6BDj1AfEMn0YguBWWTgZg8Kot1AzBRgTjBBFCInQS6b49db1ff4M07DGsg==",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
@@ -4821,9 +4821,9 @@
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.9.1.tgz",
-      "integrity": "sha512-MxZ7acNNsoNaKpetxfwi3Z11Bgrh0T2EJlCV77v9N1vWK38+st3H1WJanmLbPNtc2ocvhHJrz+DjDz3CWxQ9rQ==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.10.2.tgz",
+      "integrity": "sha512-s/KfW5YQY13BwhSQRlgomYmHuBT0k6FBxn8mgJLHcA9sTqgy/BriOhmNkMrredNzd4UOd5JVpcT6b+eckG4nkQ==",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
@@ -5180,14 +5180,14 @@
       }
     },
     "node_modules/@tiptap/vue-2": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/vue-2/-/vue-2-2.9.1.tgz",
-      "integrity": "sha512-nHnBxFFkswTzyamXGd96tAwpPJgLfMIQn84kCfjH+rKq8rnd/5BDaN6qdqh78yR743OXBBFdHekS7x1yMLDO0w==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-2/-/vue-2-2.10.2.tgz",
+      "integrity": "sha512-38HYQ7wEKwWfAiOJiKD89yRM3W+qQ20RfTd6hPq+TS2k9IV4GRw7KilqdWa/JAIk+Cn+dpilB4joUUIiMjSEng==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.9.1",
-        "@tiptap/extension-floating-menu": "^2.9.1",
-        "vue-ts-types": "^1.6.0"
+        "@tiptap/extension-bubble-menu": "^2.10.2",
+        "@tiptap/extension-floating-menu": "^2.10.2",
+        "vue-ts-types": "1.6.2"
       },
       "funding": {
         "type": "github",
@@ -25392,9 +25392,10 @@
       }
     },
     "node_modules/vue-ts-types": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vue-ts-types/-/vue-ts-types-1.6.0.tgz",
-      "integrity": "sha512-8sOvLp0ZiZOD/t899GqsMd6gHM8mMKMtqNXilsrnpvHGZoD9ZgwksJ+eL5zHmjQ7xeCPPvIwhAqYrG/daHyZGA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vue-ts-types/-/vue-ts-types-1.6.2.tgz",
+      "integrity": "sha512-iOBe4oMoTeISs+Wxlt5E6q3W6lEX6UtkwWCPu6727IoweBE3O3Vp/2/BtO+Kf5pISQU7WpX71hXTeMGqHsmecA==",
+      "license": "MIT",
       "peerDependencies": {
         "vue": "^2.6 || ^3.2"
       }
@@ -29254,9 +29255,9 @@
       "requires": {}
     },
     "@tiptap/extension-bubble-menu": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.9.1.tgz",
-      "integrity": "sha512-DWUF6NG08/bZDWw0jCeotSTvpkyqZTi4meJPomG9Wzs/Ol7mEwlNCsCViD999g0+IjyXFatBk4DfUq1YDDu++Q==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.10.2.tgz",
+      "integrity": "sha512-KAh2bvYcixJ3RFv2P05kPNLAJ4uW6BDj1AfEMn0YguBWWTgZg8Kot1AzBRgTjBBFCInQS6b49db1ff4M07DGsg==",
       "requires": {
         "tippy.js": "^6.3.7"
       }
@@ -29316,9 +29317,9 @@
       "requires": {}
     },
     "@tiptap/extension-floating-menu": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.9.1.tgz",
-      "integrity": "sha512-MxZ7acNNsoNaKpetxfwi3Z11Bgrh0T2EJlCV77v9N1vWK38+st3H1WJanmLbPNtc2ocvhHJrz+DjDz3CWxQ9rQ==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.10.2.tgz",
+      "integrity": "sha512-s/KfW5YQY13BwhSQRlgomYmHuBT0k6FBxn8mgJLHcA9sTqgy/BriOhmNkMrredNzd4UOd5JVpcT6b+eckG4nkQ==",
       "requires": {
         "tippy.js": "^6.3.7"
       }
@@ -29489,13 +29490,13 @@
       "requires": {}
     },
     "@tiptap/vue-2": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/vue-2/-/vue-2-2.9.1.tgz",
-      "integrity": "sha512-nHnBxFFkswTzyamXGd96tAwpPJgLfMIQn84kCfjH+rKq8rnd/5BDaN6qdqh78yR743OXBBFdHekS7x1yMLDO0w==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-2/-/vue-2-2.10.2.tgz",
+      "integrity": "sha512-38HYQ7wEKwWfAiOJiKD89yRM3W+qQ20RfTd6hPq+TS2k9IV4GRw7KilqdWa/JAIk+Cn+dpilB4joUUIiMjSEng==",
       "requires": {
-        "@tiptap/extension-bubble-menu": "^2.9.1",
-        "@tiptap/extension-floating-menu": "^2.9.1",
-        "vue-ts-types": "^1.6.0"
+        "@tiptap/extension-bubble-menu": "^2.10.2",
+        "@tiptap/extension-floating-menu": "^2.10.2",
+        "vue-ts-types": "1.6.2"
       }
     },
     "@tootallnate/once": {
@@ -43441,9 +43442,9 @@
       }
     },
     "vue-ts-types": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vue-ts-types/-/vue-ts-types-1.6.0.tgz",
-      "integrity": "sha512-8sOvLp0ZiZOD/t899GqsMd6gHM8mMKMtqNXilsrnpvHGZoD9ZgwksJ+eL5zHmjQ7xeCPPvIwhAqYrG/daHyZGA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vue-ts-types/-/vue-ts-types-1.6.2.tgz",
+      "integrity": "sha512-iOBe4oMoTeISs+Wxlt5E6q3W6lEX6UtkwWCPu6727IoweBE3O3Vp/2/BtO+Kf5pISQU7WpX71hXTeMGqHsmecA==",
       "requires": {}
     },
     "vue-tsc": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 12 of the total 22 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/moment](#user-content-\@nextcloud\/moment)
* [@nextcloud/vite-config](#user-content-\@nextcloud\/vite-config)
* [@vitejs/plugin-vue2](#user-content-\@vitejs\/plugin-vue2)
* [@vue/language-core](#user-content-\@vue\/language-core)
* [@vue/test-utils](#user-content-\@vue\/test-utils)
* [vite-plugin-dts](#user-content-vite-plugin-dts)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [vue-tsc](#user-content-vue-tsc)
* [vuex](#user-content-vuex)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/moment <a href="#user-content-\@nextcloud\/moment" id="\@nextcloud\/moment">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.1
* Package usage:
  * `node_modules/@nextcloud/moment`

### @nextcloud/vite-config <a href="#user-content-\@nextcloud\/vite-config" id="\@nextcloud\/vite-config">#</a>
* Caused by vulnerable dependency:
  * [@vitejs/plugin-vue2](#user-content-\@vitejs\/plugin-vue2)
  * [vite-plugin-dts](#user-content-vite-plugin-dts)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/vite-config`

### @vitejs/plugin-vue2 <a href="#user-content-\@vitejs\/plugin-vue2" id="\@vitejs\/plugin-vue2">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@vitejs/plugin-vue2`

### @vue/language-core <a href="#user-content-\@vue\/language-core" id="\@vue\/language-core">#</a>
* Caused by vulnerable dependency:
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=2.0.28
* Package usage:
  * `node_modules/@vue/language-core`

### @vue/test-utils <a href="#user-content-\@vue\/test-utils" id="\@vue\/test-utils">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=1.3.6
* Package usage:
  * `node_modules/@vue/test-utils`

### vite-plugin-dts <a href="#user-content-vite-plugin-dts" id="vite-plugin-dts">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
  * [vue-tsc](#user-content-vue-tsc)
* Affected versions: 3.0.0-beta.1 - 4.0.0-beta.2
* Package usage:
  * `node_modules/vite-plugin-dts`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### vue-tsc <a href="#user-content-vue-tsc" id="vue-tsc">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
* Affected versions: 1.7.0-alpha.0 - 2.0.28
* Package usage:
  * `node_modules/vue-tsc`

### vuex <a href="#user-content-vuex" id="vuex">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 3.1.3 - 3.6.2
* Package usage:
  * `node_modules/vuex`