### PR TITLE
fix: Do not escape possible other editors syntax when serializing

### DIFF
--- a/src/extensions/RichText.js
+++ b/src/extensions/RichText.js
@@ -67,7 +67,16 @@ export default Extension.create({
 		const defaultExtensions = [
 			this.options.editing ? Markdown : null,
 			Document,
-			Text,
+			Text.extend({
+				toMarkdown(state, node) {
+					const originalEsc = state.esc
+					state.esc = (text) => {
+						text = originalEsc.bind(state)(text)
+						return text.replace(/\\\[/g, '[').replace(/\\\]/g, ']')
+					}
+					state.text(node.textContent)
+				},
+			}),
 			Paragraph,
 			HardBreak,
 			Heading,

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -313,6 +313,23 @@ describe('Markdown serializer from html', () => {
 			'<details>\n<summary>**summary**</summary>\n```\ncode\n```\n\n</details>\n',
 		)
 	})
+
+	const assertKeepSyntax = (source) => {
+		const tiptap = createRichEditor()
+		tiptap.commands.setContent(markdownit.render(source))
+
+		const end = tiptap.state.doc.content.size - 1
+		tiptap.commands.insertContentAt(end, ' editing')
+
+		const serializer = createMarkdownSerializer(tiptap.schema)
+		const md = serializer.serialize(tiptap.state.doc)
+		expect(md).toBe(source + ' editing')
+	}
+
+	test('keep syntax for brackets', () => {
+		assertKeepSyntax('test [[foo]] bar')
+		assertKeepSyntax('test ![[foo]] bar')
+	})
 })
 
 describe('Trailing nodes', () => {

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -329,6 +329,11 @@ describe('Markdown serializer from html', () => {
 	test('keep syntax for brackets', () => {
 		assertKeepSyntax('test [[foo]] bar')
 		assertKeepSyntax('test ![[foo]] bar')
+		assertKeepSyntax('test ![[note#^block]] bar')
+		assertKeepSyntax('test [mytest] foo')
+		assertKeepSyntax('test [[mytest]] [abc](test) foo')
+		assertKeepSyntax('test #foo test')
+		assertKeepSyntax('\\\\[ test')
 	})
 })
 


### PR DESCRIPTION
This is a first attempt to resolve https://github.com/nextcloud/text/issues/4795 and https://github.com/nextcloud/text/issues/6864

Mostly just a hacky fix for now, i need to think a bit more about in which cases we may want to skip the escape and in which not

- [ ] Check for side effects with cases like https://github.com/nextcloud/text/issues/931
- [ ] See how we want to handle `\[` and `\\[` in the markdown source