### PR TITLE
fix: Skip notifications for self mentions

### DIFF
--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -22,6 +22,11 @@ class NotificationService {
 	}
 
 	public function mention(int $fileId, string $userId): bool {
+		if ($userId === $this->userId) {
+			// We allow self mentions in documents but do not notify about it
+			return false;
+		}
+
 		$notification = $this->manager->createNotification();
 		$notification->setUser($userId)
 			->setApp('text')


### PR DESCRIPTION
As discussed via chat with @jancborchardt we do not need a notification for self mentions an can just skip it