### PR TITLE
fix: prevent loading the code block extension twice for plain text

### DIFF
--- a/src/EditorFactory.js
+++ b/src/EditorFactory.js
@@ -13,8 +13,6 @@ import hljs from 'highlight.js/lib/core'
 
 import { logger } from './helpers/logger.js'
 import { FocusTrap, Mention, PlainText, RichText } from './extensions/index.js'
-// eslint-disable-next-line import/no-named-as-default
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 
 const lowlight = createLowlight()
 
@@ -65,11 +63,10 @@ const createPlainEditor = ({ language, extensions = [] } = {}) => {
 	return new Editor({
 		editorProps,
 		extensions: [
-			PlainText,
-			CodeBlockLowlight.configure({
+			PlainText.configure({
+				// Options to be passed through to `CodeBlockPlainText`
 				lowlight,
 				defaultLanguage: language,
-				exitOnTripleEnter: false,
 			}),
 			FocusTrap,
 			...extensions,

--- a/src/extensions/PlainText.js
+++ b/src/extensions/PlainText.js
@@ -14,7 +14,24 @@ import Text from '@tiptap/extension-text'
 export default Extension.create({
 	name: 'PlainText',
 
+	addOptions() {
+		return {
+			...this.parent?.(),
+			lowlight: undefined,
+			defaultLanguage: undefined,
+		}
+	},
+
 	addExtensions() {
-		return [CodeBlockPlainText, Keymap, PlainTextDocument, Text]
+		return [
+			CodeBlockPlainText.configure({
+				lowlight: this.options.lowlight,
+				defaultLanguage: this.options.defaultLanguage,
+				exitOnTripleEnter: false,
+			}),
+			Keymap,
+			PlainTextDocument,
+			Text,
+		]
 	},
 })


### PR DESCRIPTION
This fixes a warning that occurs as for plain text editing we include the codeBlock extension twice. I noticed this when running tests on #7300

We can only add the extension in our PlainTextExtension as it wraps everything we need for that already. In this case the addition options are just needed to pass them trough to the code block extension.

Fixes tons of warnings like:
```
stderr | src/tests/plaintext.spec.js > commonmark as plaintext > commonmark 557
[tiptap warn]: Duplicate extension names found: ['codeBlock']. This can lead to issues.