### PR TITLE
chore(dep): bump relative-ci/agent-upload-artifact-action

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -81,7 +81,7 @@ jobs:
 
       # Upload webpack-stats.json to use on relative-ci.yaml workflow
       - name: Upload webpack stats artifact
-        uses: relative-ci/agent-upload-artifact-action@51f8b30e845564c5415476f67dcc7758ed1b03f2 # v1.0.3
+        uses: relative-ci/agent-upload-artifact-action@a2b5741b4f7e6a989c84ec1a3059696b23c152e5 # v2.0.0
         with:
           webpackStatsFile: ./webpack-stats.json
 


### PR DESCRIPTION
Bumps actions/upload-artifact to v4 which is now required.

For a failing run see https://github.com/nextcloud/text/actions/runs/12813038066/job/35726156517?pr=6855 .
