### PR TITLE
Help modal improvements

### DIFF
--- a/src/components/HelpModal.vue
+++ b/src/components/HelpModal.vue
@@ -53,7 +53,7 @@
 					<td>{{ t('text', 'Bold') }}</td>
 					<td><code>**{{ t('text', 'Bold text') }}**</code></td>
 					<td v-if="!isMobileCached">
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>B</kbd>
 					</td>
@@ -62,7 +62,7 @@
 					<td>{{ t('text', 'Italic') }}</td>
 					<td><code>*{{ t('text', 'Italicized text') }}*</code></td>
 					<td v-if="!isMobileCached">
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>I</kbd>
 					</td>
@@ -71,7 +71,7 @@
 					<td>{{ t('text', 'Strikethrough') }}</td>
 					<td><code>~~{{ t('text', 'Mistaken text') }}~~</code></td>
 					<td v-if="!isMobileCached">
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>{{ t('text', 'Shift') }}</kbd>
 						+
@@ -82,7 +82,7 @@
 					<td>{{ t('text', 'Underline') }}</td>
 					<td><code>__{{ t('text', 'Underlined text') }}__</code></td>
 					<td v-if="!isMobileCached">
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>U</kbd>
 					</td>
@@ -95,7 +95,7 @@
 						<code># {{ t('text', 'Heading level 1') }}</code>
 					</td>
 					<td v-if="!isMobileCached" class="ellipsis_top">
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>{{ t('text', 'Shift') }}</kbd>
 						+
@@ -121,7 +121,7 @@
 						<code>###### {{ t('text', 'Heading level 6') }}</code>
 					</td>
 					<td v-if="!isMobileCached" class="noborder ellipsis_bottom">
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>{{ t('text', 'Shift') }}</kbd>
 						+
@@ -134,7 +134,7 @@
 						<code>* {{ t('text', 'An item') }}</code>
 					</td>
 					<td v-if="!isMobileCached">
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>{{ t('text', 'Shift') }}</kbd>
 						+
@@ -147,7 +147,7 @@
 						<code>1. {{ t('text', 'First item') }}</code>
 					</td>
 					<td v-if="!isMobileCached">
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>{{ t('text', 'Shift') }}</kbd>
 						+
@@ -160,7 +160,7 @@
 						<code>* [] {{ t('text', 'To-Do item') }}</code>
 					</td>
 					<td v-if="!isMobileCached">
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>{{ t('text', 'Shift') }}</kbd>
 						+
@@ -173,7 +173,7 @@
 						<code>> {{ t('text', 'Quoted text') }}</code>
 					</td>
 					<td v-if="!isMobileCached">
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>></kbd>
 					</td>
@@ -227,7 +227,7 @@
 				<tr>
 					<td>{{ t('text', 'Undo') }}</td>
 					<td>
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>Z</kbd>
 					</td>
@@ -235,7 +235,7 @@
 				<tr>
 					<td>{{ t('text', 'Redo') }}</td>
 					<td>
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>Y</kbd>
 					</td>
@@ -243,7 +243,7 @@
 				<tr>
 					<td>{{ t('text', 'Toggle outline') }}</td>
 					<td>
-						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						<kbd>{{ ctrlOrModKey }}</kbd>
 						+
 						<kbd>{{ t('text', 'Alt') }}</kbd>
 						+
@@ -258,6 +258,7 @@
 <script>
 import { NcDialog } from '@nextcloud/vue'
 import { isMobilePlatform } from '../helpers/platform.js'
+import { TRANSLATIONS, MODIFIERS } from './Menu/keys.js'
 
 export default {
 	name: 'HelpModal',
@@ -278,6 +279,7 @@ export default {
 				blockQuote: true,
 				codeBlock: true,
 			},
+			ctrlOrModKey: TRANSLATIONS[MODIFIERS.Mod],
 		}
 	},
 	computed: {

--- a/src/components/HelpModal.vue
+++ b/src/components/HelpModal.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcDialog size="normal"
+	<NcDialog size="large"
 		data-text-el="formatting-help"
 		:name="t('text', 'Formatting and shortcuts')"
 		:close-on-click-outside="true"
@@ -304,6 +304,7 @@ export default {
 	table {
 		margin-top: 24px;
 		border-collapse: collapse;
+		width: 100%;
 
 		tbody tr {
 			&:hover, &:focus, &:active {

--- a/src/components/HelpModal.vue
+++ b/src/components/HelpModal.vue
@@ -159,7 +159,13 @@
 					<td>
 						<code>* [] {{ t('text', 'To-Do item') }}</code>
 					</td>
-					<td v-if="!isMobileCached" />
+					<td v-if="!isMobileCached">
+						<kbd>{{ t('text', 'Ctrl') }}</kbd>
+						+
+						<kbd>{{ t('text', 'Shift') }}</kbd>
+						+
+						<kbd>9</kbd>
+					</td>
 				</tr>
 				<tr>
 					<td>{{ t('text', 'Blockquote') }}</td>

--- a/src/components/Menu/keys.js
+++ b/src/components/Menu/keys.js
@@ -18,7 +18,7 @@ const MODIFIERS = {
 }
 
 const TRANSLATIONS = {
-	[MODIFIERS.Mod]: isMac ? t('text', 'Command') : t('text', 'Control'),
+	[MODIFIERS.Mod]: isMac ? t('text', 'Command') : t('text', 'Ctrl'),
 	[MODIFIERS.Control]: t('text', 'Ctrl'),
 	[MODIFIERS.Alt]: t('text', isMac ? 'Option' : 'Alt'),
 	[MODIFIERS.Shift]: t('text', 'Shift'),

--- a/src/components/Suggestion/Mention/suggestions.js
+++ b/src/components/Suggestion/Mention/suggestions.js
@@ -17,6 +17,7 @@ const emitMention = ({ session, props }) => {
 		sessionId: session.id,
 		sessionToken: session.token,
 		mention: props.id,
+		scope: window.location,
 	})
 }
 


### PR DESCRIPTION
- **fix: Add missing shortcut for checklists to help modal**
- **fix: Use proper mod key on macOS in help modal**
- **fix: Change help modal size to force scrolling**

### 📝 Summary

* Resolves: #6925


#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="819" alt="Screenshot 2025-02-28 at 09 32 49" src="https://github.com/user-attachments/assets/d83fa79c-45db-4127-849c-d785c80f8f49" /> | <img width="743" alt="Screenshot 2025-02-28 at 09 31 33" src="https://github.com/user-attachments/assets/901b0af9-c18c-47e5-8d53-fa1ae4fc3deb" />

