### PR TITLE
fix(editor): Also unset `draggedOver` at drop

### DIFF
--- a/src/components/Editor/MediaHandler.vue
+++ b/src/components/Editor/MediaHandler.vue
@@ -10,6 +10,7 @@
 		@image-paste="onPaste"
 		@dragover.prevent.stop="setDraggedOver(true)"
 		@dragleave.prevent.stop="setDraggedOver(false)"
+		@drop.prevent.stop="setDraggedOver(false)"
 		@file-drop="onEditorDrop">
 		<input v-show="false"
 			ref="attachmentFileInput"
@@ -86,7 +87,6 @@ export default {
 		},
 		onEditorDrop(e) {
 			this.uploadAttachmentFiles(e.detail.files, e.detail.position)
-			this.draggedOver = false
 		},
 		onAttachmentUploadFilePicked(event) {
 			this.uploadAttachmentFiles(event.target.files)


### PR DESCRIPTION
Fixes the background staying at light blue when dragging and dropping text in the editor.

Fixes: #6724

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
