### PR TITLE
fix(links): Use custom link handling only for text-only links

### DIFF
--- a/src/marks/Link.js
+++ b/src/marks/Link.js
@@ -73,6 +73,7 @@ const Link = TipTapLink.extend({
 			{
 				...mark.attrs,
 				href,
+				'data-text-el': 'text-only-link',
 				'data-md-href': mark.attrs.href,
 				rel: 'noopener noreferrer nofollow',
 			},

--- a/src/plugins/links.js
+++ b/src/plugins/links.js
@@ -161,21 +161,26 @@ export function linkClicking() {
 						event.stopImmediatePropagation()
 					}
 				},
-				// Prevent open link (except anchor links) on left click (required for read-only mode)
-				// Open link in new tab on Ctrl/Cmd + left click
+				// Prevent open link for text-only links on left click. Required for read-only mode.
 				click: (view, event) => {
 					const linkEl = event.target.closest('a')
-					if (event.button === 0 && linkEl) {
-						// No special handling in mermaid diagrams to not break links there
-						if (linkEl.closest('svg[id^="mermaid-view"]')) {
-							return false
-						}
+					// Only text-only links need special handling (e.g. don't handle links inside preview or mermaid diagrams)
+					if (
+						!linkEl
+						|| !linkEl.matches('a[data-text-el="text-only-link"]')
+					) {
+						return false
+					}
 
+					if (event.button === 0) {
+						// Stop browser from opening the link
 						event.preventDefault()
+
 						if (isLinkToSelfWithHash(linkEl.attributes.href?.value)) {
 							// Open anchor links directly
 							location.href = linkEl.attributes.href.value
 						} else if (event.ctrlKey || event.metaKey) {
+							// Open link in new tab on Ctrl/Cmd + left click
 							window.open(linkEl.href, '_blank')
 						}
 					}


### PR DESCRIPTION
All other links inside the editor (like previews via reference widgets or links in mermaid diagrams) should be treated the standard way.

Fixes: #7384

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
