### PR TITLE
feat: use outline icons

### DIFF
--- a/src/components/Assistant.vue
+++ b/src/components/Assistant.vue
@@ -14,7 +14,7 @@
 			data-cy="assistantMenu">
 			<NcActions :title="t('text', 'Nextcloud Assistant')" :type="'secondary'">
 				<template #icon>
-					<CreationIcon :size="20" class="icon" />
+					<CreationOutlineIcon :size="20" class="icon" />
 				</template>
 				<NcActionButton
 					v-for="type in taskTypes"
@@ -22,7 +22,9 @@
 					close-after-click
 					@click="openAssistantForm(type.id)">
 					<template #icon>
-						<PencilIcon v-if="type.id == 'core:text2text'" :size="20" />
+						<PencilOutlineIcon
+							v-if="type.id == 'core:text2text'"
+							:size="20" />
 						<FormatHeader1
 							v-else-if="type.id == 'core:text2text:headline'"
 							:size="20" />
@@ -32,7 +34,7 @@
 						<TextShort
 							v-else-if="type.id == 'core:text2text:summary'"
 							:size="20" />
-						<CreationIcon v-else />
+						<CreationOutlineIcon v-else />
 					</template>
 					{{ type.name }}
 				</NcActionButton>
@@ -52,7 +54,7 @@
 					close-after-click
 					@click="showTaskList = true">
 					<template #icon>
-						<CreationIcon :size="20" />
+						<CreationOutlineIcon :size="20" />
 					</template>
 					{{ t('text', 'Show assistant results') }}
 				</NcActionButton>
@@ -68,7 +70,7 @@
 			<div class="task-list">
 				<h4 v-if="tasks.length > 0">
 					<span class="assistant-bubble">
-						<CreationIcon :size="16" class="icon" />
+						<CreationOutlineIcon :size="16" class="icon" />
 						<span>{{ t('text', 'Nextcloud Assistant') }}</span>
 					</span>
 				</h4>
@@ -84,11 +86,11 @@
 							{{ task.input.input }}
 						</template>
 						<template #icon>
-							<CheckCircleIcon
+							<CheckCircleOutlineIcon
 								v-if="task.status === STATUS_SUCCESSFUL"
 								:size="20"
 								class="icon-status--success" />
-							<ErrorIcon
+							<ErrorOutlineIcon
 								v-else-if="task.status === STATUS_FAILED"
 								:size="20"
 								class="icon-status--failed" />
@@ -113,7 +115,7 @@
 								:title="task.output.output"
 								@click.stop="() => openResult(task)">
 								<template #icon>
-									<CreationIcon :size="20" />
+									<CreationOutlineIcon :size="20" />
 								</template>
 								{{ t('text', 'Show result') }}
 							</NcActionButton>
@@ -128,7 +130,7 @@
 							</NcActionButton>
 							<NcActionButton @click="() => deleteTask(task)">
 								<template #icon>
-									<DeleteIcon :size="20" />
+									<DeleteOutlineIcon :size="20" />
 								</template>
 								{{ t('text', 'Delete task') }}
 							</NcActionButton>
@@ -153,14 +155,14 @@ import NcListItem from '@nextcloud/vue/components/NcListItem'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import { posToDOMRect } from '@tiptap/core'
 import { FloatingMenu } from '@tiptap/vue-2'
-import ErrorIcon from 'vue-material-design-icons/AlertCircle.vue'
-import CheckCircleIcon from 'vue-material-design-icons/CheckCircle.vue'
+import ErrorOutlineIcon from 'vue-material-design-icons/AlertCircleOutline.vue'
+import CheckCircleOutlineIcon from 'vue-material-design-icons/CheckCircleOutline.vue'
 import ClipboardTextOutlineIcon from 'vue-material-design-icons/ClipboardTextOutline.vue'
 import ClockOutline from 'vue-material-design-icons/ClockOutline.vue'
-import CreationIcon from 'vue-material-design-icons/Creation.vue'
-import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import CreationOutlineIcon from 'vue-material-design-icons/CreationOutline.vue'
+import DeleteOutlineIcon from 'vue-material-design-icons/DeleteOutline.vue'
 import FormatHeader1 from 'vue-material-design-icons/FormatHeader1.vue'
-import PencilIcon from 'vue-material-design-icons/Pencil.vue'
+import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 import Shuffle from 'vue-material-design-icons/Shuffle.vue'
 import TextBoxPlusOutlineIcon from 'vue-material-design-icons/TextBoxPlusOutline.vue'
 import TextShort from 'vue-material-design-icons/TextShort.vue'
@@ -186,13 +188,13 @@ export default {
 	name: 'Assistant',
 	components: {
 		FloatingMenu,
-		ErrorIcon,
-		CreationIcon,
+		ErrorOutlineIcon,
+		CreationOutlineIcon,
 		ClockOutline,
-		CheckCircleIcon,
-		DeleteIcon,
+		CheckCircleOutlineIcon,
+		DeleteOutlineIcon,
 		TextBoxPlusOutlineIcon,
-		PencilIcon,
+		PencilOutlineIcon,
 		TextShort,
 		FormatHeader1,
 		Shuffle,
@@ -249,13 +251,13 @@ export default {
 			}
 
 			if (this.tasks.filter((t) => t.status === STATUS_FAILED).length > 0) {
-				return ErrorIcon
+				return ErrorOutlineIcon
 			}
 
 			if (
 				this.tasks.filter((t) => t.status === STATUS_SUCCESSFUL).length > 0
 			) {
-				return CheckCircleIcon
+				return CheckCircleOutlineIcon
 			}
 
 			return null

--- a/src/components/Editor/DocumentStatus.vue
+++ b/src/components/Editor/DocumentStatus.vue
@@ -13,7 +13,7 @@
 				@reconnect="$emit('reconnect')" />
 			<NcNoteCard v-if="lock" type="info" :text="lockText">
 				<template #icon>
-					<Lock :size="20" />
+					<LockOutlineIcon :size="20" />
 				</template>
 			</NcNoteCard>
 		</div>
@@ -23,7 +23,7 @@
 <script>
 import { t } from '@nextcloud/l10n'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
-import Lock from 'vue-material-design-icons/Lock.vue'
+import LockOutlineIcon from 'vue-material-design-icons/LockOutline.vue'
 import isMobile from '../../mixins/isMobile.js'
 import SyncStatus from './DocumentStatus/SyncStatus.vue'
 
@@ -33,7 +33,7 @@ export default {
 	components: {
 		SyncStatus,
 		NcNoteCard,
-		Lock,
+		LockOutlineIcon,
 	},
 
 	mixins: [isMobile],

--- a/src/components/Editor/PreviewOptions.vue
+++ b/src/components/Editor/PreviewOptions.vue
@@ -38,7 +38,7 @@
 			</NcActionButton>
 			<NcActionButton close-after-click @click="deleteNode">
 				<template #icon>
-					<DeleteIcon :size="20" />
+					<DeleteOutlineIcon :size="20" />
 				</template>
 				{{ t('text', 'Remove link') }}
 			</NcActionButton>
@@ -53,7 +53,7 @@ import NcActionCaption from '@nextcloud/vue/components/NcActionCaption'
 import NcActionRadio from '@nextcloud/vue/components/NcActionRadio'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
-import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import DeleteOutlineIcon from 'vue-material-design-icons/DeleteOutline.vue'
 import DotsVerticalIcon from 'vue-material-design-icons/DotsVertical.vue'
 import OpenIcon from 'vue-material-design-icons/OpenInNew.vue'
 
@@ -67,7 +67,7 @@ export default {
 		NcActionCaption,
 		NcActionRadio,
 		NcActionSeparator,
-		DeleteIcon,
+		DeleteOutlineIcon,
 		OpenIcon,
 	},
 

--- a/src/components/Editor/SessionList.vue
+++ b/src/components/Editor/SessionList.vue
@@ -14,7 +14,7 @@
 					class="avatar-list"
 					v-bind="attrs">
 					<template #icon>
-						<AccountMultipleIcon :size="20" />
+						<AccountMultipleOutlineIcon :size="20" />
 						<AvatarWrapper
 							v-for="session in sessionsVisible"
 							:key="session.id"
@@ -68,7 +68,7 @@ import { generateUrl } from '@nextcloud/router'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcPopover from '@nextcloud/vue/components/NcPopover'
-import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue'
+import AccountMultipleOutlineIcon from 'vue-material-design-icons/AccountMultipleOutline.vue'
 import {
 	COLLABORATOR_DISCONNECT_TIME,
 	COLLABORATOR_IDLE_TIME,
@@ -78,7 +78,7 @@ import AvatarWrapper from './AvatarWrapper.vue'
 export default {
 	name: 'SessionList',
 	components: {
-		AccountMultipleIcon,
+		AccountMultipleOutlineIcon,
 		AvatarWrapper,
 		NcButton,
 		NcPopover,

--- a/src/components/Link/LinkBubbleView.vue
+++ b/src/components/Link/LinkBubbleView.vue
@@ -32,7 +32,7 @@
 					type="tertiary"
 					@click="startEdit">
 					<template #icon>
-						<PencilIcon :size="20" />
+						<PencilOutlineIcon :size="20" />
 					</template>
 				</NcButton>
 				<NcButton
@@ -103,7 +103,7 @@ import CheckIcon from 'vue-material-design-icons/Check.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 import LinkOffIcon from 'vue-material-design-icons/LinkOff.vue'
-import PencilIcon from 'vue-material-design-icons/Pencil.vue'
+import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 
 import CopyToClipboardMixin from '../../mixins/CopyToClipboardMixin.js'
 
@@ -121,7 +121,7 @@ export default {
 		NcReferenceList,
 		NcTextField,
 		LinkOffIcon,
-		PencilIcon,
+		PencilOutlineIcon,
 	},
 
 	mixins: [CopyToClipboardMixin],

--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -28,7 +28,7 @@
 		<NcButton v-if="isEmbedded" class="toggle-interactive" @click="toggleEdit">
 			{{ t('text', 'Edit') }}
 			<template #icon>
-				<PencilIcon />
+				<PencilOutlineIcon />
 			</template>
 		</NcButton>
 	</div>
@@ -41,7 +41,7 @@ import { t } from '@nextcloud/l10n'
 import { getSharingToken } from '@nextcloud/sharing/public'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import Vue from 'vue'
-import PencilIcon from 'vue-material-design-icons/Pencil.vue'
+import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 import MarkdownContentEditor from './Editor/MarkdownContentEditor.vue'
 import PlainTextReader from './PlainTextReader.vue'
 
@@ -51,7 +51,7 @@ export default {
 	name: 'ViewerComponent',
 	components: {
 		NcButton: Vue.extend(NcButton),
-		PencilIcon: Vue.extend(PencilIcon),
+		PencilOutlineIcon: Vue.extend(PencilOutlineIcon),
 		PlainTextReader: Vue.extend(PlainTextReader),
 		MarkdownContentEditor: Vue.extend(MarkdownContentEditor),
 		Editor: getEditorInstance,

--- a/src/nodes/CodeBlock/CodeBlockView.vue
+++ b/src/nodes/CodeBlock/CodeBlockView.vue
@@ -52,7 +52,7 @@
 						close-after-click
 						@click="viewMode = 'preview'">
 						<template #icon>
-							<Eye :size="20" />
+							<EyeOutlineIcon :size="20" />
 						</template>
 						{{ t('text', 'Diagram') }}
 					</NcActionButton>
@@ -112,7 +112,7 @@ import { v4 as uuidv4 } from 'uuid'
 import Check from 'vue-material-design-icons/Check.vue'
 import CodeBraces from 'vue-material-design-icons/CodeBraces.vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
-import Eye from 'vue-material-design-icons/Eye.vue'
+import EyeOutlineIcon from 'vue-material-design-icons/EyeOutline.vue'
 import Help from 'vue-material-design-icons/Help.vue'
 import MarkerIcon from 'vue-material-design-icons/Marker.vue'
 import ViewSplitVertical from 'vue-material-design-icons/ViewSplitVertical.vue'
@@ -126,7 +126,7 @@ export default {
 		ContentCopy,
 		Help,
 		Check,
-		Eye,
+		EyeOutlineIcon,
 		ViewSplitVertical,
 		CodeBraces,
 		NcActions,


### PR DESCRIPTION
### 📝 Summary

* Resolves: #7388

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
Before:
<img width="272" height="214" alt="image" src="https://github.com/user-attachments/assets/fbce1f49-9ff0-4ecf-bfeb-bed6f88132c7" />
<img width="577" height="181" alt="image" src="https://github.com/user-attachments/assets/b3176311-7954-4938-8a08-fc312681db96" />
<img width="333" height="339" alt="image" src="https://github.com/user-attachments/assets/6434371f-5cfa-4257-8a13-caf55ba7bbd4" />
<img width="440" height="391" alt="image" src="https://github.com/user-attachments/assets/88fd5e41-a472-439e-8c18-fad310beca63" />

After:
<img width="231" height="205" alt="image" src="https://github.com/user-attachments/assets/4fbb586b-9328-4bd9-828b-b220c3f53e2b" />
<img width="628" height="185" alt="image" src="https://github.com/user-attachments/assets/a1170530-b80a-4867-ab27-817f4e5eaa49" />
<img width="432" height="376" alt="image" src="https://github.com/user-attachments/assets/cd7ce1f8-4a85-4483-8084-70db5a899f8f" />
<img width="459" height="286" alt="image" src="https://github.com/user-attachments/assets/7ecfcb84-0263-4936-8330-85d4fcc559ec" />


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
