### PR TITLE
fix: Adjust padding in table cell and header components

### DIFF
--- a/src/css/prosemirror.scss
+++ b/src/css/prosemirror.scss
@@ -353,18 +353,15 @@ div.ProseMirror {
 			border-left: 0;
 			vertical-align: top;
 			max-width: 100%;
-			line-height: var(--default-clickable-area);
 			&:first-child {
 				border-left: 1px solid var(--table-color-border);
 			}
 		}
 		td {
-			padding: 0 0 0 0.75em;
 			border-top: 0;
 			color: var(--color-main-text);
 		}
 		th {
-			padding: 0 0 0 0.75em;
 			font-weight: normal;
 			border-bottom-color: var(--table-color-heading-border);
 			color: var(--table-color-heading);

--- a/src/nodes/Table/TableCellView.vue
+++ b/src/nodes/Table/TableCellView.vue
@@ -118,6 +118,7 @@ td {
 	.content {
 		flex: 1 1 0;
 		margin: 0;
+		padding: calc((var(--default-clickable-area) - var(--default-font-size) * 1.5) / 2) 0.75em;
 	}
 
 	.action-item {

--- a/src/nodes/Table/TableHeaderView.vue
+++ b/src/nodes/Table/TableHeaderView.vue
@@ -181,12 +181,17 @@ export default {
 </script>
 
 <style scoped lang="scss">
+div[contenteditable=true] th .content {
+	padding-right: 0;
+}
 th {
 
 	.content {
 		margin: 0;
 		flex-grow: 1;
+		padding: calc((var(--default-clickable-area) - var(--default-font-size) * 1.5) / 2) 0.75em;
 	}
+
 	.action-item {
 		opacity: 50%;
 	}


### PR DESCRIPTION
### 📝 Summary

I replaced the use of line-height with padding so that the text would be displayed correctly when it is in several lines.

The problem appeared after: https://github.com/nextcloud/text/pull/6150

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before](https://github.com/user-attachments/assets/2d26a7e6-458a-4564-b244-a22583fe9033) | ![after](https://github.com/user-attachments/assets/e4c0a9a9-6d63-432f-b246-cde27c2f0a24)



### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
