### PR TITLE
fix(files): switch action button to disabled state if results are empty

### DIFF
--- a/src/components/Assistant.vue
+++ b/src/components/Assistant.vue
@@ -34,7 +34,7 @@
 					{{ t('text', 'Translate') }}
 				</NcActionButton>
 				<NcActionSeparator />
-				<NcActionButton close-after-click @click="showTaskList=true">
+				<NcActionButton :disabled="tasks.length < 1" close-after-click @click="showTaskList=true">
 					<template #icon>
 						<CreationIcon :size="20" />
 					</template>


### PR DESCRIPTION
### 📝 Summary

* Resolves: part of https://github.com/nextcloud/text/issues/6152
Assistant bugs: Show assistant results does not have any results shown (emptycontent)

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-12-18 17-24-35](https://github.com/user-attachments/assets/63b95faf-8e2d-4d35-95e2-61877adcc0cd) |![Screenshot from 2024-12-18 17-23-52](https://github.com/user-attachments/assets/64af4f45-a1c6-42e7-9bd7-c6daf3ae0377)

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
