### PR TITLE
fix(cy): avoid double upload to prevent lock error

### DIFF
--- a/cypress/e2e/conflict.spec.js
+++ b/cypress/e2e/conflict.spec.js
@@ -1,7 +1,7 @@
 /**
- * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
+ * @copyright Copyright (c) 2022 Nextcloud GmbH and Nextcloud contributors
  *
- * @author John Molakvoæ <skjnldsv@protonmail.com>
+ * @author Max <max@nextcloud.com>
  *
  * @license AGPL-3.0-or-later
  *
@@ -20,9 +20,7 @@
  *
  */
 
-import { initUserAndFiles, randUser } from '../utils/index.js'
-
-const user = randUser()
+import { randUser } from '../utils/index.js'
 
 const variants = [
 	{ fixture: 'lines.txt', mime: 'text/plain' },
@@ -30,18 +28,19 @@ const variants = [
 ]
 
 variants.forEach(function({ fixture, mime }) {
+	const user = randUser()
 	const fileName = fixture
 	const prefix = mime.replaceAll('/', '-')
 	describe(`${mime} (${fileName})`, function() {
 		const getWrapper = () => cy.get('.text-editor__wrapper.has-conflicts')
 
 		before(() => {
-			initUserAndFiles(user)
+			cy.createUser(user)
 		})
 
 		beforeEach(function() {
 			cy.login(user)
-			cy.isolateTest({ sourceFile: fileName })
+			cy.createTestFolder()
 		})
 
 		it(prefix + ': no actual conflict - just reload', function() {
@@ -140,6 +139,10 @@ variants.forEach(function({ fixture, mime }) {
  * @param {string} mime - mimetype
  */
 function createConflict(fileName, mime) {
+	cy.testName().then(testName => {
+		cy.uploadFile(fileName, mime, `${testName}/${fileName}`)
+	})
+	cy.visitTestFolder()
 	cy.openFile(fileName)
 	cy.log('Inspect editor')
 	cy.getEditor().find('.ProseMirror').should('have.attr', 'contenteditable', 'true')


### PR DESCRIPTION
`isolateTest` in `beforeEach` already uploads the file.

Uploading it again in the `no actual conflict - just reload` case
sometimes led to 423 - Locked responses.

Use `cy.createTestDir()` instead and upload only once.

Signed-off-by: Max <max@nextcloud.com>
