### PR TITLE
Hide emoji button from the menubar on mobile

### DIFF
--- a/src/components/Menu/entries.js
+++ b/src/components/Menu/entries.js
@@ -70,6 +70,8 @@ export const ReadOnlyDoneEntries = [{
 	click: ({ $readOnlyActions }) => $readOnlyActions.toggle(),
 }]
 
+const isMobileDevice = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+
 export const MenuEntries = [
 	{
 		key: 'undo',
@@ -412,7 +414,11 @@ export const MenuEntries = [
 		component: ActionAttachmentUpload,
 		priority: 5,
 	},
-	{
+
+]
+
+if (!isMobileDevice) {
+	MenuEntries.push({
 		key: 'emoji-picker',
 		label: t('text', 'Insert emoji'),
 		icon: Emoticon,
@@ -421,5 +427,5 @@ export const MenuEntries = [
 			return command.emoji(emojiObject)
 		},
 		priority: 6,
-	},
-]
+	})
+}


### PR DESCRIPTION
Add RegEx to check if user uses mobile device and add Emoji Picker button inside a toolbar only in this case

### 📝 Summary

* Resolves: https://github.com/nextcloud/text/issues/7022

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2025-03-25 15-10-28](https://github.com/user-attachments/assets/2dcfdd4e-92c4-4da2-9a22-a49302fd5f27) | ![Screenshot from 2025-03-25 15-08-30](https://github.com/user-attachments/assets/0da70ed8-db13-4e82-a52e-e06f47dc96d3)

