### PR TITLE
fix: resolve file version conflict during restore

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -11,6 +11,7 @@ namespace OCA\Text\AppInfo;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
 use OCA\Text\Event\LoadEditor;
+use OCA\Text\Exception\DocumentHasUnsavedChangesException;
 use OCA\Text\Listeners\AddMissingIndicesListener;
 use OCA\Text\Listeners\BeforeAssistantNotificationListener;
 use OCA\Text\Listeners\BeforeNodeDeletedListener;
@@ -25,6 +26,7 @@ use OCA\Text\Listeners\RegisterDirectEditorEventListener;
 use OCA\Text\Listeners\RegisterTemplateCreatorListener;
 use OCA\Text\Middleware\SessionMiddleware;
 use OCA\Text\Notification\Notifier;
+use OCA\Text\Service\DocumentService;
 use OCA\TpAssistant\Event\BeforeAssistantNotificationEvent;
 use OCA\Viewer\Event\LoadViewer;
 use OCP\AppFramework\App;
@@ -37,7 +39,11 @@ use OCP\Files\Events\Node\BeforeNodeDeletedEvent;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
 use OCP\Files\Events\Node\BeforeNodeWrittenEvent;
 use OCP\Files\Events\Node\NodeCopiedEvent;
+use OCP\Files\File;
+use OCP\Files\NotFoundException;
 use OCP\Files\Template\RegisterTemplateCreatorEvent;
+use OCP\Server;
+use OCP\Util;
 
 class Application extends App implements IBootstrap {
 	public const APP_NAME = 'text';
@@ -63,8 +69,28 @@ class Application extends App implements IBootstrap {
 
 		$context->registerNotifierService(Notifier::class);
 		$context->registerMiddleware(SessionMiddleware::class);
+
+		/** @psalm-suppress DeprecatedMethod */
+		Util::connectHook('\OCP\Versions', 'rollback', $this, 'resetSessionsAfterRestoreFile');
 	}
 
 	public function boot(IBootContext $context): void {
+	}
+
+	public function resetSessionsAfterRestoreFile(array $params): void {
+		$node = $params['node'];
+		if (!$node instanceof File) {
+			return;
+		}
+
+		$documentService = Server::get(DocumentService::class);
+		// Reset document session to avoid manual conflict resolution if there's no unsaved steps
+		try {
+			$documentService->resetDocument($node->getId());
+		} catch (DocumentHasUnsavedChangesException|NotFoundException $e) {
+			// Do not throw during event handling in this is expected to happen
+			// DocumentHasUnsavedChangesException: A document editing session is likely ongoing, someone can resolve the conflict
+			// NotFoundException: The event was called oin a file that was just created so a NonExistingFile object is used that has no id yet
+		}
 	}
 }


### PR DESCRIPTION
### 📝 Summary

* Resolves: [# <!-- related github issue -->](https://github.com/nextcloud/collectives/issues/1602)

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

When restoring a previous version, there is always a conflict. This fix removes the conflict for situations where there were no unsaved changes. 

I made this fix via hook. So that you can backport to version 30.

The next step is to make a new PR for version 32, which will work through Event (I'm waiting for approval https://github.com/nextcloud/server/pull/50990) 

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
