### PR TITLE
fix(files): Add transition to buttons and take buttons away from mobile view

### DIFF
--- a/src/components/Menu/entries.js
+++ b/src/components/Menu/entries.js
@@ -42,6 +42,7 @@ import ActionAttachmentUpload from './ActionAttachmentUpload.vue'
 import ActionInsertLink from './ActionInsertLink.vue'
 
 import { MODIFIERS } from './keys.js'
+import { isMobileDevice } from '../../helpers/isMobileDevice.js'
 
 export const OutlineEntries = [{
 	key: 'outline',
@@ -69,8 +70,6 @@ export const ReadOnlyDoneEntries = [{
 	icon: PencilOff,
 	click: ({ $readOnlyActions }) => $readOnlyActions.toggle(),
 }]
-
-const isMobileDevice = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
 
 export const MenuEntries = [
 	{

--- a/src/components/SuggestionsBar.vue
+++ b/src/components/SuggestionsBar.vue
@@ -4,56 +4,50 @@
 -->
 
 <template>
-	<div v-if="isEmptyContent" class="container-suggestions">
-		<NcButton ref="linkFileOrFolder"
-			type="secondary"
-			size="normal"
-			class="suggestions--button"
-			@click="linkFile">
-			<template #icon>
-				<Document :size="20" />
-			</template>
-			<template v-if="!isMobile" #default>
+	<transition name="fade">
+		<div v-if="isEmptyContent && !isMobileDevice" class="container-suggestions">
+			<NcButton ref="linkFileOrFolder"
+				type="secondary"
+				size="normal"
+				class="suggestions--button"
+				@click="linkFile">
+				<template #icon>
+					<Document :size="20" />
+				</template>
 				{{ t('text', 'Link to file or folder') }}
-			</template>
-		</NcButton>
+			</NcButton>
 
-		<NcButton type="secondary"
-			size="normal"
-			class="suggestions--button"
-			@click="$callChooseLocalAttachment">
-			<template #icon>
-				<Upload :size="20" />
-			</template>
-			<template v-if="!isMobile" #default>
+			<NcButton type="secondary"
+				size="normal"
+				class="suggestions--button"
+				@click="$callChooseLocalAttachment">
+				<template #icon>
+					<Upload :size="20" />
+				</template>
 				{{ t('text', 'Upload') }}
-			</template>
-		</NcButton>
+			</NcButton>
 
-		<NcButton type="secondary"
-			size="normal"
-			class="suggestions--button"
-			@click="insertTable">
-			<template #icon>
-				<TableIcon :size="20" />
-			</template>
-			<template v-if="!isMobile" #default>
+			<NcButton type="secondary"
+				size="normal"
+				class="suggestions--button"
+				@click="insertTable">
+				<template #icon>
+					<TableIcon :size="20" />
+				</template>
 				{{ t('text', 'Insert Table') }}
-			</template>
-		</NcButton>
+			</NcButton>
 
-		<NcButton type="secondary"
-			size="normal"
-			class="suggestions--button"
-			@click="linkPicker">
-			<template #icon>
-				<Shape :size="20" />
-			</template>
-			<template v-if="!isMobile" #default>
+			<NcButton type="secondary"
+				size="normal"
+				class="suggestions--button"
+				@click="linkPicker">
+				<template #icon>
+					<Shape :size="20" />
+				</template>
 				{{ t('text', 'Smart Picker') }}
-			</template>
-		</NcButton>
-	</div>
+			</NcButton>
+		</div>
+	</transition>
 </template>
 
 <script>
@@ -64,7 +58,7 @@ import { getLinkWithPicker } from '@nextcloud/vue/dist/Components/NcRichText.js'
 import { useEditorMixin, useFileMixin } from './Editor.provider.js'
 import { generateUrl } from '@nextcloud/router'
 import { buildFilePicker } from '../helpers/filePicker.js'
-import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
+import { isMobileDevice } from '../helpers/isMobileDevice.js'
 
 export default {
 	name: 'SuggestionsBar',
@@ -82,9 +76,8 @@ export default {
 	],
 
 	setup() {
-		const isMobile = useIsMobile()
 		return {
-			isMobile,
+			isMobileDevice,
 		}
 	},
 
@@ -191,9 +184,26 @@ export default {
 .container-suggestions {
 	display: flex;
 	margin-left: max(0px, (100% - var(--text-editor-max-width)) / 2);
+	flex-wrap: wrap;
 }
 
 .suggestions--button {
 	margin: 5px;
 }
+
+.fade-enter-active,
+.fade-leave-active {
+	transition: opacity var(--animation-slow) ease-in-out;
+}
+
+.fade-enter-to,
+.fade-leave {
+	opacity: 1;
+}
+
+.fade-enter,
+.fade-leave-to {
+	opacity: 0;
+}
+
 </style>

--- a/src/helpers/isMobileDevice.js
+++ b/src/helpers/isMobileDevice.js
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export const isMobileDevice = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)


### PR DESCRIPTION
Signed-off-by: julia.kirschenheuter <julia.kirschenheuter@nextcloud.com>

### 📝 Summary

* Resolves: https://github.com/nextcloud/text/issues/7024

Add transition to buttons and take buttons away from mobile view

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2025-03-26 16-17-15](https://github.com/user-attachments/assets/693c787d-b87d-4088-a38b-93569765864b) | ![Screenshot from 2025-03-26 16-08-44](https://github.com/user-attachments/assets/0225fc33-b883-4326-be66-4aaab953c52b)


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
