### PR TITLE
fix(image): Only focus image description on newly inserted image

### DIFF
--- a/src/components/Editor/MediaHandler.vue
+++ b/src/components/Editor/MediaHandler.vue
@@ -226,6 +226,9 @@ export default {
 			// Scroll image into view
 			this.$editor.commands.scrollIntoView()
 
+			// Store last inserted attachment src to focus it in ImageView.vue
+			this.$editor.commands.setMeta('insertedAttachmentSrc', { src })
+
 			emit('text:image-node:add', null)
 		},
 	},

--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -170,6 +170,7 @@ export default {
 			showImageModal: false,
 			imageIndex: null,
 			isEditable: false,
+			isLastInserted: false,
 			embeddedImageList: [],
 		}
 	},
@@ -223,6 +224,12 @@ export default {
 		this.editor.on('update', ({ editor }) => {
 			this.isEditable = editor.isEditable
 		})
+		this.editor.on('transaction', ({ transaction }) => {
+			const trMeta = transaction.getMeta('insertedAttachmentSrc')
+			if (trMeta?.src === this.src) {
+				this.isLastInserted = true
+			}
+		})
 		this.loadPreview().catch(this.onImageLoadFailure)
 	},
 	methods: {
@@ -265,7 +272,9 @@ export default {
 		onLoaded() {
 			this.loaded = true
 			this.$nextTick(() => {
-				this.$refs.altInput?.focus()
+				if (this.isLastInserted) {
+					this.$refs.altInput?.focus()
+				}
 			})
 		},
 		async updateEmbeddedImageList() {


### PR DESCRIPTION
Fixes: #6843 
Fixes: nextcloud/collectives#1740

Fixes a regression from #6609

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
