### PR TITLE
chore: Bump composer files with new composer version

### DIFF
--- a/composer/composer/InstalledVersions.php
+++ b/composer/composer/InstalledVersions.php
@@ -322,6 +322,7 @@ class InstalledVersions
         }
 
         $installed = array();
+        $copiedLocalDir = false;
 
         if (self::$canGetVendors) {
             foreach (ClassLoader::getRegisteredLoaders() as $vendorDir => $loader) {
@@ -330,9 +331,11 @@ class InstalledVersions
                 } elseif (is_file($vendorDir.'/composer/installed.php')) {
                     /** @var array{root: array{name: string, pretty_version: string, version: string, reference: string|null, type: string, install_path: string, aliases: string[], dev: bool}, versions: array<string, array{pretty_version?: string, version?: string, reference?: string|null, type?: string, install_path?: string, aliases?: string[], dev_requirement: bool, replaced?: string[], provided?: string[]}>} $required */
                     $required = require $vendorDir.'/composer/installed.php';
-                    $installed[] = self::$installedByVendor[$vendorDir] = $required;
-                    if (null === self::$installed && strtr($vendorDir.'/composer', '\\', '/') === strtr(__DIR__, '\\', '/')) {
-                        self::$installed = $installed[count($installed) - 1];
+                    self::$installedByVendor[$vendorDir] = $required;
+                    $installed[] = $required;
+                    if (strtr($vendorDir.'/composer', '\\', '/') === strtr(__DIR__, '\\', '/')) {
+                        self::$installed = $required;
+                        $copiedLocalDir = true;
                     }
                 }
             }
@@ -350,7 +353,7 @@ class InstalledVersions
             }
         }
 
-        if (self::$installed !== array()) {
+        if (self::$installed !== array() && !$copiedLocalDir) {
             $installed[] = self::$installed;
         }
 

--- a/composer/composer/installed.php
+++ b/composer/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => '__root__',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '00b8b908ec601f3541533afb5f8addc06038423e',
+        'reference' => 'ee3d8b90a4886b0ca38bbc3f89b4808426726066',
         'type' => 'library',
         'install_path' => __DIR__ . '/../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         '__root__' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '00b8b908ec601f3541533afb5f8addc06038423e',
+            'reference' => 'ee3d8b90a4886b0ca38bbc3f89b4808426726066',
             'type' => 'library',
             'install_path' => __DIR__ . '/../',
             'aliases' => array(),


### PR DESCRIPTION
Make sure the autoloader check passes again on PRs with backend changes.

TO reproduce:

```
cd composer/
rm -r composer
composer install
composer dump