### PR TITLE
fix(files): remove right padding from the prosemirror container

### DIFF
--- a/src/css/prosemirror.scss
+++ b/src/css/prosemirror.scss
@@ -15,7 +15,7 @@ div.ProseMirror {
 	white-space: pre-wrap;
 	-webkit-font-variant-ligatures: none;
 	font-variant-ligatures: none;
-	padding: 4px calc(15 * var(--default-grid-baseline)) 50px calc(15 * var(--default-grid-baseline));
+	padding: 4px 0 50px calc(15 * var(--default-grid-baseline));
 	line-height: 150%;
 	font-size: var(--default-font-size);
 	outline: none;


### PR DESCRIPTION
### 📝 Summary

* Resolves: https://github.com/nextcloud/text/issues/7649 


#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1540" height="640" alt="image" src="https://github.com/user-attachments/assets/381bc511-d308-46a8-bf12-202fd98eb9e7" /> | <img width="601" height="205" alt="Screenshot from 2025-09-17 17-53-23" src="https://github.com/user-attachments/assets/3c892f56-f303-45bf-8001-59c89af5b62f" />
