### PR TITLE
fix: Load focus trap extension in markdown content editor

### DIFF
--- a/src/components/Editor/MarkdownContentEditor.vue
+++ b/src/components/Editor/MarkdownContentEditor.vue
@@ -31,7 +31,7 @@ import { ATTACHMENT_RESOLVER, EDITOR, IS_RICH_EDITOR } from '../Editor.provider.
 import { createMarkdownSerializer } from '../../extensions/Markdown.js'
 import AttachmentResolver from '../../services/AttachmentResolver.js'
 import markdownit from '../../markdownit/index.js'
-import { RichText } from '../../extensions/index.js'
+import { RichText, FocusTrap } from '../../extensions/index.js'
 import ReadonlyBar from '../Menu/ReadonlyBar.vue'
 import ContentContainer from './ContentContainer.vue'
 
@@ -133,6 +133,7 @@ export default {
 						History,
 					],
 				}),
+				FocusTrap,
 			]
 		},
 		createEditor() {


### PR DESCRIPTION
Fix https://github.com/nextcloud/deck/issues/6550

We should make sure to also load the focus trap plugin when using the markdown content editor e.g. in deck as otherwise using the tab key will just focus on the next element instead of triggering editor functionality first.

