### PR TITLE
Fix: writing during short connection failures

### DIFF
--- a/src/components/Editor/useDelayedFlag.spec.ts
+++ b/src/components/Editor/useDelayedFlag.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, expect, test, vi } from 'vitest'
+import { useDelayedFlag } from './useDelayedFlag'
+import { nextTick, ref, watch } from 'vue'
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+test('useDelayedFlag defaults to provided ref value', () => {
+	[true, false].forEach(val => {
+		const { delayed } = useDelayedFlag(ref(val))
+		expect(delayed.value).toBe(val)
+	})
+})
+
+test('switches slowly to true', async () => {
+	vi.useFakeTimers()
+	const input = ref(false)
+	const { delayed } = useDelayedFlag(input)
+	input.value = true
+	await nextTick()
+	vi.advanceTimersByTime(3000)
+	expect(delayed.value).toBe(false)
+	vi.advanceTimersByTime(5000)
+	expect(delayed.value).toBe(true)
+})
+
+test('switches fast to false', async () => {
+	vi.useFakeTimers()
+	const input = ref(true)
+	const { delayed } = useDelayedFlag(input)
+	input.value = false
+	await nextTick()
+	expect(delayed.value).toBe(true)
+	vi.advanceTimersByTime(300)
+	expect(delayed.value).toBe(false)
+})
+
+test('does not flip flop', async () => {
+	vi.useFakeTimers()
+	const input = ref(false)
+	const { delayed } = useDelayedFlag(input)
+	const probe = vi.fn()
+	watch(delayed, probe)
+	input.value = true
+	await nextTick()
+	vi.advanceTimersByTime(1000)
+	input.value = false
+	await nextTick()
+	vi.advanceTimersByTime(5000)
+	expect(delayed.value).toBe(false)
+	expect(probe).not.toBeCalled()
+})

--- a/src/components/Editor/useDelayedFlag.ts
+++ b/src/components/Editor/useDelayedFlag.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { ref, watch, type Ref } from 'vue'
+
+/**
+ * Delay the changing of the boolean
+ * @param input - ref to react to
+ */
+export function useDelayedFlag(input: Ref<boolean>): { delayed: Ref<boolean> } {
+
+	let timeout: ReturnType<typeof setTimeout> | undefined
+	const delayed = ref(input.value)
+
+	watch(input, (val) => {
+		if (timeout) {
+			clearTimeout(timeout)
+		}
+		const delay = val ? 5000 : 200
+		timeout = setTimeout(() => {
+			delayed.value = val
+		}, delay)
+
+	})
+
+	return { delayed }
+}


### PR DESCRIPTION
Fixes: #6877 

## enh(sync): add useDelayedFlag

Allow changing a flag with different delays:
* Switch it on slow.
* Switch it off fast.

Useful for errors - so they only show after a while but are resolved quickly.

Example:

const input = ref(false)
const { delayed } = useDelayedFlag(input)
...
input.value = true
// 5 seconds later delayed.value will be true
...
input.value = false
// 200 ms later delayed.value will be true

## fix(sync): allow writing during short connection failures

Delay the error message and allow editing for 5 seconds.
Also speed up the recovery by triggering push after a successful sync.
