### PR TITLE
fix/6871 smart add to next line

### DIFF
--- a/src/plugins/currentLineMenu.js
+++ b/src/plugins/currentLineMenu.js
@@ -157,12 +157,12 @@ function menuForCurrentParagraph(editor) {
 		const { selection } = editor.state
 		const { textContent } = selection.$anchor.parent
 		const eol = selection.$anchor.end()
-		const contentToInsert = textContent.match(/(^| )$/) ? '/' : ' /'
-		editor.chain()
-			.focus()
-			.setTextSelection(eol)
-			.insertContent(contentToInsert)
-			.run()
+		const chain = editor.chain().focus().setTextSelection(eol)
+		if (textContent.trim() === '') {
+			chain.insertContent('/').run()
+		} else {
+			chain.splitBlock().insertContent('/').run()
+		}
 	})
 	return menu.$el
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -77,6 +77,9 @@ const config = createAppConfig({
 				}
 			},
 		},
+		server: {
+			allowedHosts: ['host.docker.internal', 'localhost', 'nextcloud.local'],
+		},
 	},
 })
 


### PR DESCRIPTION
# 📝 Summary

* **fix(smart-picker): Add content on next line**
  Resolves: #6871
* **fix(vite): allow hostnames used for hmr via docker-dev**
  Allow using `npm run serve` for local development

# 🖼️ Screencasts

## 🏚️ Before
 
https://github.com/user-attachments/assets/552548e7-78e1-4b22-a800-03de3b6846e5

## 🏡 After

https://github.com/user-attachments/assets/7c137d87-b3d9-44ba-a166-bd9803bfd142 

# 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
