### PR TITLE
fix(lint): fix prettier warnings

### DIFF
--- a/src/components/Assistant.vue
+++ b/src/components/Assistant.vue
@@ -234,9 +234,9 @@ export default {
 	computed: {
 		showAssistant() {
 			return (
-				!this.$isRichWorkspace &&
-				!this.$isPublic &&
-				window.OCA.Assistant?.openAssistantForm
+				!this.$isRichWorkspace
+				&& !this.$isPublic
+				&& window.OCA.Assistant?.openAssistantForm
 			)
 		},
 		identifier() {
@@ -288,9 +288,9 @@ export default {
 	methods: {
 		async fetchTasks() {
 			const result = await axios.get(
-				generateOcsUrl('/taskprocessing/tasks/app/text') +
-					'?customId=' +
-					this.identifier,
+				generateOcsUrl('/taskprocessing/tasks/app/text')
+					+ '?customId='
+					+ this.identifier,
 			)
 
 			const filteredTasks = result.data.ocs.data.tasks.filter((t) =>
@@ -307,8 +307,8 @@ export default {
 		},
 		async checkNotification(event) {
 			if (
-				event.notification.app !== 'assistant' ||
-				event.notification.actions[0].type !== 'WEB'
+				event.notification.app !== 'assistant'
+				|| event.notification.actions[0].type !== 'WEB'
 			) {
 				return
 			}

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -303,8 +303,8 @@ export default {
 		},
 		isRichEditor() {
 			return (
-				loadState('text', 'rich_editing_enabled', true) &&
-				this.mime === 'text/markdown'
+				loadState('text', 'rich_editing_enabled', true)
+				&& this.mime === 'text/markdown'
 			)
 		},
 		fileExtension() {
@@ -325,10 +325,10 @@ export default {
 		},
 		renderRichEditorMenus() {
 			return (
-				this.contentLoaded &&
-				this.isRichEditor &&
-				!this.syncError &&
-				!this.readOnly
+				this.contentLoaded
+				&& this.isRichEditor
+				&& !this.syncError
+				&& !this.readOnly
 			)
 		},
 		renderMenus() {
@@ -522,8 +522,8 @@ export default {
 
 			const removedSessions = Object.keys(this.filteredSessions).filter(
 				(sessionId) =>
-					!currentSessionIds.includes(sessionId) &&
-					!currentGuestIds.includes(sessionId),
+					!currentSessionIds.includes(sessionId)
+					&& !currentGuestIds.includes(sessionId),
 			)
 
 			for (const index in removedSessions) {
@@ -535,8 +535,8 @@ export default {
 				if (this.filteredSessions[sessionKey]) {
 					// update timestamp if relevant
 					if (
-						this.filteredSessions[sessionKey].lastContact <
-						session.lastContact
+						this.filteredSessions[sessionKey].lastContact
+						< session.lastContact
 					) {
 						set(
 							this.filteredSessions[sessionKey],
@@ -665,9 +665,9 @@ export default {
 
 		onSync({ steps, document }) {
 			this.hasConnectionIssue =
-				this.$syncService.backend.fetcher === 0 ||
-				!this.$providers[0].wsconnected ||
-				this.$syncService.pushError > 0
+				this.$syncService.backend.fetcher === 0
+				|| !this.$providers[0].wsconnected
+				|| this.$syncService.pushError > 0
 			if (this.$syncService.pushError > 0) {
 				// successfully received steps - so let's try and also push
 				this.$syncService.sendStepsNow()
@@ -689,9 +689,9 @@ export default {
 			}
 
 			if (
-				type === ERROR_TYPE.SAVE_COLLISSION &&
-				(!this.syncError ||
-					this.syncError.type !== ERROR_TYPE.SAVE_COLLISSION)
+				type === ERROR_TYPE.SAVE_COLLISSION
+				&& (!this.syncError
+					|| this.syncError.type !== ERROR_TYPE.SAVE_COLLISSION)
 			) {
 				this.contentLoaded = true
 				this.syncError = {
@@ -700,8 +700,8 @@ export default {
 				}
 			}
 			if (
-				type === ERROR_TYPE.CONNECTION_FAILED ||
-				type === ERROR_TYPE.SOURCE_NOT_FOUND
+				type === ERROR_TYPE.CONNECTION_FAILED
+				|| type === ERROR_TYPE.SOURCE_NOT_FOUND
 			) {
 				this.hasConnectionIssue = true
 			}
@@ -728,8 +728,8 @@ export default {
 			if (Object.prototype.hasOwnProperty.call(state, 'dirty')) {
 				// ignore initial loading and other automated changes before first user change
 				if (
-					this.$editor &&
-					(this.$editor.can().undo() || this.$editor.can().redo())
+					this.$editor
+					&& (this.$editor.can().undo() || this.$editor.can().redo())
 				) {
 					this.dirty = state.dirty
 					if (this.dirty) {
@@ -898,11 +898,11 @@ export default {
 			}
 
 			if (
-				event.key === 'Tab' &&
-				!event.shiftKey &&
-				!event.ctrlKey &&
-				!event.metaKey &&
-				this.$editor.isActive('codeBlock')
+				event.key === 'Tab'
+				&& !event.shiftKey
+				&& !event.ctrlKey
+				&& !event.metaKey
+				&& this.$editor.isActive('codeBlock')
 			) {
 				this.$editor.commands.insertContent('\t')
 				this.$editor.commands.focus()

--- a/src/components/SuggestionsBar.vue
+++ b/src/components/SuggestionsBar.vue
@@ -153,8 +153,8 @@ export default {
 						)
 						this.setLink(url.href, fileInfo.name)
 						this.startPath =
-							fileInfo.path +
-							(fileInfo.type === 'dir' ? `/${fileInfo.name}/` : '')
+							fileInfo.path
+							+ (fileInfo.type === 'dir' ? `/${fileInfo.name}/` : '')
 					})
 				})
 				.catch(() => {

--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -115,9 +115,9 @@ export default {
 		/** @return {boolean} */
 		useSourceView() {
 			return (
-				this.source &&
-				(this.fileVersion || !this.fileid || this.isEmbedded) &&
-				!this.hasToggledInteractiveEmbedding
+				this.source
+				&& (this.fileVersion || !this.fileid || this.isEmbedded)
+				&& !this.hasToggledInteractiveEmbedding
 			)
 		},
 

--- a/src/extensions/FocusTrap.js
+++ b/src/extensions/FocusTrap.js
@@ -12,9 +12,9 @@ const toggleFocusTrap = ({ editor }) => {
 	const activeTrap = trapStack[trapStack.length - 1]
 
 	const possibleEditorTabCommand =
-		editor.can().sinkListItem('listItem') ||
-		editor.can().goToNextCell() ||
-		editor.can().goToPreviousCell()
+		editor.can().sinkListItem('listItem')
+		|| editor.can().goToNextCell()
+		|| editor.can().goToPreviousCell()
 
 	if (possibleEditorTabCommand) {
 		activeTrap?.pause()

--- a/src/extensions/Keymap.js
+++ b/src/extensions/Keymap.js
@@ -20,9 +20,9 @@ const Keymap = Extension.create({
 					handleKeyDown(view, event) {
 						const key = event.key || event.keyCode
 						if (
-							(event.ctrlKey || event.metaKey) &&
-							!event.shiftKey &&
-							(key === 'f' || key === 70)
+							(event.ctrlKey || event.metaKey)
+							&& !event.shiftKey
+							&& (key === 'f' || key === 70)
 						) {
 							// We need to stop propagation and dispatch the event on the window
 							// in order to force triggering the browser native search in the text editor

--- a/src/extensions/Mention.js
+++ b/src/extensions/Mention.js
@@ -17,9 +17,9 @@ export default TipTapMention.extend({
 					return {
 						id: decodeURIComponent(element.getAttribute('data-id')),
 						label:
-							element.innerText ||
-							element.textContent ||
-							element.getAttribute('data-label'),
+							element.innerText
+							|| element.textContent
+							|| element.getAttribute('data-label'),
 					}
 				},
 				priority: 100,

--- a/src/extensions/UserColor.js
+++ b/src/extensions/UserColor.js
@@ -17,11 +17,11 @@ const UserColor = Extension.create({
 			clientID: 0,
 			color: (clientID) => {
 				return (
-					'#' +
-					Math.floor(
+					'#'
+					+ Math.floor(
 						Math.abs(Math.sin(clientID) * 16777215) % 16777215,
-					).toString(16) +
-					'aa'
+					).toString(16)
+					+ 'aa'
 				)
 			},
 			name: (clientID) => {
@@ -76,9 +76,9 @@ const UserColor = Extension.create({
 								return Decoration.inline(span.from, span.to, {
 									class: 'author-annotation',
 									style:
-										'background-color: ' +
-										this.spec.color(clientID) +
-										'66;',
+										'background-color: '
+										+ this.spec.color(clientID)
+										+ '66;',
 									title: this.spec.name(clientID),
 								})
 							})

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -40,9 +40,9 @@ const registerFileCreate = () => {
 				id: 'file',
 				displayName: t('text', 'New text file'),
 				templateName:
-					t('text', 'New text file') +
-					'.' +
-					loadState('text', 'default_file_extension'),
+					t('text', 'New text file')
+					+ '.'
+					+ loadState('text', 'default_file_extension'),
 				iconClass: 'icon-filetype-text',
 				fileType: 'file',
 				actionLabel: t('text', 'Create new text file'),

--- a/src/markdownit/hardbreak.js
+++ b/src/markdownit/hardbreak.js
@@ -16,9 +16,9 @@ export default function keepHardbreakSyntax(md) {
 	md.inline.ruler.at('newline', (state, silent) => {
 		const rval = markdownitNewline(state, silent)
 		if (
-			rval &&
-			state.tokens.length &&
-			state.tokens[state.tokens.length - 1].type === 'hardbreak'
+			rval
+			&& state.tokens.length
+			&& state.tokens[state.tokens.length - 1].type === 'hardbreak'
 		)
 			state.tokens[state.tokens.length - 1].attrSet('syntax', '  ')
 		return rval
@@ -28,9 +28,9 @@ export default function keepHardbreakSyntax(md) {
 	md.inline.ruler.at('escape', (state, silent) => {
 		const rval = markdownitEscape(state, silent)
 		if (
-			rval &&
-			state.tokens.length &&
-			state.tokens[state.tokens.length - 1].type === 'hardbreak'
+			rval
+			&& state.tokens.length
+			&& state.tokens[state.tokens.length - 1].type === 'hardbreak'
 		)
 			state.tokens[state.tokens.length - 1].attrSet('syntax', '\\')
 		return rval

--- a/src/markdownit/preview.js
+++ b/src/markdownit/preview.js
@@ -11,15 +11,15 @@
 function isPreviewLinkInParagraph(tokens, i) {
 	const [prev, cur, next] = tokens.slice(i - 1, i + 2)
 	return (
-		prev?.type === 'paragraph_open' &&
-		cur.type === 'inline' &&
-		cur.children &&
-		cur.children.length === 3 &&
-		cur.children[0].type === 'link_open' &&
-		cur.children[0].attrGet('title') === 'preview' &&
-		cur.children[1].type === 'text' &&
-		cur.children[2].type === 'link_close' &&
-		next.type === 'paragraph_close'
+		prev?.type === 'paragraph_open'
+		&& cur.type === 'inline'
+		&& cur.children
+		&& cur.children.length === 3
+		&& cur.children[0].type === 'link_open'
+		&& cur.children[0].attrGet('title') === 'preview'
+		&& cur.children[1].type === 'text'
+		&& cur.children[2].type === 'link_close'
+		&& next.type === 'paragraph_close'
 	)
 }
 

--- a/src/markdownit/splitMixedLists.js
+++ b/src/markdownit/splitMixedLists.js
@@ -25,8 +25,8 @@ export default function splitMixedLists(md) {
 			}
 			const splitBefore = findChildOf(tokens, i, (child) => {
 				return (
-					child.nesting === 1 &&
-					includesClass(child, 'task-list-item') !== startsWithTask
+					child.nesting === 1
+					&& includesClass(child, 'task-list-item') !== startsWithTask
 				)
 			})
 			if (splitBefore > i) {

--- a/src/markdownit/taskLists.ts
+++ b/src/markdownit/taskLists.ts
@@ -111,10 +111,10 @@ function findParentToken(tokens: Token[], index: number): Token | undefined {
  */
 function isTodoItem(tokens: Token[], index: number): boolean {
 	return (
-		isInline(tokens[index]) &&
-		isParagraph(tokens[index - 1]) &&
-		isListItem(tokens[index - 2]) &&
-		startsWithTodoMarkdown(tokens[index])
+		isInline(tokens[index])
+		&& isParagraph(tokens[index - 1])
+		&& isListItem(tokens[index - 2])
+		&& startsWithTodoMarkdown(tokens[index])
 	)
 }
 

--- a/src/marks/Link.js
+++ b/src/marks/Link.js
@@ -152,8 +152,8 @@ const Link = TipTapLink.extend({
 			// remove upstream link click handle plugin
 			.filter(({ key }) => {
 				return (
-					!key.startsWith('handleClickLink') &&
-					!key.startsWith('textHandleClickLink')
+					!key.startsWith('handleClickLink')
+					&& !key.startsWith('textHandleClickLink')
 				)
 			})
 

--- a/src/nodes/Callouts.js
+++ b/src/nodes/Callouts.js
@@ -34,11 +34,11 @@ export default Node.create({
 				rendered: false,
 				parseHTML: (element) => {
 					return (
-						element.getAttribute('data-callout') ||
-						typesAvailable.find((type) =>
+						element.getAttribute('data-callout')
+						|| typesAvailable.find((type) =>
 							element.classList.contains(type),
-						) ||
-						(element.classList.contains('warning') && 'warn')
+						)
+						|| (element.classList.contains('warning') && 'warn')
 					)
 				},
 				renderHTML: (attributes) => {

--- a/src/nodes/CodeBlockView.vue
+++ b/src/nodes/CodeBlockView.vue
@@ -174,15 +174,15 @@ export default {
 		},
 		showCode() {
 			return (
-				!this.supportPreview ||
-				this.viewMode === 'code' ||
-				this.viewMode === 'side-by-side'
+				!this.supportPreview
+				|| this.viewMode === 'code'
+				|| this.viewMode === 'side-by-side'
 			)
 		},
 		showPreview() {
 			return (
-				this.supportPreview &&
-				(this.viewMode === 'preview' || this.viewMode === 'side-by-side')
+				this.supportPreview
+				&& (this.viewMode === 'preview' || this.viewMode === 'side-by-side')
 			)
 		},
 		defaultMode() {

--- a/src/nodes/Image.js
+++ b/src/nodes/Image.js
@@ -45,8 +45,8 @@ const Image = TiptapImage.extend({
 					handleDrop: (view, event, slice) => {
 						// only catch the drop if it contains files
 						if (
-							event.dataTransfer.files &&
-							event.dataTransfer.files.length > 0
+							event.dataTransfer.files
+							&& event.dataTransfer.files.length > 0
 						) {
 							const coordinates = view.posAtCoords({
 								left: event.clientX,
@@ -66,8 +66,8 @@ const Image = TiptapImage.extend({
 					handlePaste: (view, event, slice) => {
 						// only catch the paste if it contains files
 						if (
-							event.clipboardData.files &&
-							event.clipboardData.files.length > 0
+							event.clipboardData.files
+							&& event.clipboardData.files.length > 0
 						) {
 							// let the editor wrapper catch this custom event
 							const customEvent = new CustomEvent('image-paste', {

--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -293,14 +293,14 @@ export default {
 		handleAttachmentClick() {
 			// Open in viewer if possible
 			if (
-				OCA.Viewer &&
+				OCA.Viewer
 				// Viewer is not in use
-				!OCA.Viewer.file &&
+				&& !OCA.Viewer.file
 				// Viewer supports mimetype
-				OCA.Viewer.mimetypes.indexOf(this.attachment.mimetype) !== -1 &&
+				&& OCA.Viewer.mimetypes.indexOf(this.attachment.mimetype) !== -1
 				// Attachment has davPath, i.e. is native attachment and not in public share
 				//  (in public share we probably don't have DAV access)
-				this.attachment.davPath
+				&& this.attachment.davPath
 			) {
 				// Viewer exists, is not in use and supports mimetype
 				OCA.Viewer.open({ path: this.attachment.davPath })

--- a/src/nodes/Paragraph.js
+++ b/src/nodes/Paragraph.js
@@ -30,8 +30,8 @@ const Paragraph = TiptapParagraph.extend({
 				const previousNode = parent.child(index - 1)
 				// Check this and the previous sibling are paragraphs
 				if (
-					node.type.name === this.name &&
-					previousNode.type.name === this.name
+					node.type.name === this.name
+					&& previousNode.type.name === this.name
 				) {
 					return this.editor.chain().joinBackward().setHardBreak().run()
 				}

--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -79,8 +79,8 @@ export default Node.create({
 				() =>
 				({ state, chain }) => {
 					return (
-						previewPossible(state) &&
-						chain()
+						previewPossible(state)
+						&& chain()
 							.setNode(
 								this.name,
 								previewAttributesFromSelection(state),
@@ -97,8 +97,8 @@ export default Node.create({
 				() =>
 				({ state, chain }) => {
 					return (
-						isActive(this.name, this.attributes, state) &&
-						chain().setNode('paragraph').run()
+						isActive(this.name, this.attributes, state)
+						&& chain().setNode('paragraph').run()
 					)
 				},
 
@@ -183,8 +183,8 @@ function previewPossible({ selection }) {
  */
 function hasOtherContent(node) {
 	return (
-		node.childCount > 2 ||
-		(node.childCount === 2 && node.lastChild.textContent.trim())
+		node.childCount > 2
+		|| (node.childCount === 2 && node.lastChild.textContent.trim())
 	)
 }
 

--- a/src/nodes/TaskItem.js
+++ b/src/nodes/TaskItem.js
@@ -97,18 +97,18 @@ const TaskItem = TipTapTaskItem.extend({
 							position,
 							function (node) {
 								return (
-									node.type === schema.nodes.taskItem ||
-									node.type === schema.nodes.listItem
+									node.type === schema.nodes.taskItem
+									|| node.type === schema.nodes.listItem
 								)
 							},
 						)
 						const isListClicked =
 							event.target.tagName.toLowerCase() === 'li'
 						if (
-							!isListClicked ||
-							!parentList ||
-							parentList.node.type !== schema.nodes.taskItem ||
-							!view.editable
+							!isListClicked
+							|| !parentList
+							|| parentList.node.type !== schema.nodes.taskItem
+							|| !view.editable
 						) {
 							return
 						}

--- a/src/plugins/currentLineMenu.js
+++ b/src/plugins/currentLineMenu.js
@@ -48,8 +48,8 @@ export default function currentLineMenu({ editor }) {
 					return { decorations: DecorationSet.empty }
 				}
 				const decorations =
-					mapDecorations(value, tr, currentParagraph) ||
-					currentParagraphDecorations(
+					mapDecorations(value, tr, currentParagraph)
+					|| currentParagraphDecorations(
 						newState.doc,
 						currentParagraph,
 						editor,
@@ -107,11 +107,11 @@ function getCurrentParagraph({ selection }) {
 	const isRootDepth = depth === 1
 	const noLinkPickerYet = !parent.textContent.match(/(^| )\/$/)
 	if (
-		isRootDepth &&
-		noLinkPickerYet &&
-		selection.empty &&
-		parent.isTextblock &&
-		!parent.type.spec.code
+		isRootDepth
+		&& noLinkPickerYet
+		&& selection.empty
+		&& parent.isTextblock
+		&& !parent.type.spec.code
 	) {
 		return { pos }
 	}

--- a/src/plugins/extractLinkParagraphs.js
+++ b/src/plugins/extractLinkParagraphs.js
@@ -61,8 +61,8 @@ function previewPossible(node) {
  */
 function hasOtherContent(node) {
 	return (
-		node.childCount > 2 ||
-		(node.childCount === 2 && node.lastChild.textContent.trim())
+		node.childCount > 2
+		|| (node.childCount === 2 && node.lastChild.textContent.trim())
 	)
 }
 

--- a/src/plugins/headingAnchor.js
+++ b/src/plugins/headingAnchor.js
@@ -33,8 +33,8 @@ export default function headingAnchor() {
 				}
 				const headings = extractHeadings(newState.doc)
 				const decorations =
-					mapDecorations(value, tr, headings) ||
-					anchorDecorations(newState.doc, headings)
+					mapDecorations(value, tr, headings)
+					|| anchorDecorations(newState.doc, headings)
 				return { headings, decorations }
 			},
 		},

--- a/src/plugins/links.js
+++ b/src/plugins/links.js
@@ -95,10 +95,10 @@ export function linkBubble(options) {
 			handleClickOn: (view, pos, _node, _nodePos, event, direct) => {
 				// Only regard left clicks without Ctrl/Meta
 				if (
-					!direct ||
-					event.button !== 0 ||
-					event.ctrlKey ||
-					event.metaKey
+					!direct
+					|| event.button !== 0
+					|| event.ctrlKey
+					|| event.metaKey
 				) {
 					return false
 				}
@@ -138,11 +138,11 @@ export function linkClicking() {
 				// Open link in new tab on middle click
 				auxclick: (view, event) => {
 					if (
-						event.target.closest('a') &&
-						event.button === 1 &&
-						!event.ctrlKey &&
-						!event.metaKey &&
-						!event.shiftKey
+						event.target.closest('a')
+						&& event.button === 1
+						&& !event.ctrlKey
+						&& !event.metaKey
+						&& !event.shiftKey
 					) {
 						event.preventDefault()
 						event.stopImmediatePropagation()

--- a/src/plugins/previewOptions.js
+++ b/src/plugins/previewOptions.js
@@ -48,8 +48,8 @@ export default function previewOptions({ editor }) {
 				}
 				const linkParagraphs = extractLinkParagraphs(newState.doc)
 				const decorations =
-					mapDecorations(value, tr, linkParagraphs) ||
-					linkParagraphDecorations(newState.doc, linkParagraphs, editor)
+					mapDecorations(value, tr, linkParagraphs)
+					|| linkParagraphDecorations(newState.doc, linkParagraphs, editor)
 				return { linkParagraphs, decorations }
 			},
 		},
@@ -109,8 +109,8 @@ function linkParagraphsChanged(current, prev) {
  */
 const isDifferentFrom = (other) => (linkParagraph, i) => {
 	return (
-		linkParagraph.type !== other[i].type ||
-		linkParagraph.nodeSize !== other[i].nodeSize
+		linkParagraph.type !== other[i].type
+		|| linkParagraph.nodeSize !== other[i].nodeSize
 	)
 }
 

--- a/src/plugins/searchDecorations.js
+++ b/src/plugins/searchDecorations.js
@@ -31,10 +31,10 @@ export default function searchDecorations() {
 				const matchAllChanged = newSearch.matchAll !== oldSearch.matchAll
 
 				if (
-					tr.docChanged ||
-					queryChanged ||
-					indexChanged ||
-					matchAllChanged
+					tr.docChanged
+					|| queryChanged
+					|| indexChanged
+					|| matchAllChanged
 				) {
 					const { results, total, index } = runSearch(
 						tr.doc,

--- a/src/services/AttachmentResolver.js
+++ b/src/services/AttachmentResolver.js
@@ -137,8 +137,8 @@ export default class AttachmentResolver {
  */
 function isDirectUrl(src) {
 	return (
-		src.startsWith('http://') ||
-		src.startsWith('https://') ||
-		src.startsWith('data:')
+		src.startsWith('http://')
+		|| src.startsWith('https://')
+		|| src.startsWith('data:')
 	)
 }

--- a/src/services/SessionApi.js
+++ b/src/services/SessionApi.js
@@ -160,15 +160,15 @@ export class Connection {
 		const formData = new FormData()
 		formData.append('file', file)
 		const url =
-			_endpointUrl('attachment/upload') +
-			'?documentId=' +
-			encodeURIComponent(this.#document.id) +
-			'&sessionId=' +
-			encodeURIComponent(this.#session.id) +
-			'&sessionToken=' +
-			encodeURIComponent(this.#session.token) +
-			'&token=' +
-			encodeURIComponent(this.#options.shareToken || '')
+			_endpointUrl('attachment/upload')
+			+ '?documentId='
+			+ encodeURIComponent(this.#document.id)
+			+ '&sessionId='
+			+ encodeURIComponent(this.#session.id)
+			+ '&sessionToken='
+			+ encodeURIComponent(this.#session.token)
+			+ '&token='
+			+ encodeURIComponent(this.#options.shareToken || '')
 		return this.#post(url, formData, {
 			headers: {
 				'Content-Type': 'multipart/form-data',

--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -250,8 +250,8 @@ class SyncService {
 		const awareness = sessions
 			.filter(
 				(s) =>
-					s.lastContact >
-					Math.floor(Date.now() / 1000) - COLLABORATOR_DISCONNECT_TIME,
+					s.lastContact
+					> Math.floor(Date.now() / 1000) - COLLABORATOR_DISCONNECT_TIME,
 			)
 			.filter((s) => s.lastAwarenessMessage)
 			.map((s) => {

--- a/src/services/y-websocket.js
+++ b/src/services/y-websocket.js
@@ -56,8 +56,8 @@ messageHandlers[messageSync] = (
 		return
 	}
 	if (
-		syncMessageType === syncProtocol.messageYjsSyncStep2 ||
-		syncMessageType === syncProtocol.messageYjsUpdate
+		syncMessageType === syncProtocol.messageYjsSyncStep2
+		|| syncMessageType === syncProtocol.messageYjsUpdate
 	) {
 		syncProtocol.readSyncMessage(
 			decoderForRemote,
@@ -419,9 +419,9 @@ export class WebsocketProvider extends Observable {
 		this._checkInterval = /** @type {any} */ (
 			setInterval(() => {
 				if (
-					this.wsconnected &&
-					messageReconnectTimeout <
-						time.getUnixTime() - this.wsLastMessageReceived
+					this.wsconnected
+					&& messageReconnectTimeout
+						< time.getUnixTime() - this.wsLastMessageReceived
 				) {
 					// no message received in a long time - not even your own awareness
 					// updates (which are updated every 15 seconds)
@@ -437,10 +437,10 @@ export class WebsocketProvider extends Observable {
 	get url() {
 		const encodedParams = url.encodeQueryParams(this.params)
 		return (
-			this.serverUrl +
-			'/' +
-			this.roomname +
-			(encodedParams.length === 0 ? '' : '?' + encodedParams)
+			this.serverUrl
+			+ '/'
+			+ this.roomname
+			+ (encodedParams.length === 0 ? '' : '?' + encodedParams)
 		)
 	}
 

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -112,11 +112,11 @@ describe('Markdown though editor', () => {
 
 	test('escaping', () => {
 		const test =
-			'(Asdf [asdf asdf](asdf asdf) asdf asdf asdf asdf asdf asdf asdf asdf asdf)\n' +
-			'\n' +
-			'* [asdf asdf asdf/asdf](Asdf Asdf)\n' +
-			'* asdf asdf asdf [a--f asdf asdf](a--f Asdf Asdf)\n' +
-			'* [Asdf asdf asdf asdf asdf asdf](Asdf asdf)'
+			'(Asdf [asdf asdf](asdf asdf) asdf asdf asdf asdf asdf asdf asdf asdf asdf)\n'
+			+ '\n'
+			+ '* [asdf asdf asdf/asdf](Asdf Asdf)\n'
+			+ '* asdf asdf asdf [a--f asdf asdf](a--f Asdf Asdf)\n'
+			+ '* [Asdf asdf asdf asdf asdf asdf](Asdf asdf)'
 		expect(markdownThroughEditor(test)).toBe(test)
 		expect(markdownThroughEditor('This is a [test] for escaping')).toBe(
 			'This is a [test] for escaping',

--- a/src/views/DirectEditing.vue
+++ b/src/views/DirectEditing.vue
@@ -50,8 +50,8 @@ const callMobileMessage = (messageName, attributes) => {
 
 	// Forward to mobile handler
 	if (
-		window.DirectEditingMobileInterface &&
-		typeof window.DirectEditingMobileInterface[messageName] === 'function'
+		window.DirectEditingMobileInterface
+		&& typeof window.DirectEditingMobileInterface[messageName] === 'function'
 	) {
 		if (attributesString === null || typeof attributesString === 'undefined') {
 			window.DirectEditingMobileInterface[messageName]()
@@ -62,9 +62,9 @@ const callMobileMessage = (messageName, attributes) => {
 
 	// iOS webkit fallback
 	if (
-		window.webkit &&
-		window.webkit.messageHandlers &&
-		window.webkit.messageHandlers.DirectEditingMobileInterface
+		window.webkit
+		&& window.webkit.messageHandlers
+		&& window.webkit.messageHandlers.DirectEditingMobileInterface
 	) {
 		window.webkit.messageHandlers.DirectEditingMobileInterface.postMessage(
 			message,
@@ -96,10 +96,10 @@ export default {
 		},
 		isMobile() {
 			return (
-				window.DirectEditingMobileInterface ||
-				(window.webkit &&
-					window.webkit.messageHandlers &&
-					window.webkit.messageHandlers.DirectEditingMobileInterface)
+				window.DirectEditingMobileInterface
+				|| (window.webkit
+					&& window.webkit.messageHandlers
+					&& window.webkit.messageHandlers.DirectEditingMobileInterface)
 			)
 		},
 	},

--- a/src/views/RichWorkspace.vue
+++ b/src/views/RichWorkspace.vue
@@ -175,8 +175,8 @@ export default {
 				})
 				.catch((error) => {
 					if (
-						error.response.data.ocs &&
-						error.response.data.ocs.data.folder
+						error.response.data.ocs
+						&& error.response.data.ocs.data.folder
 					) {
 						this.folder = error.response.data.ocs.data.folder
 					} else {
@@ -222,8 +222,8 @@ export default {
 			if (SUPPORTED_STATIC_FILENAMES.includes(node.basename)) {
 				this.localHasRichWorkspace = true
 			} else if (
-				node.fileid === this.file?.id &&
-				node.path !== this.file?.path
+				node.fileid === this.file?.id
+				&& node.path !== this.file?.path
 			) {
 				this.localHasRichWorkspace = false
 			}


### PR DESCRIPTION
### 📝 Summary

Fixes Prettier warnings to prevent failures like:
https://github.com/nextcloud/text/actions/runs/14547996764/job/40815853006?pr=7063

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/3e9f51ae-5d80-4537-b14c-b78ee91589ca) | ![grafik](https://github.com/user-attachments/assets/18bfe213-05b7-49de-9a3f-e2cc12c115e5)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
