### PR TITLE
fix: Avoid pushing empty messages

### DIFF
--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -208,7 +208,7 @@ class ApiService {
 				'message' => 'text_steps',
 				'body' => [
 					'documentId' => $document->getId(),
-					'steps' => $steps,
+					'steps' => array_values(array_filter($steps)),
 				],
 			]);
 		}


### PR DESCRIPTION
Found in sentry 
Fixes a regular js console error when using notify_push where the awareness message may be pushed as empty string.

We avoid this filtering on the backend before we emit the messages over notify_push, but @max-nextcloud do you happen to know if seeing those empty awareness messages being pushed is expected?


<img width="1474" alt="Screenshot 2025-03-10 at 12 58 08" src="https://github.com/user-attachments/assets/57c6fa67-c322-4585-a812-0ed169409743" />
<img width="345" alt="Screenshot 2025-03-10 at 12 58 43" src="https://github.com/user-attachments/assets/9cd77fdf-cae0-4bbd-b8e7-51e385a0c27a" />

Without this PR parsing the empty data fails in https://github.com/nextcloud/text/blob/ed577363f0b20e745cfe4602a18787a90dd05512/src/services/y-websocket.js#L167

