### PR TITLE
fix: showing RichWorkspace for non-English language

### DIFF
--- a/src/views/RichWorkspace.vue
+++ b/src/views/RichWorkspace.vue
@@ -32,10 +32,12 @@ import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { getSharingToken, isPublicShare } from '@nextcloud/sharing/public'
 import getEditorInstance from '../components/Editor.singleton.js'
 import RichTextReader from '../components/RichTextReader.vue'
+import { loadState } from '@nextcloud/initial-state'
 
 const IS_PUBLIC = isPublicShare()
 const WORKSPACE_URL = generateOcsUrl('apps/text' + (IS_PUBLIC ? '/public' : '') + '/workspace', 2)
-const SUPPORTED_STATIC_FILENAMES = ['Readme.md', 'README.md', 'readme.md']
+const descriptionFile = t('text', 'Readme') + '.' + loadState('text', 'default_file_extension')
+const SUPPORTED_STATIC_FILENAMES = [descriptionFile, 'Readme.md', 'README.md', 'readme.md']
 
 export default {
 	name: 'RichWorkspace',


### PR DESCRIPTION
### 📝 Summary

* Resolves: #6805


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
