### PR TITLE
fix(RichText): always load Mention extension in rich text editor

### DIFF
--- a/src/EditorFactory.js
+++ b/src/EditorFactory.js
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import MentionSuggestion from './components/Suggestion/Mention/suggestions.js'
-
 import 'proxy-polyfill'
 
 import { Editor } from '@tiptap/core'
@@ -12,7 +10,7 @@ import { createLowlight } from 'lowlight'
 import hljs from 'highlight.js/lib/core'
 
 import { logger } from './helpers/logger.js'
-import { FocusTrap, Mention, PlainText, RichText } from './extensions/index.js'
+import { FocusTrap, PlainText, RichText } from './extensions/index.js'
 
 const lowlight = createLowlight()
 
@@ -41,10 +39,7 @@ const createRichEditor = ({ extensions = [], connection, relativePath, isEmbedde
 	return new Editor({
 		editorProps,
 		extensions: [
-			RichText.configure({ relativePath, isEmbedded }),
-			Mention.configure({
-				suggestion: MentionSuggestion({ connection }),
-			}),
+			RichText.configure({ connection, relativePath, isEmbedded }),
 			FocusTrap,
 			...extensions,
 		],

--- a/src/extensions/RichText.js
+++ b/src/extensions/RichText.js
@@ -32,6 +32,8 @@ import LinkBubble from './../extensions/LinkBubble.js'
 import LinkPicker from './../extensions/LinkPicker.js'
 import ListItem from '@tiptap/extension-list-item'
 import Markdown from './../extensions/Markdown.js'
+import Mention from './../extensions/Mention.js'
+import MentionSuggestion from '../components/Suggestion/Mention/suggestions.js'
 import OrderedList from './../nodes/OrderedList.js'
 import Paragraph from './../nodes/Paragraph.js'
 import Preview from './../nodes/Preview.js'
@@ -54,6 +56,7 @@ export default Extension.create({
 
 	addOptions() {
 		return {
+			connection: null,
 			editing: true,
 			extensions: [],
 			relativePath: null,
@@ -99,6 +102,11 @@ export default Extension.create({
 			KeepSyntax,
 			Keymap,
 			FrontMatter,
+			Mention.configure({
+				suggestion: MentionSuggestion({
+					connection: this.options.connection,
+				}),
+			}),
 			Search,
 			Emoji.configure({
 				suggestion: EmojiSuggestion(),


### PR DESCRIPTION
Brings back mention bubbles in MarkdownContentEditor.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
