### PR TITLE
feat(link): Toggle link on selection with Mod-K shortcut

### DIFF
--- a/src/components/HelpModal.vue
+++ b/src/components/HelpModal.vue
@@ -198,7 +198,11 @@
 					<td>
 						<code>[Title](https://example.org)</code>
 					</td>
-					<td v-if="!isMobileCached" />
+					<td v-if="!isMobileCached">
+						<kbd>{{ ctrlOrModKey }}</kbd>
+						+
+						<kbd>K</kbd>
+					</td>
 				</tr>
 				<tr>
 					<td>{{ t('text', 'Insert emoji') }}</td>

--- a/src/components/Link/LinkBubbleView.vue
+++ b/src/components/Link/LinkBubbleView.vue
@@ -67,7 +67,8 @@
 
 		<!-- link edit form -->
 		<div v-if="isEditable && edit" class="link-view-bubble__edit">
-			<NcTextField name="newHref"
+			<NcTextField ref="hrefField"
+				name="newHref"
 				:label="t('text', 'URL')"
 				:value.sync="newHref"
 				@keypress.enter.prevent="updateLink" />
@@ -174,6 +175,7 @@ export default {
 	watch: {
 		key() {
 			this.resetBubble()
+			this.startEditIfEmpty()
 		},
 	},
 
@@ -182,6 +184,10 @@ export default {
 		this.editor.on('update', ({ editor }) => {
 			this.isEditable = editor.isEditable
 		})
+	},
+
+	mounted() {
+		this.startEditIfEmpty()
 	},
 
 	methods: {
@@ -204,6 +210,15 @@ export default {
 		startEdit() {
 			this.edit = true
 			this.newHref = this.href
+			this.$nextTick(() => {
+				this.$refs.hrefField.focus()
+			})
+		},
+
+		startEditIfEmpty() {
+			if (this.isEditable && !this.href) {
+				this.startEdit()
+			}
 		},
 
 		stopEdit() {

--- a/src/components/Menu/entries.js
+++ b/src/components/Menu/entries.js
@@ -401,6 +401,8 @@ export const MenuEntries = [
 	{
 		key: 'insert-link',
 		label: t('text', 'Insert link'),
+		keyChar: 'k',
+		keyModifiers: [MODIFIERS.Mod],
 		isActive: 'link',
 		icon: LinkIcon,
 		component: ActionInsertLink,

--- a/src/marks/Link.js
+++ b/src/marks/Link.js
@@ -90,6 +90,7 @@ const Link = TipTapLink.extend({
 			}),
 		]
 	},
+
 	addCommands() {
 		return {
 			...this.parent?.(),
@@ -144,6 +145,20 @@ const Link = TipTapLink.extend({
 						return commands.setLink(attrs)
 					}
 				},
+		}
+	},
+
+	addKeyboardShortcuts() {
+		return {
+			'Mod-k': () => {
+				const { empty } = this.editor.state.selection
+				if (empty) {
+					console.debug('empty selection')
+					return false
+				}
+				console.debug('toggle link for selection')
+				return this.editor.commands.toggleLink({ href: '' })
+			},
 		}
 	},
 


### PR DESCRIPTION
Acts only upon selection as inserting a link with empty title creates an invisible link, resulting in bad user experience in the WYSIWYG editor.

Fixes: #7152

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
