### PR TITLE
bump/workflows/npm audit fix

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -59,13 +59,12 @@ jobs:
         id: npm-audit
         uses: nextcloud-libraries/npm-audit-action@1b1728b2b4a7a78d69de65608efcf4db0e3e42d0 # v0.2.0
 
-      - name: Run npm ci and npm run build
+      - name: Run npm ci
         if: steps.checkout.outcome == 'success'
         env:
           CYPRESS_INSTALL_BINARY: 0
         run: |
           npm ci
-          npm run build --if-present
 
       - name: Create Pull Request
         if: steps.checkout.outcome == 'success'


### PR DESCRIPTION
- **chore(workflows): update npm-audit-fix**
- **chore(workflows): no build in npm-audit-fix**

This will prevent failures on the non existing `master` branch.
Also stop building the js artifacts for the PR.
