### PR TITLE
[main] Fix npm audit

### DIFF
--- a/js/RichText-Bscnwozd.chunk.mjs.license
+++ b/js/RichText-Bscnwozd.chunk.mjs.license
@@ -124,7 +124,7 @@ This file is generated from multiple sources. Included packages:
 	- version: 2.9.1
 	- license: MIT
 - @tiptap/extension-floating-menu
-	- version: 2.11.5
+	- version: 2.11.7
 	- license: MIT
 - @tiptap/extension-gapcursor
 	- version: 2.9.1
@@ -190,7 +190,7 @@ This file is generated from multiple sources. Included packages:
 	- version: 2.9.1
 	- license: MIT
 - @tiptap/vue-2
-	- version: 2.11.5
+	- version: 2.11.7
 	- license: MIT
 - entities
 	- version: 4.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -4965,9 +4965,9 @@
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.11.5.tgz",
-      "integrity": "sha512-rx+rMd7EEdht5EHLWldpkzJ56SWYA9799b33ustePqhXd6linnokJCzBqY13AfZ9+xp3RsR6C0ZHI9GGea0tIA==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.11.7.tgz",
+      "integrity": "sha512-0vYqSUSSap3kk3/VT4tFE1/6StX70I3/NKQ4J68ZSFgkgyB3ZVlYv7/dY3AkEukjsEp3yN7m8Gw8ei2eEwyzwg==",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
@@ -5109,9 +5109,9 @@
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.11.5.tgz",
-      "integrity": "sha512-HsMI0hV5Lwzm530Z5tBeyNCBNG38eJ3qjfdV2OHlfSf3+KOEfn6a5AUdoNaZO02LF79/8+7BaYU2drafag9cxQ==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.11.7.tgz",
+      "integrity": "sha512-DG54WoUu2vxHRVzKZiR5I5RMOYj45IlxQMkBAx1wjS0ch41W8DUYEeipvMMjCeKtEI+emz03xYUcOAP9LRmg+w==",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
@@ -5468,13 +5468,13 @@
       }
     },
     "node_modules/@tiptap/vue-2": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/vue-2/-/vue-2-2.11.5.tgz",
-      "integrity": "sha512-aj9jDcarn96h/Dhftr42lX0HLyX0Sf+6PBX5CKwB4MZmwYd4Cewff20Cc8poYTDGrlZ2kWr9PVpzVfc++4VscA==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-2/-/vue-2-2.11.7.tgz",
+      "integrity": "sha512-yr80TUCZVhgn233K1TE6dBYc8bMzPihl0vrK5IY8f87qbYhWmzJha4CHiRLRh8ZoK4vFWA0o13vi3G7JjPEpbA==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.11.5",
-        "@tiptap/extension-floating-menu": "^2.11.5",
+        "@tiptap/extension-bubble-menu": "^2.11.7",
+        "@tiptap/extension-floating-menu": "^2.11.7",
         "vue-ts-types": "1.6.2"
       },
       "funding": {
@@ -25443,9 +25443,9 @@
       "requires": {}
     },
     "@tiptap/extension-bubble-menu": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.11.5.tgz",
-      "integrity": "sha512-rx+rMd7EEdht5EHLWldpkzJ56SWYA9799b33ustePqhXd6linnokJCzBqY13AfZ9+xp3RsR6C0ZHI9GGea0tIA==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.11.7.tgz",
+      "integrity": "sha512-0vYqSUSSap3kk3/VT4tFE1/6StX70I3/NKQ4J68ZSFgkgyB3ZVlYv7/dY3AkEukjsEp3yN7m8Gw8ei2eEwyzwg==",
       "requires": {
         "tippy.js": "^6.3.7"
       }
@@ -25505,9 +25505,9 @@
       "requires": {}
     },
     "@tiptap/extension-floating-menu": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.11.5.tgz",
-      "integrity": "sha512-HsMI0hV5Lwzm530Z5tBeyNCBNG38eJ3qjfdV2OHlfSf3+KOEfn6a5AUdoNaZO02LF79/8+7BaYU2drafag9cxQ==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.11.7.tgz",
+      "integrity": "sha512-DG54WoUu2vxHRVzKZiR5I5RMOYj45IlxQMkBAx1wjS0ch41W8DUYEeipvMMjCeKtEI+emz03xYUcOAP9LRmg+w==",
       "requires": {
         "tippy.js": "^6.3.7"
       }
@@ -25678,12 +25678,12 @@
       "requires": {}
     },
     "@tiptap/vue-2": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/vue-2/-/vue-2-2.11.5.tgz",
-      "integrity": "sha512-aj9jDcarn96h/Dhftr42lX0HLyX0Sf+6PBX5CKwB4MZmwYd4Cewff20Cc8poYTDGrlZ2kWr9PVpzVfc++4VscA==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-2/-/vue-2-2.11.7.tgz",
+      "integrity": "sha512-yr80TUCZVhgn233K1TE6dBYc8bMzPihl0vrK5IY8f87qbYhWmzJha4CHiRLRh8ZoK4vFWA0o13vi3G7JjPEpbA==",
       "requires": {
-        "@tiptap/extension-bubble-menu": "^2.11.5",
-        "@tiptap/extension-floating-menu": "^2.11.5",
+        "@tiptap/extension-bubble-menu": "^2.11.7",
+        "@tiptap/extension-floating-menu": "^2.11.7",
         "vue-ts-types": "1.6.2"
       }
     },


### PR DESCRIPTION
# Audit report

This audit fix resolves 7 of the total 19 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/moment](#user-content-\@nextcloud\/moment)
* [@vue/test-utils](#user-content-\@vue\/test-utils)
* [node-gettext](#user-content-node-gettext)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=4.2.0-beta.1
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: 1.1.0 - 3.1.0
* Package usage:
  * `node_modules/@nextcloud/moment/node_modules/@nextcloud/l10n`

### @nextcloud/moment <a href="#user-content-\@nextcloud\/moment" id="\@nextcloud\/moment">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.1
* Package usage:
  * `node_modules/@nextcloud/moment`

### @vue/test-utils <a href="#user-content-\@vue\/test-utils" id="\@vue\/test-utils">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=1.3.6
* Package usage:
  * `node_modules/@vue/test-utils`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **high** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`