### PR TITLE
chore: adjust viteconfig to remove outdated assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,6 @@
         "@nextcloud/stylelint-config": "^3.0.1",
         "@nextcloud/vite-config": "^1.5.3",
         "@types/markdown-it": "^14.1.2",
-        "@vitejs/plugin-vue2": "^2.3.3",
         "@vitest/coverage-v8": "^3.1.1",
         "@vue/test-utils": "^1.3.0 <2",
         "@vue/tsconfig": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "@nextcloud/stylelint-config": "^3.0.1",
     "@nextcloud/vite-config": "^1.5.3",
     "@types/markdown-it": "^14.1.2",
-    "@vitejs/plugin-vue2": "^2.3.3",
     "@vitest/coverage-v8": "^3.1.1",
     "@vue/test-utils": "^1.3.0 <2",
     "@vue/tsconfig": "^0.5.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: Ferdinand Thiessen <opensource@fthiessen.de>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-/// <reference types="vitest/config" />
+import type { ViteDevServer, Connect } from 'vite'
 
 import { createAppConfig } from '@nextcloud/vite-config'
-import type { ViteDevServer, Connect } from 'vite'
 import webpackStats from 'rollup-plugin-webpack-stats'
 import path from 'path'
 
@@ -22,7 +21,7 @@ const rewriteMiddlewarePlugin = {
 			}
 			next()
 		})
-	}
+	},
 }
 
 const config = createAppConfig({
@@ -34,6 +33,9 @@ const config = createAppConfig({
 	init: path.join(__dirname, 'src', 'init.js'),
 }, {
 	createEmptyCSSEntryPoints: true,
+	emptyOutputDirectory: {
+		additionalDirectories: ['css/'],
+	},
 	extractLicenseInformation: {
 		overwriteLicenses: {
 			khroma: 'MIT',
@@ -74,7 +76,7 @@ const config = createAppConfig({
 			server: {
 				deps: {
 					inline: [/@nextcloud.*/],
-				}
+				},
 			},
 		},
 		server: {


### PR DESCRIPTION
## 📝 Summary

CSS assets need to be cleaned if committed.
So adding `css/` to the list of directories to clean on build. Also fix some code style issues and remove unneeded dependency.

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
