### PR TITLE
Use "tertiary no background" as type for the buttons in table's header

### DIFF
--- a/src/nodes/Table/TableHeaderView.vue
+++ b/src/nodes/Table/TableHeaderView.vue
@@ -9,6 +9,7 @@
 			<NodeViewContent class="content" />
 			<NcActions v-if="isEditable"
 				ref="menu"
+				type="tertiary-no-background"
 				data-text-table-actions="header">
 				<NcActionButtonGroup>
 					<NcActionButton data-text-table-action="align-column-left"


### PR DESCRIPTION
### 📝 Summary

* Resolves: part of https://github.com/nextcloud/text/issues/6152
"Can use "tertiary no background" as type for the buttons"

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-12-18 17-36-46](https://github.com/user-attachments/assets/68d2fee9-108d-40d3-a99e-dbff1722d8fa) |![Screenshot from 2024-12-18 17-36-04](https://github.com/user-attachments/assets/027c14e5-a711-4623-bc94-856f21b25943)

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
