### PR TITLE
fix: catch all errors when getting rich workspace file

### DIFF
--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -17,7 +17,6 @@ use OCA\Text\Service\WorkspaceService;
 use OCP\Files\GenericFileException;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotPermittedException;
-use OCP\Files\StorageNotAvailableException;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\Lock\LockedException;
@@ -82,7 +81,7 @@ class WorkspacePlugin extends ServerPlugin {
 		$node = $node->getNode();
 		try {
 			$file = $this->workspaceService->getFile($node);
-		} catch (StorageNotAvailableException $e) {
+		} catch (\Exception $e) {
 			$file = null;
 		}
 


### PR DESCRIPTION
A belated companion to https://github.com/nextcloud/text/pull/6243

Storage failures don't always throw the right exception [:see_no_evil:](https://github.com/nextcloud/server/pull/49494) better to 