### PR TITLE
fix(readonly-bar): Clean up read-only menu bar to behave consistently with normal menu bar

### DIFF
--- a/cypress/e2e/openreadonly.spec.js
+++ b/cypress/e2e/openreadonly.spec.js
@@ -24,7 +24,7 @@ describe('Open read-only mode', function () {
 
 	describe('Disabled', function () {
 		const checkMenubar = function () {
-			cy.get('.text-editor--readonly-bar').should('not.exist')
+			cy.get('[data-text-el="readonly-bar"]').should('not.exist')
 			cy.get('.text-menubar', { timeout: 10000 })
 				.getActionEntry('done')
 				.should('not.exist')
@@ -52,14 +52,14 @@ describe('Open read-only mode', function () {
 
 	describe('Enabled', function () {
 		const requireReadOnlyBar = function () {
-			cy.get('.text-editor--readonly-bar').should('exist')
-			cy.get('.text-editor--readonly-bar')
+			cy.get('[data-text-el="readonly-bar"]').should('exist')
+			cy.get('[data-text-el="readonly-bar"]')
 				.getActionEntry('edit')
 				.should('exist')
 		}
 
 		const requireMenubar = function () {
-			cy.get('.text-editor--readonly-bar').should('not.exist')
+			cy.get('[data-text-el="readonly-bar"]').should('not.exist')
 			cy.get('.text-menubar').getActionEntry('done').should('exist')
 		}
 
@@ -82,7 +82,7 @@ describe('Open read-only mode', function () {
 			requireReadOnlyBar()
 
 			// Switch to edit-mode
-			cy.get('.text-editor--readonly-bar').getActionEntry('edit').click()
+			cy.get('[data-text-el="readonly-bar"]').getActionEntry('edit').click()
 
 			requireMenubar()
 
@@ -98,10 +98,10 @@ describe('Open read-only mode', function () {
 			requireReadOnlyBar()
 
 			// Switch to edit-mode
-			cy.get('.text-editor--readonly-bar').getActionEntry('edit').click()
+			cy.get('[data-text-el="readonly-bar"]').getActionEntry('edit').click()
 
 			// Check that read-only bar does not exist
-			cy.get('.text-editor--readonly-bar').should('not.exist')
+			cy.get('[data-text-el="readonly-bar"]').should('not.exist')
 		})
 	})
 })

--- a/cypress/e2e/share.spec.js
+++ b/cypress/e2e/share.spec.js
@@ -41,7 +41,7 @@ describe('Open test.md in viewer', function () {
 					.find('h2')
 					.should('contain', 'Hello world')
 
-				cy.get('.text-editor--readonly-bar')
+				cy.get('[data-text-el="readonly-bar"]')
 					.getActionEntry('outline')
 					.click()
 

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -23,7 +23,7 @@
 			@outline-toggled="outlineToggled">
 			<MainContainer v-if="contentLoaded">
 				<!-- Readonly -->
-				 <template v-if="readOnly || (openReadOnlyEnabled && !editMode)">
+				<template v-if="readOnly || (openReadOnlyEnabled && !editMode)">
 					<slot name="readonlyBar">
 						<ReadonlyBar
 							:is-hidden="hideMenu"

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -23,11 +23,11 @@
 			@outline-toggled="outlineToggled">
 			<MainContainer v-if="contentLoaded">
 				<!-- Readonly -->
-				<div
-					v-if="readOnly || (openReadOnlyEnabled && !editMode)"
-					class="text-editor--readonly-bar">
+				 <template v-if="readOnly || (openReadOnlyEnabled && !editMode)">
 					<slot name="readonlyBar">
-						<ReadonlyBar :open-read-only="openReadOnlyEnabled">
+						<ReadonlyBar
+							:is-hidden="hideMenu"
+							:open-read-only="openReadOnlyEnabled">
 							<Status
 								:document="document"
 								:dirty="dirty"
@@ -35,7 +35,7 @@
 								:has-connection-issue="requireReconnect" />
 						</ReadonlyBar>
 					</slot>
-				</div>
+				</template>
 				<!-- Rich Menu -->
 				<template v-else>
 					<MenuBar
@@ -858,8 +858,7 @@ export default defineComponent({
 	}
 }
 
-.menubar-placeholder,
-.text-editor--readonly-bar {
+.menubar-placeholder {
 	position: fixed;
 	position: -webkit-sticky;
 	position: sticky;
@@ -873,7 +872,6 @@ export default defineComponent({
 	padding-block: var(--default-grid-baseline);
 }
 
-.text-editor--readonly-bar,
 .menubar-placeholder--with-slot {
 	opacity: unset;
 	visibility: unset;

--- a/src/components/Menu/ReadonlyBar.vue
+++ b/src/components/Menu/ReadonlyBar.vue
@@ -4,7 +4,15 @@
 -->
 
 <template>
-	<div data-text-el="readonly-bar" class="text-readonly-bar">
+	<div
+		data-text-el="readonly-bar"
+		class="text-readonly-bar"
+		:class="{
+			'text-readonly-bar--ready': isReady,
+			'text-readonly-bar--is-workspace': isRichWorkspace,
+			'text-readonly-bar--hide': isHidden,
+			'is-mobile': $isMobile,
+		}">
 		<div
 			ref="menubar"
 			role="toolbar"
@@ -25,7 +33,7 @@
 				:can-be-focussed="activeMenuEntry === index"
 				@disabled="disableMenuEntry(actionEntry.key, $event)" />
 		</div>
-		<div class="text-menubar__slot">
+		<div class="text-readonly-bar__slot">
 			<slot />
 		</div>
 	</div>
@@ -36,45 +44,127 @@ import { defineComponent } from 'vue'
 import { OutlineEntries, ReadOnlyEditEntries } from './entries.js'
 
 import { t } from '@nextcloud/l10n'
+import { useEditorFlags } from '../../composables/useEditorFlags.ts'
+import { useIsMobileMixin } from '../Editor.provider.ts'
 import ActionList from './ActionList.vue'
 import ActionSingle from './ActionSingle.vue'
 import ToolBarLogic from './ToolBarLogic.js'
 
 export default defineComponent({
 	name: 'ReadonlyBar',
+
 	components: {
 		ActionList,
 		ActionSingle,
 	},
+
 	extends: ToolBarLogic,
+
+	mixins: [useIsMobileMixin],
+
 	props: {
+		isHidden: {
+			type: Boolean,
+			default: false,
+		},
 		openReadOnly: {
 			type: Boolean,
 			default: false,
 		},
 	},
+
+	emits: ['update:loaded'],
+
+	setup() {
+		const { isRichWorkspace } = useEditorFlags()
+		return {
+			isRichWorkspace,
+		}
+	},
+
 	data() {
 		return {
 			entries: this.openReadOnly
 				? [...ReadOnlyEditEntries, ...OutlineEntries]
 				: [...OutlineEntries],
+			isReady: false,
 		}
 	},
+
+	mounted() {
+		this.$nextTick(() => {
+			this.isReady = true
+			this.$emit('update:loaded', true)
+		})
+	},
+
 	methods: {
 		t,
 	},
 })
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .text-readonly-bar {
-	display: flex;
-	height: var(--default-clickable-area);
+	--background-blur: blur(10px);
+	position: sticky;
+	top: 0;
+	bottom: var(--default-grid-baseline);
+	width: 100%;
+	z-index: 10021; // above modal-header so menubar is always on top
+	background-color: var(--color-main-background-translucent);
+	backdrop-filter: var(--background-blur);
+	max-height: var(
+		--default-clickable-area
+	); // important for mobile so that the buttons are always inside the container
 	border-bottom: 1px solid var(--color-border);
 	padding-block: var(--default-grid-baseline);
-}
-.text-readonly-bar__entries {
+
+	visibility: hidden;
+
 	display: flex;
-	flex-grow: 1;
+	justify-content: flex-end;
+	align-items: center;
+
+	&.is-mobile {
+		border-top: 1px solid var(--color-border);
+		border-bottom: unset;
+	}
+
+	&.text-readonly-bar--ready:not(.text-readonly-bar--hide) {
+		visibility: visible;
+		animation-name: fadeInDown;
+		animation-duration: 0.3s;
+	}
+
+	&.text-readonly-bar--hide {
+		opacity: 0;
+		transition:
+			visibility 0.2s 0.4s,
+			opacity 0.2s 0.4s;
+	}
+	.text-readonly-bar__entries {
+		display: flex;
+		flex-grow: 1;
+		margin-left: max(0px, calc((100% - var(--text-editor-max-width)) / 2));
+	}
+
+	.text-readonly-bar__slot {
+		justify-content: flex-end;
+		display: flex;
+		min-width: max(0px, min(100px, (100% - var(--text-editor-max-width)) / 2));
+	}
+
+	&.text-readonly-bar--is-workspace {
+		.text-readonly-bar__entries {
+			margin-left: 0;
+		}
+	}
+
+	@media (max-width: 660px) {
+		.text-readonly-bar__entries {
+			margin-left: 0;
+		}
+	}
 }
 </style>


### PR DESCRIPTION
### 📝 Summary

This pull request addresses several issues related to read-only mode:
- The README.md viewer in the file app no longer displays the read-only menu bar.
- The read-only menu bar now spans the full viewport width.
- Improved mobile support.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
