### PR TITLE
fix(createEditor): always provide editor.

### DIFF
--- a/src/components/BaseReader.vue
+++ b/src/components/BaseReader.vue
@@ -53,10 +53,7 @@ export default {
 		// extensions is a factory building a list of extensions for the editor
 		const extensions = inject('extensions')
 		const renderHtml = inject('renderHtml')
-		const editor = new Editor({
-			content: renderHtml(props.content),
-			extensions: extensions(),
-		})
+		const editor = new Editor({ extensions: extensions() })
 		provideEditor(editor)
 		watch(
 			() => props.content,
@@ -67,6 +64,10 @@ export default {
 		)
 		const { setEditable } = useEditorMethods(editor)
 		setEditable(false)
+
+		// Render the initial content last as it may render Vue components
+		// that break the vue context of this setup function.
+		editor.setContent(renderHtml(props.content))
 		return { editor }
 	},
 

--- a/src/components/BaseReader.vue
+++ b/src/components/BaseReader.vue
@@ -52,22 +52,22 @@ export default {
 	setup(props) {
 		// extensions is a factory building a list of extensions for the editor
 		const extensions = inject('extensions')
-		const renderHtml = inject('renderHtml')
 		const editor = new Editor({ extensions: extensions() })
 		provideEditor(editor)
+
+		const { setContent, setEditable } = useEditorMethods(editor)
 		watch(
 			() => props.content,
 			(content) => {
 				console.warn({ content })
-				editor.commands.setContent(renderHtml(content), true)
+				setContent(content)
 			},
 		)
-		const { setEditable } = useEditorMethods(editor)
 		setEditable(false)
 
 		// Render the initial content last as it may render Vue components
 		// that break the vue context of this setup function.
-		editor.setContent(renderHtml(props.content))
+		setContent(props.content, { addToHistory: false })
 		return { editor }
 	},
 

--- a/src/components/Editor/MarkdownContentEditor.vue
+++ b/src/components/Editor/MarkdownContentEditor.vue
@@ -124,7 +124,7 @@ export default {
 		// Set content after the setup function
 		// as it may render other vue components such as preview toggle
 		// which breaks the context of the setup function.
-		this.setContent(this.content)
+		this.setContent(this.content, { addToHistory: false })
 		this.editor.on('create', () => {
 			this.$emit('ready')
 			this.$parent.$emit('ready')

--- a/src/components/Editor/MarkdownContentEditor.vue
+++ b/src/components/Editor/MarkdownContentEditor.vue
@@ -34,7 +34,6 @@ import { editorFlagsKey } from '../../composables/useEditorFlags.ts'
 import { useEditorMethods } from '../../composables/useEditorMethods.ts'
 import { FocusTrap, RichText } from '../../extensions/index.js'
 import { createMarkdownSerializer } from '../../extensions/Markdown.js'
-import markdownit from '../../markdownit/index.js'
 import AttachmentResolver from '../../services/AttachmentResolver.js'
 import { ATTACHMENT_RESOLVER } from '../Editor.provider.ts'
 import ReadonlyBar from '../Menu/ReadonlyBar.vue'
@@ -94,10 +93,7 @@ export default {
 			}),
 			FocusTrap,
 		]
-		const editor = new Editor({
-			content: markdownit.render(props.content),
-			extensions,
-		})
+		const editor = new Editor({ extensions })
 
 		const { setEditable, setContent } = useEditorMethods(editor)
 		watch(
@@ -121,10 +117,14 @@ export default {
 			isRichEditor: true,
 			isRichWorkspace: false,
 		})
-		return { editor }
+		return { editor, setContent }
 	},
 
 	created() {
+		// Set content after the setup function
+		// as it may render other vue components such as preview toggle
+		// which breaks the context of the setup function.
+		this.setContent(this.content)
 		this.editor.on('create', () => {
 			this.$emit('ready')
 			this.$parent.$emit('ready')

--- a/src/components/PlainTextReader.vue
+++ b/src/components/PlainTextReader.vue
@@ -8,7 +8,6 @@
 </template>
 
 <script>
-import escapeHtml from 'escape-html'
 import { PlainText } from './../extensions/index.js'
 import BaseReader from './BaseReader.vue'
 
@@ -17,9 +16,6 @@ export default {
 	components: { BaseReader },
 
 	provide: {
-		renderHtml(content) {
-			return '<pre>' + escapeHtml(content) + '</pre>'
-		},
 		extensions: () => [PlainText],
 	},
 

--- a/src/components/RichTextReader.vue
+++ b/src/components/RichTextReader.vue
@@ -11,7 +11,6 @@
 
 <script>
 import { RichText } from './../extensions/index.js'
-import markdownit from './../markdownit/index.js'
 import BaseReader from './BaseReader.vue'
 
 export default {
@@ -19,9 +18,6 @@ export default {
 	components: { BaseReader },
 
 	provide: {
-		renderHtml(content) {
-			return markdownit.render(content)
-		},
 		extensions() {
 			return [
 				RichText.configure({

--- a/src/extensions/RichText.js
+++ b/src/extensions/RichText.js
@@ -67,7 +67,7 @@ export default Extension.create({
 
 	addExtensions() {
 		const defaultExtensions = [
-			this.options.editing ? Markdown : null,
+			Markdown,
 			Document,
 			Text,
 			Paragraph,


### PR DESCRIPTION
Set content after providing the editor.

If the content contains links the editor renders `PreviewOptions`.

Rendering another component breaks the context of the setup function.
Namely `setCurrentInstance` gets called in the vue runtime
overwriting the current instance.

This leads to `provide` not working anymore as it has no current instance
to work with.

