### PR TITLE
feat: Add experimental option to allow typing during connectivity issues or being offline

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -46,7 +46,10 @@ class ConfigService {
 
 	public function isNotifyPushSyncEnabled(): bool {
 		return $this->appConfig->getValueBool(Application::APP_NAME, 'notify_push');
+	}
 
+	public function isExperimentalOfflineTypingEnabled(): bool {
+		return $this->appConfig->getValueBool(Application::APP_NAME, 'experimental_offline_typing');
 	}
 
 	public function isFullWidthEditor(?string $userId): bool {

--- a/lib/Service/InitialStateProvider.php
+++ b/lib/Service/InitialStateProvider.php
@@ -84,6 +84,11 @@ class InitialStateProvider {
 		);
 
 		$this->initialState->provideInitialState(
+			'experimental_offline_typing',
+			$this->configService->isExperimentalOfflineTypingEnabled(),
+		);
+
+		$this->initialState->provideInitialState(
 			'is_full_width_editor',
 			$this->configService->isFullWidthEditor($this->userId),
 		);

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -139,6 +139,8 @@ import { fetchNode } from '../services/WebdavClient.ts'
 import SuggestionsBar from './SuggestionsBar.vue'
 import { useDelayedFlag } from './Editor/useDelayedFlag.ts'
 
+const experimentalOfflineTyping = loadState('text', 'experimental_offline_typing', false)
+
 export default {
 	name: 'Editor',
 	components: {
@@ -375,7 +377,7 @@ export default {
 			if (val) {
 				this.emit('sync-service:error')
 			}
-			if (this.$editor?.isEditable === val) {
+			if (!experimentalOfflineTyping && this.$editor?.isEditable === val) {
 				this.$editor.setEditable(!val)
 			}
 		},
@@ -643,7 +645,7 @@ export default {
 			this.document = document
 
 			this.syncError = null
-			const editable = this.editMode && !this.requireReconnect
+			const editable = this.editMode && (!this.requireReconnect || experimentalOfflineTyping)
 			if (this.$editor.isEditable !== editable) {
 				this.$editor.setEditable(editable)
 			}
@@ -744,7 +746,9 @@ export default {
 		onIdle() {
 			this.$syncService.close()
 			this.idle = true
-			this.readOnly = true
+			if (!experimentalOfflineTyping) {
+				this.readOnly = true
+			}
 			this.editMode = false
 			this.$editor.setEditable(this.editMode)
 
@@ -790,7 +794,9 @@ export default {
 			this.$providers = []
 			this.$syncService = null
 			// disallow editing while still showing the content
-			this.readOnly = true
+			if (!experimentalOfflineTyping) {
+				this.readOnly = true
+			}
 		},
 
 		async close() {


### PR DESCRIPTION
Something to have merged so we can experiment on daily

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
