### PR TITLE
Fix position of assistant button

### DIFF
--- a/src/components/Assistant.vue
+++ b/src/components/Assistant.vue
@@ -335,8 +335,8 @@ export default {
 			}
 		},
 		floatingOptions() {
-			const buttonSize = 44
-			const topSpacing = 110 + 22
+			const buttonSize = 34
+			const topSpacing = 0
 			const bottomSpacing = 50 + 22
 			return {
 				placement: 'right',
@@ -344,22 +344,16 @@ export default {
 					const editorRect = this.$parent.$el.querySelector('.ProseMirror').getBoundingClientRect()
 					const pos = posToDOMRect(this.$editor.view, this.$editor.state.selection.from, this.$editor.state.selection.to)
 					let rightSpacing = 0
-					let addTopSpacing = 0
 
-					if (editorRect.width < 670) {
-						rightSpacing = 20
-					}
-
-					if (editorRect.width < 425) {
+					if (editorRect.width < 890) {
 						rightSpacing = 66
-						addTopSpacing = 30
 					}
 
 					return {
 						...pos,
 						width: editorRect.width - rightSpacing,
 						height: limitInRange(pos.height, buttonSize, window.innerHeight),
-						top: limitInRange(pos.top, topSpacing, window.innerHeight - bottomSpacing) + addTopSpacing,
+						top: limitInRange(pos.top, topSpacing, window.innerHeight - bottomSpacing),
 						left: editorRect.left,
 						right: editorRect.right,
 						bottom: limitInRange(pos.top + buttonSize, bottomSpacing, window.innerHeight - topSpacing) + 22,


### PR DESCRIPTION
### 📝 Summary

* Resolves: https://github.com/nextcloud/text/issues/6768

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After

|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![Screenshot from 2025-03-28 19-29-15](https://github.com/user-attachments/assets/8a71e628-2810-4831-9d84-d79de20b2439) | ![Screenshot from 2025-03-28 19-27-15](https://github.com/user-attachments/assets/78fcc084-4fa6-4e98-b06d-66955efa455e) |-------------|---------------------------------------------------------------|
| ![Screenshot from 2025-03-28 19-29-37](https://github.com/user-attachments/assets/74013103-6235-4917-b230-4fb3e43f6750) | ![Screenshot from 2025-03-28 19-26-50](https://github.com/user-attachments/assets/a800f336-f4ff-4958-95f4-793638773bae)

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
