### PR TITLE
fix(details): Accept details open tag and summary tag in same line

### DIFF
--- a/src/markdownit/details.ts
+++ b/src/markdownit/details.ts
@@ -8,6 +8,8 @@ import type StateBlock from 'markdown-it/lib/rules_block/state_block.mjs'
 import type Token from 'markdown-it/lib/token.mjs'
 
 const DETAILS_START_REGEX = /^<details>\s*$/
+const DETAILS_AND_SUMMARY_START_REGEX =
+	/(?<=^<details>\s*<summary>).*(?=<\/summary>\s*$)/
 const DETAILS_END_REGEX = /^<\/details>\s*$/
 const SUMMARY_REGEX = /(?<=^<summary>).*(?=<\/summary>\s*$)/
 
@@ -28,8 +30,17 @@ function parseDetails(
 	let start = state.bMarks[startLine] + state.tShift[startLine]
 	let max = state.eMarks[startLine]
 
-	// Details block start
-	if (!state.src.slice(start, max).match(DETAILS_START_REGEX)) {
+	let detailsFound = false
+	let detailsSummary = null
+	let startLineCount = 2
+
+	const m = state.src.slice(start, max).match(DETAILS_AND_SUMMARY_START_REGEX)
+	if (m) {
+		// Details block start and summary in same line
+		detailsSummary = m[0].trim()
+		startLineCount = 1
+	} else if (!state.src.slice(start, max).match(DETAILS_START_REGEX)) {
+		// Details block start in separate line
 		return false
 	}
 
@@ -38,8 +49,6 @@ function parseDetails(
 		return true
 	}
 
-	let detailsFound = false
-	let detailsSummary = null
 	let nestedCount = 0
 	let nextLine = startLine
 	for (;;) {
@@ -112,7 +121,7 @@ function parseDetails(
 
 	token = state.push('details_summary', 'summary', -1)
 
-	state.md.block.tokenize(state, startLine + 2, nextLine)
+	state.md.block.tokenize(state, startLine + startLineCount, nextLine)
 
 	token = state.push('details_close', 'details', -1)
 	token.block = true

--- a/src/tests/markdownit/details.spec.js
+++ b/src/tests/markdownit/details.spec.js
@@ -26,7 +26,7 @@ describe('Details extension', () => {
 		)
 	})
 	it('renders with spaces', () => {
-		const rendered = markdownit.render('  <details>  \n <summary>summary </summary> \n  content \n  </details>')
+		const rendered = markdownit.render('  <details>  \n <summary> summary </summary> \n  content \n  </details>  ')
 		expect(stripIndent(rendered)).toBe(
 			'<details><summary>summary</summary><p>content</p></details>',
 		)
@@ -55,10 +55,10 @@ describe('Details extension', () => {
 			'<details><summary>summary</summary><details><summary>nested summary</summary><p>nested content</p></details><p>content</p></details>',
 		)
 	})
-	it('does not render with missing linebreak after details open', () => {
+	it('renders without linebreak after details open', () => {
 		const rendered = markdownit.render('<details><summary>summary</summary>\ncontent\n</details>')
 		expect(stripIndent(rendered)).toBe(
-			'<p>&lt;details&gt;&lt;summary&gt;summary&lt;/summary&gt;content&lt;/details&gt;</p>',
+			'<details><summary>summary</summary><p>content</p></details>',
 		)
 	})
 	it('does not render with missing linebreak after summary', () => {


### PR DESCRIPTION
Fixes: #6414

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
