### PR TITLE
fix(links): do not steal focus on initial loading

### DIFF
--- a/src/components/Link/LinkBubbleView.vue
+++ b/src/components/Link/LinkBubbleView.vue
@@ -153,7 +153,7 @@ export default {
 	data() {
 		return {
 			isEditable: false,
-			edit: false,
+			edit: true,
 			newHref: null,
 			referenceTitle: null,
 		}
@@ -204,10 +204,6 @@ export default {
 		this.editor.on('update', ({ editor }) => {
 			this.isEditable = editor.isEditable
 		})
-	},
-
-	mounted() {
-		this.startEditIfEmpty()
 	},
 
 	methods: {


### PR DESCRIPTION
The `LinkBubbleView` is created and then mounted by `createTooltip`
in the `update` function of the `LinkBubblePluginView`.

This already happens during the initial rendering
as that is the first time the editor content is updated.

At this time the `href` is null and therefore `startEdit` is called
which in turn sets the focus in the entry field.

Instead set `edit` to `true` right away.

The behavior of `mod-k` is still inconsistent.
In particular it will not focus the link entry
if the `href` already was falsy - for example right after the start.
