### PR TITLE
Further TextDirection improvements

### DIFF
--- a/src/extensions/Keymap.js
+++ b/src/extensions/Keymap.js
@@ -20,6 +20,11 @@ const Keymap = Extension.create({
 				emit('text:keyboard:outline')
 				return true
 			},
+			/**
+			 * <Backspace>
+			 * Allows to undo input rules after they got automatically applied
+			 */
+			Backspace: () => this.editor.commands.undoInputRule(),
 		}
 	},
 

--- a/src/extensions/RichText.js
+++ b/src/extensions/RichText.js
@@ -121,11 +121,15 @@ export default Extension.create({
 			TrailingNode,
 			TextDirection.configure({
 				types: [
-					'heading',
-					'paragraph',
-					'listItem',
-					'taskItem',
 					'blockquote',
+					'callout',
+					'detailsSummary',
+					'heading',
+					'listItem',
+					'paragraph',
+					'tableCell',
+					'tableHeader',
+					'taskItem',
 				],
 			}),
 		]

--- a/src/nodes/Callout.vue
+++ b/src/nodes/Callout.vue
@@ -7,6 +7,7 @@
 		data-text-el="callout"
 		class="callout"
 		:class="`callout--${type}`"
+		:dir="dir"
 		as="div">
 		<component :is="icon" class="callout__icon" />
 		<NodeViewContent class="callout__content" />
@@ -42,7 +43,10 @@ export default {
 			return ICONS_MAP[this.type] || Info
 		},
 		type() {
-			return this.node?.attrs?.type || 'info'
+			return this.node.attrs.type || 'info'
+		},
+		dir() {
+			return this.node.attrs.dir || ''
 		},
 	},
 }

--- a/src/nodes/DetailsView.vue
+++ b/src/nodes/DetailsView.vue
@@ -86,7 +86,7 @@ div.details {
 
 	.details-container {
 		width: 100%;
-		margin-right: 12px;
+		margin-inline-end: 12px;
 	}
 
 	:deep(summary) {

--- a/src/nodes/Table/TableCellView.vue
+++ b/src/nodes/Table/TableCellView.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NodeViewWrapper data-text-el="table-cell" as="td" :style="textAlign">
+	<NodeViewWrapper data-text-el="table-cell" as="td" :dir="dir" :style="textAlign">
 		<div class="container">
 			<NodeViewContent class="content" />
 			<NcActions v-if="isEditable" data-text-table-actions="row">
@@ -80,6 +80,9 @@ export default {
 	computed: {
 		textAlign() {
 			return { 'text-align': this.node.attrs.textAlign }
+		},
+		dir() {
+			return this.node.attrs.dir || ''
 		},
 	},
 	beforeMount() {

--- a/src/nodes/Table/TableHeaderView.vue
+++ b/src/nodes/Table/TableHeaderView.vue
@@ -4,7 +4,11 @@
 -->
 
 <template>
-	<NodeViewWrapper data-text-el="table-header" as="th" :style="textAlign">
+	<NodeViewWrapper
+		data-text-el="table-header"
+		as="th"
+		:dir="dir"
+		:style="textAlign">
 		<div>
 			<NodeViewContent class="content" />
 			<NcActions
@@ -131,6 +135,9 @@ export default {
 	computed: {
 		textAlign() {
 			return { 'text-align': this.node.attrs.textAlign }
+		},
+		dir() {
+			return this.node.attrs.dir || ''
 		},
 	},
 	beforeMount() {

--- a/src/tests/fixtures/tables/handbook/handbook.html
+++ b/src/tests/fixtures/tables/handbook/handbook.html
@@ -12,12 +12,12 @@
 <td style="width: 20%; height: 29px;">a</td>
 <td style="width: 20%; height: 29px;">b</td>
 <td style="width: 20%; height: 29px;">c</td>
-<td style="width: 20%; height: 29px;">d</td>
+<td style="width: 20%; height: 29px;">ب</td>
 </tr>
 <tr style="height: 29px;">
 <td style="width: 20%; height: 29px;"><strong>Number</strong></td>
 <td style="width: 20%; height: 29px;">1</td>
-<td style="width: 20%; height: 29px;">2</td>
+<td style="width: 20%; height: 29px;">٢</td>
 <td style="width: 20%; height: 29px;">3</td>
 <td style="width: 20%; height: 29px;">4</td>
 </tr>

--- a/src/tests/fixtures/tables/handbook/handbook.out.html
+++ b/src/tests/fixtures/tables/handbook/handbook.out.html
@@ -1,28 +1,28 @@
 <div class="table-wrapper" style="overflow-x: auto;">
 <table>
 <tr>
-<th><strong>Heading 0</strong></th>
-<th><strong>Heading 1</strong></th>
-<th><strong>Heading 2</strong></th>
-<th><strong>Heading 3</strong></th>
-<th><strong>Heading 4</strong></th>
+<th dir="ltr"><strong>Heading 0</strong></th>
+<th dir="ltr"><strong>Heading 1</strong></th>
+<th dir="ltr"><strong>Heading 2</strong></th>
+<th dir="ltr"><strong>Heading 3</strong></th>
+<th dir="ltr"><strong>Heading 4</strong></th>
 </tr>
 <tr>
-<td><strong>Letter</strong></td>
-<td>a</td>
-<td>b</td>
-<td>c</td>
-<td>d</td>
+<td dir="ltr"><strong>Letter</strong></td>
+<td dir="ltr">a</td>
+<td dir="ltr">b</td>
+<td dir="ltr">c</td>
+<td dir="rtl">ب</td>
 </tr>
 <tr>
-<td><strong>Number</strong></td>
+<td dir="ltr"><strong>Number</strong></td>
 <td>1</td>
-<td>2</td>
+<td dir="rtl">٢</td>
 <td>3</td>
 <td>4</td>
 </tr>
 <tr>
-<td><strong>Square</strong></td>
+<td dir="ltr"><strong>Square</strong></td>
 <td>1</td>
 <td>4</td>
 <td>9</td>

--- a/src/tests/nodes/Table.spec.js
+++ b/src/tests/nodes/Table.spec.js
@@ -49,14 +49,19 @@ describe('Table', () => {
 			editor.state.doc,
 			table(
 				thead(
-					th({ textAlign: 'center' }, 'heading'),
-					th({ textAlign: 'right' }, 'heading 2'),
-					th('heading 3'),
+					th({ dir: 'ltr', textAlign: 'center' }, 'heading'),
+					th({ dir: 'ltr', textAlign: 'right' }, 'heading 2'),
+					th({ dir: 'ltr' }, 'heading 3'),
 				),
 				tr(
-					td({ textAlign: 'center' }, 'center'),
-					td({ textAlign: 'right' }, 'right'),
-					td('left cell ', br({ syntax: 'html' }), 'with line break'),
+					td({ dir: 'ltr', textAlign: 'center' }, 'center'),
+					td({ dir: 'ltr', textAlign: 'right' }, 'right'),
+					td(
+						{ dir: 'ltr' },
+						'left cell ',
+						br({ syntax: 'html' }),
+						'with line break',
+					),
 				),
 			),
 		)
@@ -69,14 +74,19 @@ describe('Table', () => {
 			editor.state.doc,
 			table(
 				thead(
-					th({ textAlign: 'center' }, 'heading'),
-					th({ textAlign: 'right' }, 'heading 2'),
-					th('heading 3'),
+					th({ dir: 'ltr', textAlign: 'center' }, 'heading'),
+					th({ dir: 'ltr', textAlign: 'right' }, 'heading 2'),
+					th({ dir: 'ltr' }, 'heading 3'),
 				),
 				tr(
-					td({ textAlign: 'center' }, 'center'),
-					td({ textAlign: 'right' }, 'right'),
-					td('left cell ', br({ syntax: '  ' }), 'with line break'),
+					td({ dir: 'ltr', textAlign: 'center' }, 'center'),
+					td({ dir: 'ltr', textAlign: 'right' }, 'right'),
+					td(
+						{ dir: 'ltr' },
+						'left cell ',
+						br({ syntax: '  ' }),
+						'with line break',
+					),
 				),
 			),
 		)


### PR DESCRIPTION
### 📝 Summary

* [fix(TextDirection): Only regard changed nodes in `appendTransaction`](https://github.com/nextcloud/text/commit/a10882a78ce6d26482fad7242ee7f9ebe130560c)
* [fix(Keymap): Add Backspace shortcut to undo input rules](https://github.com/nextcloud/text/commit/bfb19fdc6927c51c22cebfe1a27353fc4986611b)
* [fix(TextDirection): Regard table cell, details summary and callouts](https://github.com/nextcloud/text/commit/c5e0b3538681a205fa4b1ba056d78cbf8f2bc88d)

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="2482" height="2116" alt="image" src="https://github.com/user-attachments/assets/303693e0-aefa-40e8-ac45-29d67cc0a442" /> | <img width="2482" height="2116" alt="image" src="https://github.com/user-attachments/assets/ae9c0ce4-8d90-42ec-8524-ece301208805" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
