### PR TITLE
fix: add close button when open readonly files on mobile app

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -33,6 +33,7 @@
 								:dirty="dirty"
 								:sync-error="syncError"
 								:has-connection-issue="requireReconnect" />
+							<slot name="header" />
 						</ReadonlyBar>
 					</slot>
 				</template>


### PR DESCRIPTION
### 📝 Summary

* Resolves: #7580

<!-- Write a summary of your change and some reasoning if needed -->
Add close button when open read-only files on mobile app

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/9cddee43-c2e6-40d3-84c8-f66ac79902b5" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/a998cf03-2547-4252-babf-6d67b947705d" />



### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
