### PR TITLE
Refactor document status and menubar padding

### DIFF
--- a/cypress/e2e/conflict.spec.js
+++ b/cypress/e2e/conflict.spec.js
@@ -9,13 +9,13 @@ const variants = [
 	{ fixture: 'lines.txt', mime: 'text/plain' },
 	{ fixture: 'test.md', mime: 'text/markdown' },
 ]
+const getWrapper = () => cy.get('.text-editor__wrapper.has-conflicts')
 
 variants.forEach(function({ fixture, mime }) {
 	const user = randUser()
 	const fileName = fixture
 	const prefix = mime.replaceAll('/', '-')
 	describe(`${mime} (${fileName})`, function() {
-		const getWrapper = () => cy.get('.text-editor__wrapper.has-conflicts')
 
 		before(() => {
 			cy.createUser(user)
@@ -114,6 +114,36 @@ variants.forEach(function({ fixture, mime }) {
 			getWrapper().should('not.exist')
 		})
 
+	})
+})
+
+describe('conflict dialog scroll behaviour', function() {
+	const user = randUser()
+	const fileName = 'long.md'
+
+	before(() => {
+		cy.createUser(user)
+	})
+
+	it('document status and collision resolution dialog elements are sticky', function() {
+		cy.login(user)
+		cy.createTestFolder()
+
+		createConflict(fileName, 'text/markdown')
+
+		cy.openFile(fileName)
+
+		cy.get('.text-editor .document-status')
+			.should('contain', 'The file was overwritten.')
+		getWrapper()
+			.find('.text-editor__main h2')
+			.contains('Third subheading')
+			.scrollIntoView()
+
+		cy.get('.text-editor #resolve-conflicts')
+			.should('be.visible')
+		cy.get('.text-editor .document-status')
+			.should('be.visible')
 	})
 })
 

--- a/cypress/e2e/nodes/CodeBlock.spec.js
+++ b/cypress/e2e/nodes/CodeBlock.spec.js
@@ -77,7 +77,7 @@ describe('Front matter support', function() {
 				cy.getContent().find('code').eq(1).find('.hljs-keyword').eq(1).contains('function')
 
 				// Mermaid diagram
-				cy.getEditor().find('.text-editor__wrapper').scrollTo('bottom')
+				cy.get('#viewer .modal-container__content').scrollTo('bottom')
 				cy.getContent().find('.split-view__preview').eq(2).should('be.visible')
 				cy.get('.code-block').eq(2).find('code').should('not.be.visible')
 				cy.get('.split-view__preview').find('svg .erDiagramTitleText')

--- a/cypress/fixtures/long.md
+++ b/cypress/fixtures/long.md
@@ -1,0 +1,21 @@
+# Hello world
+
+## First subheading
+
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+
+## Second subheading
+
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+
+## Third subheading
+
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.

--- a/src/components/CollisionResolveDialog.vue
+++ b/src/components/CollisionResolveDialog.vue
@@ -72,7 +72,10 @@ export default {
 
 <style scoped lang="scss">
 #resolve-conflicts {
+	position: sticky;
+	top: 0;
 	display: flex;
+	z-index: 1;
 	margin: auto;
 	padding: 0 var(--default-grid-baseline);
 	button {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -15,6 +15,7 @@
 		<CollisionResolveDialog v-if="isResolvingConflict" :sync-error="syncError" />
 		<Wrapper
 			v-if="displayed"
+			:is-mobile="isMobile"
 			:is-resolving-conflict="isResolvingConflict"
 			:has-connection-issue="requireReconnect"
 			:content-loaded="contentLoaded"
@@ -984,7 +985,9 @@ export default {
 }
 
 .text-editor .text-editor__wrapper.has-conflicts {
-	height: calc(100% - 50px);
+	// Make space for document status and conflict resolving dialog
+	height: calc(100% - 48px - 54px);
+	overflow-y: auto;
 }
 
 #body-public {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -15,7 +15,6 @@
 		<CollisionResolveDialog v-if="isResolvingConflict" :sync-error="syncError" />
 		<Wrapper
 			v-if="displayed"
-			:is-mobile="isMobile"
 			:is-resolving-conflict="isResolvingConflict"
 			:has-connection-issue="requireReconnect"
 			:content-loaded="contentLoaded"

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -9,6 +9,7 @@
 		ref="el"
 		data-text-el="editor-container"
 		class="text-editor"
+		:class="{ 'is-mobile': isMobile }"
 		tabindex="-1"
 		@keydown.stop="onKeyDown">
 		<SkeletonLoading v-if="showLoadingSkeleton" />
@@ -970,6 +971,13 @@ export default {
 .modal-container .text-editor {
 	top: 0;
 	height: calc(100vh - var(--header-height));
+
+	&.is-mobile {
+		// TODO: Why is this required to prevent small scrolling container on mobile with short content?
+		height: calc(
+			100vh - var(--header-height) - 2 * var(--default-grid-baseline)
+		);
+	}
 }
 
 .text-editor {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -63,13 +63,13 @@
 				v-if="isResolvingConflict"
 				:content="syncError.data.outsideChange"
 				:is-rich-editor="isRichEditor" />
-			<DocumentStatus
-				:idle="idle"
-				:lock="lock"
-				:sync-error="syncError"
-				:has-connection-issue="requireReconnect"
-				@reconnect="reconnect" />
 		</Wrapper>
+		<DocumentStatus
+			:idle="idle"
+			:lock="lock"
+			:sync-error="syncError"
+			:has-connection-issue="requireReconnect"
+			@reconnect="reconnect" />
 		<Assistant v-if="hasEditor" />
 		<Translate
 			:show="translateModal"

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -974,7 +974,8 @@ export default {
 }
 
 .text-editor {
-	display: block;
+	display: flex;
+	flex-direction: column;
 	width: 100%;
 	max-width: 100%;
 	height: 100%;

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -268,6 +268,7 @@ export default {
 			filteredSessions: {},
 
 			idle: false,
+			lock: null,
 			dirty: false,
 			contentLoaded: false,
 			syncError: null,

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1016,8 +1016,8 @@ export default {
 	height: var(
 		--default-clickable-area
 	); // important for mobile so that the buttons are always inside the container
-	padding-top: 3px;
-	padding-bottom: 3px;
+	border-bottom: 1px solid var(--color-border);
+	padding-block: var(--default-grid-baseline);
 }
 
 .text-editor--readonly-bar,
@@ -1060,7 +1060,10 @@ export default {
 	width: 50%;
 	#read-only-editor {
 		margin: 0px auto;
-		padding-top: 50px;
+		// Add height of the menubar as padding-top
+		padding-top: calc(
+			var(--default-clickable-area) + 2 * var(--default-grid-baseline)
+		);
 		overflow: initial;
 	}
 }

--- a/src/components/Editor/DocumentStatus.vue
+++ b/src/components/Editor/DocumentStatus.vue
@@ -70,7 +70,7 @@ export default {
 
 <style scoped lang="scss">
 	.document-status {
-		position: absolute;
+		position: sticky;
 		bottom: calc(var(--default-grid-baseline) * 2);
 		z-index: 100000;
 		// max-height: 50px;

--- a/src/components/Editor/DocumentStatus.vue
+++ b/src/components/Editor/DocumentStatus.vue
@@ -74,7 +74,7 @@ export default {
 		bottom: calc(var(--default-grid-baseline) * 2);
 		z-index: 100000;
 		// max-height: 50px;
-		margin: auto;
+		margin-inline: auto;
 		display: flex;
 		width: 100%;
 		justify-content: center;

--- a/src/components/Editor/MainContainer.vue
+++ b/src/components/Editor/MainContainer.vue
@@ -29,6 +29,8 @@ export default {
 
 <style scoped lang="scss">
 	.text-editor__main, .editor {
+		display: flex;
+		flex-direction: column;
 		background: var(--color-main-background);
 		color: var(--color-main-text);
 		background-clip: padding-box;
@@ -39,12 +41,9 @@ export default {
 	}
 
 	.text-editor__main {
-		display: flex;
-		flex-direction: column;
-
 		&.is-mobile {
+			flex-grow: 1;
 			flex-direction: column-reverse;
-			height: 100%;
 		}
 	}
 </style>

--- a/src/components/Editor/MainContainer.vue
+++ b/src/components/Editor/MainContainer.vue
@@ -37,4 +37,14 @@ export default {
 		position: relative;
 		width: 100%;
 	}
+
+	.text-editor__main {
+		display: flex;
+		flex-direction: column;
+
+		&.is-mobile {
+			flex-direction: column-reverse;
+			height: 100%;
+		}
+	}
 </style>

--- a/src/components/Editor/MarkdownContentEditor.vue
+++ b/src/components/Editor/MarkdownContentEditor.vue
@@ -4,8 +4,7 @@
 -->
 
 <template>
-	<Wrapper :is-mobile="isMobile"
-		:content-loaded="true"
+	<Wrapper :content-loaded="true"
 		:show-outline-outside="showOutlineOutside"
 		@outline-toggled="outlineToggled">
 		<MainContainer>
@@ -35,12 +34,10 @@ import markdownit from '../../markdownit/index.js'
 import { RichText, FocusTrap } from '../../extensions/index.js'
 import ReadonlyBar from '../Menu/ReadonlyBar.vue'
 import ContentContainer from './ContentContainer.vue'
-import isMobile from '../../mixins/isMobile.js'
 
 export default {
 	name: 'MarkdownContentEditor',
 	components: { ContentContainer, ReadonlyBar, MenuBar, MainContainer, Wrapper },
-	mixins: [isMobile],
 	provide() {
 		const val = {}
 

--- a/src/components/Editor/MarkdownContentEditor.vue
+++ b/src/components/Editor/MarkdownContentEditor.vue
@@ -4,7 +4,8 @@
 -->
 
 <template>
-	<Wrapper :content-loaded="true"
+	<Wrapper :is-mobile="isMobile"
+		:content-loaded="true"
 		:show-outline-outside="showOutlineOutside"
 		@outline-toggled="outlineToggled">
 		<MainContainer>
@@ -34,10 +35,12 @@ import markdownit from '../../markdownit/index.js'
 import { RichText, FocusTrap } from '../../extensions/index.js'
 import ReadonlyBar from '../Menu/ReadonlyBar.vue'
 import ContentContainer from './ContentContainer.vue'
+import isMobile from '../../mixins/isMobile.js'
 
 export default {
 	name: 'MarkdownContentEditor',
 	components: { ContentContainer, ReadonlyBar, MenuBar, MainContainer, Wrapper },
+	mixins: [isMobile],
 	provide() {
 		const val = {}
 

--- a/src/components/Editor/MediaHandler.vue
+++ b/src/components/Editor/MediaHandler.vue
@@ -6,7 +6,7 @@
 <template>
 	<div class="editor editor-media-handler"
 		data-text-el="editor-media-handler"
-		:class="{ draggedOver, 'editor--mobile': isMobile }"
+		:class="{ draggedOver, 'is-mobile': isMobile }"
 		@image-paste="onPaste"
 		@dragover.prevent.stop="setDraggedOver(true)"
 		@dragleave.prevent.stop="setDraggedOver(false)"
@@ -206,14 +206,3 @@ export default {
 	},
 }
 </script>
-
-<style scoped lang="scss">
-
-.editor--mobile {
-	display: flex;
-	flex-direction: column-reverse;
-	height: 100%;
-	overflow: auto;
-}
-
-</style>

--- a/src/components/Editor/Wrapper.vue
+++ b/src/components/Editor/Wrapper.vue
@@ -6,7 +6,6 @@
 <template>
 	<div class="text-editor__wrapper"
 		:class="{
-			'is-mobile': isMobile,
 			'has-conflicts': isResolvingConflict,
 			'is-rich-workspace': $isRichWorkspace,
 			'is-rich-editor': $isRichEditor,
@@ -45,10 +44,6 @@ export default {
 	},
 
 	props: {
-		isMobile: {
-			type: Boolean,
-			require: true,
-		},
 		isResolvingConflict: {
 			type: Boolean,
 			default: false,
@@ -135,10 +130,6 @@ export default {
 		flex-grow: 1;
 
 		width: 100%;
-		&.is-mobile {
-			// Required for sticky bottom toolbar
-			height: 100%;
-		}
 
 		.ProseMirror {
 			margin-top: 0 !important;

--- a/src/components/Editor/Wrapper.vue
+++ b/src/components/Editor/Wrapper.vue
@@ -130,9 +130,9 @@ export default {
 </script>
 
 <style scoped lang="scss">
-
 	.text-editor__wrapper {
 		display: flex;
+		flex-grow: 1;
 
 		width: 100%;
 		&.is-mobile {
@@ -144,5 +144,4 @@ export default {
 			margin-top: 0 !important;
 		}
 	}
-
 </style>

--- a/src/components/Editor/Wrapper.vue
+++ b/src/components/Editor/Wrapper.vue
@@ -130,7 +130,6 @@ export default {
 		display: flex;
 		width: 100%;
 		height: 100%;
-		overflow: auto;
 
 		.ProseMirror {
 			margin-top: 0 !important;

--- a/src/components/Editor/Wrapper.vue
+++ b/src/components/Editor/Wrapper.vue
@@ -6,6 +6,7 @@
 <template>
 	<div class="text-editor__wrapper"
 		:class="{
+			'is-mobile': isMobile,
 			'has-conflicts': isResolvingConflict,
 			'is-rich-workspace': $isRichWorkspace,
 			'is-rich-editor': $isRichEditor,
@@ -44,9 +45,13 @@ export default {
 	},
 
 	props: {
-		isResolvingConflict: {
+		isMobile: {
 			type: Boolean,
 			require: true,
+		},
+		isResolvingConflict: {
+			type: Boolean,
+			default: false,
 		},
 		hasConnectionIssue: {
 			type: Boolean,
@@ -128,8 +133,12 @@ export default {
 
 	.text-editor__wrapper {
 		display: flex;
+
 		width: 100%;
-		height: 100%;
+		&.is-mobile {
+			// Required for sticky bottom toolbar
+			height: 100%;
+		}
 
 		.ProseMirror {
 			margin-top: 0 !important;

--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -13,6 +13,7 @@
 			'text-menubar--ready': isReady,
 			'text-menubar--hide': isHidden,
 			'text-menubar--is-workspace': $isRichWorkspace,
+			'is-mobile': $isMobile,
 		}">
 		<HelpModal v-if="displayHelp" @close="hideHelp" />
 
@@ -241,6 +242,11 @@ export default {
 		display: flex;
 		justify-content: flex-end;
 		align-items: center;
+
+		&.is-mobile {
+			border-top: 1px solid var(--color-border);
+			border-bottom: unset;
+		}
 
 		&.text-menubar--ready:not(.text-menubar--hide) {
 			visibility: visible;

--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -227,6 +227,8 @@ export default {
 		--background-blur: blur(10px);
 		position: sticky;
 		top: 0;
+		bottom: var(--default-grid-baseline);
+		width: 100%;
 		z-index: 10021; // above modal-header so menubar is always on top
 		background-color: var(--color-main-background-translucent);
 		backdrop-filter: var(--background-blur);

--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -232,8 +232,7 @@ export default {
 		backdrop-filter: var(--background-blur);
 		max-height: var(--default-clickable-area); // important for mobile so that the buttons are always inside the container
 		border-bottom: 1px solid var(--color-border);
-		padding-top:3px;
-		padding-bottom: 3px;
+		padding-block: var(--default-grid-baseline);
 
 		visibility: hidden;
 

--- a/src/components/Menu/ReadonlyBar.vue
+++ b/src/components/Menu/ReadonlyBar.vue
@@ -55,9 +55,9 @@ export default defineComponent({
 <style scoped>
 .text-readonly-bar {
 	display: flex;
+	height: var(--default-clickable-area);
 	border-bottom: 1px solid var(--color-border);
-	padding-top: 3px;
-	padding-bottom: 3px;
+	padding-block: var(--default-grid-baseline);
 }
 .text-readonly-bar__entries {
 	display: flex;


### PR DESCRIPTION
### 📝 Summary

* fix: Make CollisionResolveDialog and DocumentStatus sticky
* fix: Remove overflow property from editor wrapper
* refactor(css): Use default-grid-baseline for menubar padding
* fix(Editor): Add property `lock` to data
* test(cy): Add regression test for sticky elements

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
