### PR TITLE
fix(character-count): use the NcActionTexts name prop

### DIFF
--- a/src/components/Menu/CharacterCount.vue
+++ b/src/components/Menu/CharacterCount.vue
@@ -4,12 +4,9 @@
 -->
 
 <template>
-	<NcActionText data-text-action-entry="character-count">
+	<NcActionText data-text-action-entry="character-count" :name="countString">
 		<template #icon>
 			<AlphabeticalVariant />
-		</template>
-		<template #default>
-			{{ countString }}
 		</template>
 	</NcActionText>
 </template>


### PR DESCRIPTION
The default slot somehow is not reactive.

Backported fix from d7df4c0.

Signed-off-by: Max <max@nextcloud.com>
