### PR TITLE
chore: Remove stable28 from CI jobs as it's end of life

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable30', 'stable29', 'stable28']
+        branches: ['main', 'master', 'stable30', 'stable29']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable30', 'stable29', 'stable28']
+        branches: ['main', 'master', 'stable30', 'stable29']
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 

--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -11,7 +11,6 @@ on:
       - main
       - stable3*
       - stable29
-      - stable28
 
 concurrency:
   group: update-node-dist-${{ github.head_ref || github.ref || github.run_id }}

--- a/renovate.json
+++ b/renovate.json
@@ -20,8 +20,7 @@
   "baseBranches": [
     "main",
     "stable30",
-    "stable29",
-    "stable28"
+    "stable29"
   ],
   "enabledManagers": [
     "npm"
@@ -109,8 +108,9 @@
         "minor"
       ],
       "matchBaseBranches": [
-        "stable26",
-        "stable27"
+        "stable28",
+        "stable27",
+        "stable26"
       ],
       "enabled": false
     },


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
