### PR TITLE
fix(ci): err due to update-node-dist being canceled

### DIFF
--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -14,7 +14,6 @@ on:
 
 concurrency:
   group: update-node-dist-${{ github.head_ref || github.ref || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
   update-node-dist:


### PR DESCRIPTION
The `update-node-dist` workflow pushes a new commit to the branch it runs on.
This commit triggers the workflow again.
Prevent the second workflow from canceling the first
just before the first would have finished.

Every time the workflow is canceled it sends out a notification.

Without `cancel-in-progress` there will be at most one workflow running and one pending.
Most of the time the pending workflow will be the one that resulted from the commit pushed by the running workflow.
If two PRs are merged quickly after each other
first run will be finished even though it was not needed.
However this will happen rarely and will at most waste a few minutes of CI runtime.
