### PR TITLE
Fix: Replace attachment file IDs when copying markdown files

### DIFF
--- a/lib/Listeners/NodeCopiedListener.php
+++ b/lib/Listeners/NodeCopiedListener.php
@@ -36,9 +36,10 @@ class NodeCopiedListener implements IEventListener {
 			&& $target instanceof File
 			&& $target->getMimeType() === 'text/markdown'
 		) {
-			$this->attachmentService->copyAttachments($source, $target);
+			$fileIdMapping = $this->attachmentService->copyAttachments($source, $target);
 			$target->unlock(ILockingProvider::LOCK_SHARED);
 			AttachmentService::replaceAttachmentFolderId($source, $target);
+			AttachmentService::replaceAttachmentFileIds($target, $fileIdMapping);
 			$target->lock(ILockingProvider::LOCK_SHARED);
 		}
 	}

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -693,27 +693,34 @@ class AttachmentService {
 	 * @param File $source
 	 * @param File $target
 	 *
+	 * @return array file id translation map
 	 * @throws InvalidPathException
 	 * @throws NoUserException
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 * @throws LockedException
 	 */
-	public function copyAttachments(File $source, File $target): void {
+	public function copyAttachments(File $source, File $target): array {
 		try {
 			$sourceAttachmentDir = $this->getAttachmentDirectoryForFile($source);
 		} catch (NotFoundException $e) {
 			// silently return if no attachment dir was found for source file
-			return;
+			return [];
 		}
 		// create a new attachment dir next to the new file
 		$targetAttachmentDir = $this->getAttachmentDirectoryForFile($target, true);
 		// copy the attachment files
+		$fileIdMapping = [];
 		foreach ($sourceAttachmentDir->getDirectoryListing() as $sourceAttachment) {
 			if ($sourceAttachment instanceof File) {
-				$targetAttachmentDir->newFile($sourceAttachment->getName(), $sourceAttachment->getContent());
+				$newFile = $targetAttachmentDir->newFile($sourceAttachment->getName(), $sourceAttachment->getContent());
+				$fileIdMapping[] = [
+					$sourceAttachment->getId(),
+					$newFile->getId()
+				];
 			}
 		}
+		return $fileIdMapping;
 	}
 
 	public static function replaceAttachmentFolderId(File $source, File $target): void {
@@ -730,6 +737,20 @@ class AttachmentService {
 			'${1}' . $targetId . '${2}',
 			'${1}' . $targetId . '${2}',
 		];
+		$content = preg_replace($patterns, $replacements, $target->getContent());
+		if ($content !== null) {
+			$target->putContent($content);
+		}
+	}
+
+	public static function replaceAttachmentFileIds(File $target, array $fileIdMapping): void {
+		$patterns = [];
+		$replacements = [];
+		foreach ($fileIdMapping as $mapping) {
+			$patterns[] = '/(\[(?:\\\]|[^]])+\]\(\s*\S+\/f\/)' . $mapping[0] . '(\s*)(\(preview\)\s*)?\)/';
+			// Replace `[title](URL/f/sourceId (preview))` with `[title](URL/f/targetId (preview))`
+			$replacements[] = '${1}' . $mapping[1] . '${2}${3})';
+		}
 		$content = preg_replace($patterns, $replacements, $target->getContent());
 		if ($content !== null) {
 			$target->putContent($content);


### PR DESCRIPTION
### 📝 Summary

When copying markdown files, the attachment IDs embedded in the file content were not updated to match the newly created attachments. This PR fixes that by:

- Updating `AttachmentService::copyAttachments()` to return a map of old to new file IDs.
- Adding `AttachmentService::replaceAttachmentFileIds()` to update these references in the file content.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
