### PR TITLE
fix: attachment visibility for authenticated users via shared links

### DIFF
--- a/lib/Middleware/SessionMiddleware.php
+++ b/lib/Middleware/SessionMiddleware.php
@@ -123,12 +123,14 @@ class SessionMiddleware extends Middleware {
 	private function assertUserOrShareToken(ISessionAwareController $controller): void {
 		$documentId = (int)$this->request->getParam('documentId');
 		if (null !== $userId = $this->userSession->getUser()?->getUID()) {
-			// Check if user has access to document
-			if ($this->rootFolder->getUserFolder($userId)->getFirstNodeById($documentId) === null) {
-				throw new InvalidSessionException();
+			if (count($this->rootFolder->getUserFolder($userId)->getById($documentId)) !== 0) {
+				$controller->setUserId($userId);
+				$controller->setDocumentId($documentId);
+				return;
 			}
-			$controller->setUserId($userId);
-		} elseif ('' !== $shareToken = (string)$this->request->getParam('shareToken')) {
+		}
+	
+		if ('' !== $shareToken = (string)$this->request->getParam('shareToken')) {
 			try {
 				$share = $this->shareManager->getShareByToken($shareToken);
 			} catch (ShareNotFound) {
@@ -155,11 +157,12 @@ class SessionMiddleware extends Middleware {
 			if ($attributes !== null && $attributes->getAttribute('permissions', 'download') === false) {
 				throw new InvalidSessionException();
 			}
-		} else {
-			throw new InvalidSessionException();
+
+			$controller->setDocumentId($documentId);
+			return;
 		}
 
-		$controller->setDocumentId($documentId);
+		throw new InvalidSessionException();
 	}
 
 	public function afterException($controller, $methodName, \Exception $exception): JSONResponse|Response {


### PR DESCRIPTION
### 📝 Summary

Bug description and steps to reproduce:

admin: Created a Collective.
admin: Added a page with attached images.
admin: Enabled "access via link."
admin: Shared the link with Alice.
alice: Logged into Nextcloud.
alice: Opens the link.
Result: The Collective opens, but the images return a 403 error code.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before](https://github.com/user-attachments/assets/84a05572-0e08-4570-b632-123355f3e0ca)| ![after](https://github.com/user-attachments/assets/7ee640da-0e9b-4219-a817-b49f6e1d2d1e)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
