### PR TITLE
test(nodes): destroy editor after use

### DIFF
--- a/src/tests/nodes/Preview.spec.js
+++ b/src/tests/nodes/Preview.spec.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { test as baseTest } from 'vitest'
 import Preview from './../../nodes/Preview.js'
 import Markdown from './../../extensions/Markdown.js'
 import Link from './../../marks/Link.js'
@@ -13,33 +14,39 @@ import {
 } from '../testHelpers/markdown.js'
 import createCustomEditor from '../testHelpers/createCustomEditor.ts'
 
+const test = baseTest.extend({
+	editor: async ({ task: _ }, use) => {
+		const editor = createCustomEditor('', [Markdown, Preview, Link])
+		await use(editor)
+		editor.destroy()
+	}
+})
+
 describe('Preview extension', () => {
-	it('exposes toMarkdown function', () => {
+	test('exposes toMarkdown function', () => {
 		const toMarkdown = getExtensionField(Preview, 'toMarkdown', Preview)
 		expect(typeof toMarkdown).toEqual('function')
 	})
 
-	it('exposes the toMarkdown function in the prosemirror schema', () => {
-		const editor = createEditorWithPreview()
+	test('exposes the toMarkdown function in the prosemirror schema', ({ editor }) => {
 		const preview = editor.schema.nodes.preview
 		expect(preview.spec.toMarkdown).toBeDefined()
 	})
 
-	it('markdown syntax is preserved through editor', () => {
+	test('markdown syntax is preserved through editor', () => {
 		const markdown = '[link](https://nextcloud.com (preview))'
 		expect(markdownThroughEditor(markdown)).toBe(markdown)
 	})
 
-	it('serializes HTML to markdown', () => {
+	test('serializes HTML to markdown', () => {
 		const markdown = '[link](https://nextcloud.com (preview))'
 		const link = '<a href="https://nextcloud.com" title="preview">link</a>'
 		expect(markdownThroughEditorHtml(link))
 			.toBe(markdown)
 	})
 
-	it('detects links', () => {
+	test('detects links', ({ editor }) => {
 		const link = '<a href="https://nextcloud.com" title="preview">link</a>'
-		const editor = createEditorWithPreview()
 		editor.commands.setContent(`${link}<p>hello></p>`)
 		const node = editor.state.doc.content.firstChild
 		expect(node.type.name).toBe('preview')
@@ -49,4 +56,3 @@ describe('Preview extension', () => {
 
 })
 
-const createEditorWithPreview = () => createCustomEditor('', [Markdown, Preview, Link])

--- a/src/tests/tiptap.spec.js
+++ b/src/tests/tiptap.spec.js
@@ -10,7 +10,9 @@ const renderedHTML = (markdown) => {
 	const editor = createRichEditor()
 	editor.commands.setContent(markdownit.render(markdown))
 	// Remove TrailingNode
-	return editor.getHTML().replace(/<p><\/p>$/, '')
+	const res = editor.getHTML().replace(/<p><\/p>$/, '')
+	editor.destroy()
+	return res
 }
 
 describe('TipTap', () => {


### PR DESCRIPTION
Fixes errors during test runs such as https://github.com/nextcloud/text/actions/runs/15742170977/job/44369984600

![Bildschirmfoto vom 2025-06-19 09-45-46](https://github.com/user-attachments/assets/e11bf578-7e3c-4e9c-9921-bfda3d090c0a)

Use [vitests test.extend](https://vitest.dev/guide/test-context.html#test-extend) to make sure destroy is also called if the test fails.

We create editors without destroying them in a lot more tests. I briefly tried to fix that with a editorTest fixture everywhere - but it's just too much work right now. I've only seen these ones error out during tests. So let's fix them when they throw exceptions one by one...