### PR TITLE
fix(workspace): Use filecache existance for checking if readme exists

### DIFF
--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -91,7 +91,7 @@ class WorkspacePlugin extends ServerPlugin {
 			if ($file instanceof File) {
 				$cache = $this->cacheFactory->createDistributed('text_workspace');
 				$cacheKey = $file->getFileInfo()->getId() . '_' . $file->getFileInfo()->getEtag();
-				if ($cachedContent = $cache->get($cacheKey)) {
+				if (($cachedContent = $cache->get($cacheKey)) !== null) {
 					return $cachedContent;
 				}
 

--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -30,9 +30,12 @@ class WorkspaceService {
 	public function getFile(Folder $folder): ?File {
 		foreach ($this->getSupportedFilenames() as $filename) {
 			try {
-				$file = $folder->get($filename);
-				if ($file instanceof File) {
-					return $file;
+				$exists = $folder->getStorage()->getCache('')->get($filename);
+				if ($exists) {
+					$file = $folder->get($filename);
+					if ($file instanceof File) {
+						return $file;
+					}
 				}
 			} catch (NotFoundException|StorageInvalidException) {
 				continue;

--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -30,7 +30,7 @@ class WorkspaceService {
 	public function getFile(Folder $folder): ?File {
 		foreach ($this->getSupportedFilenames() as $filename) {
 			try {
-				$exists = $folder->getStorage()->getCache('')->get($filename);
+				$exists = $folder->getStorage()->getCache()->get($folder->getInternalPath() . '/' . $filename);
 				if ($exists) {
 					$file = $folder->get($filename);
 					if ($file instanceof File) {


### PR DESCRIPTION
Alternative to https://github.com/nextcloud/text/pull/5963

While i initially pushed this fix to the earlier PR i think it would be enough in its own without affecting mobile app behaviour. We save the most expensive step to check file existence on the actual remote storage by just using the file cache entry.

This improves the situation for any external storage as well as federated shares by saving 4 checks on the remote for file existence, only if we know a file we will access it to get the content.

This of course has one limitation, that the file needs to be known to Nextcloud already, but should be fine for most of the cases.

## Todo from chat:

- [x] The propfind does not return a file id anymore (empty file or not)
- [x] I was wondering why I see the readme.md file being accessed even when I directly reload the page. Looked into redis and saw:

1738924269.607566 [0 unix:/var/run/redis/redis-server.sock] "GET" "8b16b520c496b13f920772e0b509487a/text_workspace175301_549b3998cd6b2f08d58c4033e85a084a"
1738924269.617739 [0 unix:/var/run/redis/redis-server.sock] "SETEX" "8b16b520c496b13f920772e0b509487a/text_workspace175301_549b3998cd6b2f08d58c4033e85a084a" "3600" "\"\""
Turns out the file was empty, so the check at https://github.com/nextcloud/text/blob/40e63bb4857eb045504ade2b2960ec3bcb83d7b3/lib/DAV/WorkspacePlugin.php#L92-L96 fails.

Might be a corner case, but guess filing an issue makes sense?

