### PR TITLE
Fix flaky cypress tests

### DIFF
--- a/cypress/e2e/Assistant.spec.js
+++ b/cypress/e2e/Assistant.spec.js
@@ -101,18 +101,16 @@ describe('Assistant', () => {
 			.should('be.visible')
 			.click()
 
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
 		cy.wait(1000)
 
 		cy.get('[data-cy="translate-input"]')
 			.should('be.visible')
 			.focus()
 
-		cy.wait(1000)
-
 		cy.get('[data-cy="translate-input"]')
 			.should('be.focused')
 		cy.get('[data-cy="translate-input"]')
-			.should('be.visible')
 			.type('Hello World')
 	})
 })

--- a/cypress/e2e/Assistant.spec.js
+++ b/cypress/e2e/Assistant.spec.js
@@ -101,13 +101,18 @@ describe('Assistant', () => {
 			.should('be.visible')
 			.click()
 
+		cy.wait(1000)
+
 		cy.get('[data-cy="translate-input"]')
 			.should('be.visible')
-			.click()
+			.focus()
+
+		cy.wait(1000)
+
+		cy.get('[data-cy="translate-input"]')
+			.should('be.focused')
 		cy.get('[data-cy="translate-input"]')
 			.should('be.visible')
 			.type('Hello World')
-		cy.get('[data-cy="translate-input"]')
-			.should('be.focused')
 	})
 })

--- a/cypress/e2e/api/SessionApi.spec.js
+++ b/cypress/e2e/api/SessionApi.spec.js
@@ -279,12 +279,15 @@ describe('The session Api', function() {
 		it('signals closing connection', function() {
 			cy.then(() => {
 				return new Promise((resolve, reject) => {
+					// Create a promise that resolves when close completes
 					connection.close()
-					connection.push({ steps: [messages.update], version, awareness: '' })
-						.then(
-							() => reject(new Error('Push should have thrown ConnectionClosed()')),
-							resolve,
-						)
+						.then(() => {
+							connection.push({ steps: [messages.update], version, awareness: '' })
+								.then(
+									() => reject(new Error('Push should have thrown ConnectionClosed()')),
+									resolve,
+								)
+						})
 				})
 			})
 		})


### PR DESCRIPTION
## runner 1 Assistant - Open translate dialog

Otherwise this test is flaky as it may not focus fast enough before entering text, also clicking my interfere with the autofocus of the language selection. Certainly the test could be improved but this is a quick fix to get back to green ci

## runner 7 The session Api - signals closing connection

The issue is that the close api call was not awaited properly. This lead to situations where the push was called too early. Can be tested locally with adding a sleep on the backend in https://github.com/nextcloud/text/blob/tests/cypress-green/lib/Service/ApiService.php#L161