### PR TITLE
chore(ci): Drop stable29 from CI jobs as it's end of life

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable31', 'stable30', 'stable29']
+        branches: ['main', 'master', 'stable31', 'stable30']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable31', 'stable30', 'stable29']
+        branches: ['main', 'master', 'stable31', 'stable30']
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 

--- a/renovate.json
+++ b/renovate.json
@@ -20,8 +20,7 @@
   "baseBranches": [
     "main",
     "stable31",
-    "stable30",
-    "stable29"
+    "stable30"
   ],
   "enabledManagers": [
     "npm"
@@ -110,6 +109,7 @@
         "minor"
       ],
       "matchBaseBranches": [
+        "stable29",
         "stable28",
         "stable27",
         "stable26"


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
