### PR TITLE
fix(workspace): fix race condition when loading

### DIFF
--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -192,6 +192,7 @@ export const addMenuRichWorkspace = () => {
 
 let FilesHeaderRichWorkspaceView
 let FilesHeaderRichWorkspaceInstance
+let latestFolder
 
 export const FilesWorkspaceHeader = new Header({
 	id: 'workspace',
@@ -201,6 +202,7 @@ export const FilesWorkspaceHeader = new Header({
 		return ['files', 'favorites', 'public-share'].includes(view.id)
 	},
 	render: async (el, folder) => {
+		latestFolder = folder
 		// Import the RichWorkspace component only when needed
 		if (!FilesHeaderRichWorkspaceView) {
 			FilesHeaderRichWorkspaceView = (
@@ -214,9 +216,9 @@ export const FilesWorkspaceHeader = new Header({
 			console.debug('Destroying existing FilesHeaderRichWorkspaceInstance')
 		}
 
-		const hasRichWorkspace = !!folder.attributes['rich-workspace-file']
-		const content = folder.attributes['rich-workspace'] || ''
-		const path = folder.path || ''
+		const hasRichWorkspace = !!latestFolder.attributes['rich-workspace-file']
+		const content = latestFolder.attributes['rich-workspace'] || ''
+		const path = latestFolder.path || ''
 
 		// Create a new instance of the RichWorkspace component
 		FilesHeaderRichWorkspaceInstance = new Vue({
@@ -232,6 +234,7 @@ export const FilesWorkspaceHeader = new Header({
 	},
 
 	updated(folder) {
+		latestFolder = folder
 		if (!FilesHeaderRichWorkspaceInstance) {
 			console.error('No vue instance found for FilesWorkspaceHeader')
 			return


### PR DESCRIPTION
`render` is called first.
It awaits the import of `FilesHeaderRichWorkspaceView`.
`updated` is called in the meantime.
It failed during the if block as `FilesHeaderRichWorkspaceInstance` is not available yet.
`render` continues with the folder it started with, which had no workspace.

Not sure this is a good solution. But it does the trick for me.
