### PR TITLE
fix(reuse): add license info for vitest snapshots

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -30,9 +30,9 @@ SPDX-FileCopyrightText = "Nils Adermann, Jordi Boggiano"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
-path = ["cypress/fixtures/**", "cypress/snapshots/**", "src/tests/fixtures/**"]
+path = ["cypress/fixtures/**", "cypress/snapshots/**", "src/tests/fixtures/**", "src/tests/**/__snapshots__/**"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2019-2024 Nextcloud GmbH and Nextcloud contributors"
+SPDX-FileCopyrightText = "2019-2025 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"
 
 [[annotations]]


### PR DESCRIPTION
Signed-off-by: Max <max@nextcloud.com>

### 📝 Summary

* Resolves: Failing reuse checks such as 
  https://github.com/nextcloud/text/actions/runs/13810263325/job/38630051332

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- Tests are fixed by this.
