### PR TITLE
fix(files): add `tiptap-text-direction` extension to support RTL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "proxy-polyfill": "^0.3.2",
         "slug": "^10.0.0",
         "tippy.js": "^6.3.7",
+        "tiptap-text-direction": "^0.3.2",
         "uuid": "^11.0.5",
         "vue": "^2.7.16",
         "vue-click-outside": "^1.1.0",
@@ -23397,6 +23398,16 @@
         "@popperjs/core": "^2.9.0"
       }
     },
+    "node_modules/tiptap-text-direction": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tiptap-text-direction/-/tiptap-text-direction-0.3.2.tgz",
+      "integrity": "sha512-EBiJq4urei+joaBqhPUwaZ7bfmsSf62Lzd4KXm3T0kjtDC8pj3EFoXdi/9MEvbTsiY8iqx3S/kfRInRCMiN7ng==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0",
+        "@tiptap/pm": "^2.0.0"
+      }
+    },
     "node_modules/tldts": {
       "version": "6.1.76",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.76.tgz",
@@ -41686,6 +41697,12 @@
       "requires": {
         "@popperjs/core": "^2.9.0"
       }
+    },
+    "tiptap-text-direction": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tiptap-text-direction/-/tiptap-text-direction-0.3.2.tgz",
+      "integrity": "sha512-EBiJq4urei+joaBqhPUwaZ7bfmsSf62Lzd4KXm3T0kjtDC8pj3EFoXdi/9MEvbTsiY8iqx3S/kfRInRCMiN7ng==",
+      "requires": {}
     },
     "tldts": {
       "version": "6.1.76",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@tiptap/extension-collaboration-cursor": "^2.9.1",
     "@tiptap/extension-document": "^2.9.1",
     "@tiptap/extension-dropcursor": "^2.9.1",
+    "tiptap-text-direction": "^0.3.2",
     "@tiptap/extension-gapcursor": "^2.9.1",
     "@tiptap/extension-hard-break": "^2.9.1",
     "@tiptap/extension-heading": "^2.9.1",

--- a/src/css/prosemirror.scss
+++ b/src/css/prosemirror.scss
@@ -284,6 +284,14 @@ div.ProseMirror {
 		}
 	}
 
+	li [dir="rtl"] {
+		text-align: right;
+	}
+
+	li [dir="ltr"] {
+		text-align: left;
+	}
+
 	ul, ol {
 		padding-left: 10px;
 		margin-left: 10px;

--- a/src/extensions/RichText.js
+++ b/src/extensions/RichText.js
@@ -41,6 +41,7 @@ import TaskItem from './../nodes/TaskItem.js'
 import TaskList from './../nodes/TaskList.js'
 import Text from '@tiptap/extension-text'
 import TrailingNode from './../nodes/TrailingNode.js'
+import TextDirection from 'tiptap-text-direction'
 /* eslint-enable import/no-named-as-default */
 
 import { Strong, Italic, Strike, Link, Underline } from './../marks/index.js'
@@ -111,6 +112,9 @@ export default Extension.create({
 			}),
 			LinkBubble,
 			TrailingNode,
+			TextDirection.configure({
+				types: ['heading', 'paragraph', 'listItem', 'orderedList'],
+			}),
 		]
 		const additionalExtensionNames = this.options.extensions.map(e => e.name)
 		return [

--- a/src/tests/tiptap.spec.js
+++ b/src/tests/tiptap.spec.js
@@ -16,16 +16,16 @@ const renderedHTML = (markdown) => {
 describe('TipTap', () => {
 	it('render softbreaks', () => {
 		const markdown = 'This\nis\none\nparagraph'
-		expect(renderedHTML(markdown)).toEqual(`<p>${markdown}</p>`)
+		expect(renderedHTML(markdown)).toEqual(`<p dir="ltr">${markdown}</p>`)
 	})
 
 	it('render hardbreak', () => {
 		const markdown = 'Hard line break  \nNext Paragraph'
-		expect(renderedHTML(markdown)).toEqual('<p>Hard line break<br>Next Paragraph</p>')
+		expect(renderedHTML(markdown)).toEqual('<p dir="ltr">Hard line break<br>Next Paragraph</p>')
 	})
 
 	it('render taskList', () => {
 		const markdown = '* [ ] item 1\n'
-		expect(renderedHTML(markdown)).toEqual('<ul class="contains-task-list"><li data-checked="false" class="task-list-item checkbox-item"><input type="checkbox" class="" contenteditable="false"><label><p>item 1</p></label></li></ul>')
+		expect(renderedHTML(markdown)).toEqual('<ul class="contains-task-list"><li data-checked="false" class="task-list-item checkbox-item"><input type="checkbox" class="" contenteditable="false"><label><p dir="ltr">item 1</p></label></li></ul>')
 	})
 })


### PR DESCRIPTION
### 📝 Summary

* Resolves: https://github.com/nextcloud/text/issues/882

Now it is possible to detect RTL writing style for languages, which requires RTL. Using https://github.com/amirhhashemi/tiptap-text-direction extension. This version works for:

- Paragraph
- Heading
- Lists

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2025-01-23 16-09-02](https://github.com/user-attachments/assets/bb6e2edd-2f55-4981-b426-7876c87eac49) | ![Screenshot from 2025-01-23 16-07-29](https://github.com/user-attachments/assets/22a15d0b-05ba-4c6d-9dd3-0b9a60e8a77c)

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
