### PR TITLE
refactor: cleanup main entry point

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,19 +5,11 @@
 
 // eslint-disable-next-line import/no-unresolved, n/no-missing-import
 import 'vite/modulepreload-polyfill'
+import Vue from 'vue'
+import DirectEditing from './views/DirectEditing.vue'
 
-if (document.getElementById('app-content')) {
-	Promise.all([
-		import(/* webpackChunkName: "editor" */'vue'),
-		import(/* webpackChunkName: "editor" */'./views/DirectEditing.vue'),
-	]).then((imports) => {
-		const Vue = imports[0].default
-		Vue.prototype.t = window.t
-		Vue.prototype.OCA = window.OCA
-		const DirectEditing = imports[1].default
-		const vm = new Vue({
-			render: h => h(DirectEditing),
-		})
-		vm.$mount(document.getElementById('app-content'))
-	})
-}
+Vue.prototype.t = window.t
+Vue.prototype.OCA = window.OCA
+
+const DirectView = Vue.extend(DirectEditing)
+new DirectView().$mount('#app-content')

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2,11 +2,11 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+// eslint-disable-next-line import/no-unresolved, n/no-missing-import
+import 'vite/modulepreload-polyfill'
 
 import { logger } from './helpers/logger.js'
 import { openMimetypesMarkdown, openMimetypesPlainText } from './helpers/mime.js'
-// eslint-disable-next-line import/no-unresolved, n/no-missing-import
-import 'vite/modulepreload-polyfill'
 
 /**
  * Wrapper for async registration of ViewerComponent.


### PR DESCRIPTION
### 📝 Summary

- module chunking is nowadays done automatically so we can simplify the entry point.

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
