### PR TITLE
fix(link): Don't throw exception on invalid URL href

### DIFF
--- a/src/marks/Link.js
+++ b/src/marks/Link.js
@@ -60,10 +60,15 @@ const Link = TipTapLink.extend({
 
 	renderHTML(options) {
 		const { mark } = options
-		const url = new URL(mark.attrs.href, window.location)
-		const href = PROTOCOLS_TO_LINK_TO.includes(url.protocol)
-			? domHref(mark, this.options.relativePath)
-			: '#'
+		let href
+		try {
+			const url = new URL(mark.attrs.href, window.location)
+			href = PROTOCOLS_TO_LINK_TO.includes(url.protocol)
+				? domHref(mark, this.options.relativePath)
+				: '#'
+		} catch (error) {
+			href = '#'
+		}
 		return ['a', {
 			...mark.attrs,
 			href,


### PR DESCRIPTION
When pasting strings with invalid URLs, `new URL()` in `renderHTML()` of the Link extension threw an error, which made the paste parser choke.

We should catch this exception and handle it gracefully to not break HTML parsing completely with invalid URLs.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
