### PR TITLE
fix(ci): do not install cypress in jest workflow.

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -42,6 +42,8 @@ jobs:
         run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
       - name: Install dependencies
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: npm ci
 
       - name: Run jest


### PR DESCRIPTION
It is not required and attempting to install can cause failures
if the cypress server cannot be reached such as here:
https://github.com/nextcloud/text/actions/runs/12330192763/job/34415369232?pr=6780
