### PR TITLE
fix(keymap): Fix browser keybinding ctrl+del to delete word ahead

### DIFF
--- a/src/extensions/Keymap.js
+++ b/src/extensions/Keymap.js
@@ -62,7 +62,8 @@ const Keymap = Extension.create({
 
 						/**
 						 * <Mod>-<Del>
-						 * Overwrite Viewer keybinding to delete the file
+						 * Prevent Viewer keybinding to delete the file, but don't prevent
+						 * browser keybinding to delete word after cursor.
 						 */
 						if (
 							(event.ctrlKey || event.metaKey)
@@ -71,7 +72,6 @@ const Keymap = Extension.create({
 							&& event.key === 'Delete'
 						) {
 							event.stopPropagation()
-							return true
 						}
 					},
 				},


### PR DESCRIPTION
Fixes: #7454

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
