### PR TITLE
fix(attachments): Adjust path to attachments folder when copying a node

### DIFF
--- a/lib/Listeners/NodeCopiedListener.php
+++ b/lib/Listeners/NodeCopiedListener.php
@@ -13,6 +13,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeCopiedEvent;
 use OCP\Files\File;
+use OCP\Lock\ILockingProvider;
 
 /**
  * @template-implements IEventListener<Event|NodeCopiedEvent>
@@ -36,6 +37,9 @@ class NodeCopiedListener implements IEventListener {
 			&& $target->getMimeType() === 'text/markdown'
 		) {
 			$this->attachmentService->copyAttachments($source, $target);
+			$target->unlock(ILockingProvider::LOCK_SHARED);
+			AttachmentService::replaceAttachmentFolderId($source, $target);
+			$target->lock(ILockingProvider::LOCK_SHARED);
 		}
 	}
 }

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -715,4 +715,24 @@ class AttachmentService {
 			}
 		}
 	}
+
+	public static function replaceAttachmentFolderId(File $source, File $target): void {
+		$sourceId = $source->getId();
+		$targetId = $target->getId();
+		$patterns = [
+			// Replace `[title](.attachments.1/file.png)` with `[title](attachments.2/file.png)`
+			// '/(\[[^]]+\]\(\s*\<?\.attachments\.)' . $sourceId . '(\/[^)]+\>?\s*\))/',
+			'/(\[(?:\\\]|[^]])+\]\(\s*\<?\.attachments\.)' . $sourceId . '(\/[^)]+\>?\s*\))/',
+			// Replace `[ref]: .attachments.1/file.png` with `[ref]: .attachments.2/file.png`
+			'/(\[(?:\\\]|[^]])+\]:\s+.attachments\.)' . $sourceId . '(\/[^\s]+)/',
+		];
+		$replacements = [
+			'${1}' . $targetId . '${2}',
+			'${1}' . $targetId . '${2}',
+		];
+		$content = preg_replace($patterns, $replacements, $target->getContent());
+		if ($content !== null) {
+			$target->putContent($content);
+		}
+	}
 }

--- a/tests/unit/Service/AttachmentServiceTest.php
+++ b/tests/unit/Service/AttachmentServiceTest.php
@@ -4,10 +4,12 @@ namespace OCA\Text\Tests;
 
 use OCA\Text\AppInfo\Application;
 use OCA\Text\Service\AttachmentService;
+use OCP\Files\File;
 use OCP\Files\Folder;
+use PHPUnit\Framework\TestCase;
 
-class AttachmentServiceTest extends \PHPUnit\Framework\TestCase {
-	private static $attachmentNames = [
+class AttachmentServiceTest extends TestCase {
+	private static array $attachmentNames = [
 		'aaa.png',
 		'aaa (2).png',
 		'aaa 2).png',
@@ -21,12 +23,12 @@ class AttachmentServiceTest extends \PHPUnit\Framework\TestCase {
 		'a`a`.png',
 	];
 
-	public function testDummy() {
+	public function testDummy(): void {
 		$app = new Application();
 		$this->assertEquals('text', $app::APP_NAME);
 	}
 
-	public function testGetAttachmentNamesFromContent() {
+	public function testGetAttachmentNamesFromContent(): void {
 		$content = "some content\n";
 		foreach (self::$attachmentNames as $name) {
 			// this is how it's generated in MenuBar.vue
@@ -42,7 +44,7 @@ class AttachmentServiceTest extends \PHPUnit\Framework\TestCase {
 		}
 	}
 
-	public function testGetAttachmentIdsFromContent() {
+	public function testGetAttachmentIdsFromContent(): void {
 		$urls = [
 			'www.example.com',
 			'http://example.com',
@@ -69,7 +71,7 @@ class AttachmentServiceTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals(range(1, $id - 1), $computedIds);
 	}
 
-	public function testGetUniqueFileName() {
+	public function testGetUniqueFileName(): void {
 		$fileNameList = [
 			'foo.png',
 			'bar',
@@ -103,5 +105,86 @@ class AttachmentServiceTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals('lala (4).png', AttachmentService::getUniqueFileName($folder, 'lala.png'));
 		$this->assertEquals('yay (4).png', AttachmentService::getUniqueFileName($folder, 'yay.png'));
 		$this->assertEquals('file.ext (2).ext', AttachmentService::getUniqueFileName($folder, 'file.ext.ext'));
+	}
+
+	// Replacement expected
+	public static function contentReplacedProvider(): array {
+		return [
+			['![image.png](.attachments.1/image.png)', '![image.png](.attachments.2/image.png)'],
+			// Spaces surrounding link URL
+			['![image.png](  .attachments.1/image%20%282%29.png  )', '![image.png](  .attachments.2/image%20%282%29.png  )'],
+			// Escaped square brackets in title
+			['![title \[#1\]](.attachments.1/image.png)', '![title \[#1\]](.attachments.2/image.png)'],
+			// Angle brackets surrounding link URL
+			['![image.png](<.attachments.1/image.png>)', '![image.png](<.attachments.2/image.png>)'],
+			// Spaces and angle brackets surrounding link URL
+			['![image.png](  <.attachments.1/image.png>  )', '![image.png](  <.attachments.2/image.png>  )'],
+			// Spaces in title
+			['![title with space](.attachments.1/image.png)', '![title with space](.attachments.2/image.png)'],
+			// Several links in a row
+			['Some text\n\n![image.png](.attachments.1/image.png)\n\nMore text. [file.tar.gz](.attachments.1/file.tar.gz) ...', 'Some text\n\n![image.png](.attachments.2/image.png)\n\nMore text. [file.tar.gz](.attachments.2/file.tar.gz) ...'],
+			// Reference link syntax
+			['[reference]: .attachments.1/image.png', '[reference]: .attachments.2/image.png'],
+			// Reference link syntax with title
+			['[reference]: .attachments.1/image.png "title"', '[reference]: .attachments.2/image.png "title"'],
+			// Reference link syntax with escaped square brackets in reference name
+			['[reference \[#1\]]: .attachments.1/image.png "title"', '[reference \[#1\]]: .attachments.2/image.png "title"'],
+		];
+	}
+
+	// No replacement expected
+	public static function contentNotReplacedProvider(): array {
+		return [
+			// Empty title
+			[ '![](.attachments.1/image.png)' ],
+			// Empty filename
+			[ '![title](.attachments.1/)' ],
+			// Wrong fileId #1
+			[ '![image.png](.attachments.01/image.png)' ],
+			// Wrong fileId #2
+			[ '![image.png](.attachments.12/image.png)' ],
+			// Normal brackets around title
+			[ '!(image.png)(.attachments.1/image.png)' ],
+			// Square brackets in title
+			['![title [#1]](.attachments.1/image.png)' ],
+			// Reference link syntax with square brackets in reference name
+			['[reference [#1]]: .attachments.1/image.png' ],
+		];
+	}
+
+	/**
+	 * @dataProvider contentReplacedProvider
+	 */
+	public function testReplaceAttachmentFolderId(string $sourceContent, string $targetContent): void {
+		$source = $this->createMock(File::class);
+		$source->method('getId')->willReturn(1);
+		$target = $this->createMock(File::class);
+		$target->method('getId')->willReturn(2);
+		$target->method('getContent')->willReturn($sourceContent);
+		$replacedContent = '';
+		$target->method('putContent')->willReturnCallback(function (string $content) use (&$replacedContent) {
+			$replacedContent = $content;
+		});
+
+		AttachmentService::replaceAttachmentFolderId($source, $target);
+		$this->assertEquals($targetContent, $replacedContent);
+	}
+
+	/**
+	 * @dataProvider contentNotReplacedProvider
+	 */
+	public function testReplaceAttachmentFolderIdNoReplace(string $sourceContent): void {
+		$source = $this->createMock(File::class);
+		$source->method('getId')->willReturn(1);
+		$target = $this->createMock(File::class);
+		$target->method('getId')->willReturn(2);
+		$target->method('getContent')->willReturn($sourceContent);
+		$replacedContent = '';
+		$target->method('putContent')->willReturnCallback(function (string $content) use (&$replacedContent) {
+			$replacedContent = $content;
+		});
+
+		AttachmentService::replaceAttachmentFolderId($source, $target);
+		$this->assertEquals($sourceContent, $replacedContent);
 	}
 }


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
