### PR TITLE
Fix: Delete old sessions in cleanup cron

### DIFF
--- a/lib/Cron/Cleanup.php
+++ b/lib/Cron/Cleanup.php
@@ -54,6 +54,10 @@ class Cleanup extends TimedJob {
 		$removedSessions = $this->sessionService->removeInactiveSessionsWithoutSteps();
 		$this->logger->debug('Removed ' . $removedSessions . ' inactive sessions');
 
+		$this->logger->debug('Run cleanup job for old sessions');
+		$removedOldSessions = $this->sessionService->removeOldSessions();
+		$this->logger->debug('Removed ' . $removedOldSessions . ' old sessions');
+
 		$this->logger->debug('Run cleanup job for obsolete documents folders');
 		$this->documentService->cleanupOldDocumentsFolders();
 	}

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -150,10 +150,10 @@ class SessionMapper extends QBMapper {
 		$ageThreshold = time() - $ageInSeconds;
 
 		do {
-			$oldSessionsBuilder = $this->db->getQueryBuilder();
-			$result = $oldSessionsBuilder->select('id')
+			$oldSessionsQb = $this->db->getQueryBuilder();
+			$result = $oldSessionsQb->select('id')
 				->from('text_sessions')
-				->where($oldSessionsBuilder->expr()->lt('last_contact', $oldSessionsBuilder->createNamedParameter($ageThreshold)))
+				->where($oldSessionsQb->expr()->lt('last_contact', $oldSessionsQb->createNamedParameter($ageThreshold)))
 				->setMaxResults($batchSize)
 				->executeQuery();
 
@@ -166,15 +166,15 @@ class SessionMapper extends QBMapper {
 				break;
 			}
 
-			$deleteStepsBuilder = $this->db->getQueryBuilder();
-			$deleteStepsBuilder->delete('text_steps')
-				->where($deleteStepsBuilder->expr()->in('session_id', $deleteStepsBuilder->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
+			$deleteStepsQb = $this->db->getQueryBuilder();
+			$deleteStepsQb->delete('text_steps')
+				->where($deleteStepsQb->expr()->in('session_id', $deleteStepsQb->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
 				->setParameter('ids', $sessionIds, IQueryBuilder::PARAM_INT_ARRAY)
 				->executeStatement();
 
-			$deleteSessionsBuilder = $this->db->getQueryBuilder();
-			$batchDeleted = $deleteSessionsBuilder->delete('text_sessions')
-				->where($deleteSessionsBuilder->expr()->in('id', $deleteSessionsBuilder->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
+			$deleteSessionsQb = $this->db->getQueryBuilder();
+			$batchDeleted = $deleteSessionsQb->delete('text_sessions')
+				->where($deleteSessionsQb->expr()->in('id', $deleteSessionsQb->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
 				->setParameter('ids', $sessionIds, IQueryBuilder::PARAM_INT_ARRAY)
 				->executeStatement();
 

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -166,12 +166,6 @@ class SessionMapper extends QBMapper {
 				break;
 			}
 
-			$deleteStepsQb = $this->db->getQueryBuilder();
-			$deleteStepsQb->delete('text_steps')
-				->where($deleteStepsQb->expr()->in('session_id', $deleteStepsQb->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
-				->setParameter('ids', $sessionIds, IQueryBuilder::PARAM_INT_ARRAY)
-				->executeStatement();
-
 			$deleteSessionsQb = $this->db->getQueryBuilder();
 			$batchDeleted = $deleteSessionsQb->delete('text_sessions')
 				->where($deleteSessionsQb->expr()->in('id', $deleteSessionsQb->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -150,21 +150,10 @@ class SessionMapper extends QBMapper {
 		$ageThreshold = time() - $ageInSeconds;
 
 		do {
-			$oldSessionsQb = $this->db->getQueryBuilder();
-			$result = $oldSessionsQb->select('s.id')
-				->from('text_sessions', 's')
-				->leftJoin('s', 'text_documents', 'd', $oldSessionsQb->expr()->eq('s.document_id', 'd.id'))
-				->leftJoin('s', 'text_steps', 'st', $oldSessionsQb->expr()->andX(
-					$oldSessionsQb->expr()->eq('st.session_id', 's.id'),
-					$oldSessionsQb->expr()->gte('st.id', 'd.last_saved_version')
-				))
-				->where($oldSessionsQb->expr()->lt('s.last_contact', $oldSessionsQb->createNamedParameter($ageThreshold)))
-				->andWhere(
-					$oldSessionsQb->expr()->orX(
-						$oldSessionsQb->expr()->isNull('d.id'),
-						$oldSessionsQb->expr()->isNull('st.id')
-					)
-				)
+			$oldSessionsBuilder = $this->db->getQueryBuilder();
+			$result = $oldSessionsBuilder->select('id')
+				->from('text_sessions')
+				->where($oldSessionsBuilder->expr()->lt('last_contact', $oldSessionsBuilder->createNamedParameter($ageThreshold)))
 				->setMaxResults($batchSize)
 				->executeQuery();
 
@@ -177,15 +166,15 @@ class SessionMapper extends QBMapper {
 				break;
 			}
 
-			$deleteStepsQb = $this->db->getQueryBuilder();
-			$deleteStepsQb->delete('text_steps')
-				->where($deleteStepsQb->expr()->in('session_id', $deleteStepsQb->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
+			$deleteStepsBuilder = $this->db->getQueryBuilder();
+			$deleteStepsBuilder->delete('text_steps')
+				->where($deleteStepsBuilder->expr()->in('session_id', $deleteStepsBuilder->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
 				->setParameter('ids', $sessionIds, IQueryBuilder::PARAM_INT_ARRAY)
 				->executeStatement();
 
-			$deleteSessionsQb = $this->db->getQueryBuilder();
-			$batchDeleted = $deleteSessionsQb->delete('text_sessions')
-				->where($deleteSessionsQb->expr()->in('id', $deleteSessionsQb->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
+			$deleteSessionsBuilder = $this->db->getQueryBuilder();
+			$batchDeleted = $deleteSessionsBuilder->delete('text_sessions')
+				->where($deleteSessionsBuilder->expr()->in('id', $deleteSessionsBuilder->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
 				->setParameter('ids', $sessionIds, IQueryBuilder::PARAM_INT_ARRAY)
 				->executeStatement();
 

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -156,7 +156,7 @@ class SessionMapper extends QBMapper {
 				->where($oldSessionsBuilder->expr()->lt('last_contact', $oldSessionsBuilder->createNamedParameter($ageThreshold)))
 				->setMaxResults($batchSize)
 				->executeQuery();
-			
+
 			$sessionIds = array_map(function ($row) {
 				return (int)$row['id'];
 			}, $result->fetchAll());

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -150,10 +150,21 @@ class SessionMapper extends QBMapper {
 		$ageThreshold = time() - $ageInSeconds;
 
 		do {
-			$oldSessionsBuilder = $this->db->getQueryBuilder();
-			$result = $oldSessionsBuilder->select('id')
-				->from('text_sessions')
-				->where($oldSessionsBuilder->expr()->lt('last_contact', $oldSessionsBuilder->createNamedParameter($ageThreshold)))
+			$oldSessionsQb = $this->db->getQueryBuilder();
+			$result = $oldSessionsQb->select('s.id')
+				->from('text_sessions', 's')
+				->leftJoin('s', 'text_documents', 'd', $oldSessionsQb->expr()->eq('s.document_id', 'd.id'))
+				->leftJoin('s', 'text_steps', 'st', $oldSessionsQb->expr()->andX(
+					$oldSessionsQb->expr()->eq('st.session_id', 's.id'),
+					$oldSessionsQb->expr()->gte('st.id', 'd.last_saved_version')
+				))
+				->where($oldSessionsQb->expr()->lt('s.last_contact', $oldSessionsQb->createNamedParameter($ageThreshold)))
+				->andWhere(
+					$oldSessionsQb->expr()->orX(
+						$oldSessionsQb->expr()->isNull('d.id'),
+						$oldSessionsQb->expr()->isNull('st.id')
+					)
+				)
 				->setMaxResults($batchSize)
 				->executeQuery();
 
@@ -166,15 +177,15 @@ class SessionMapper extends QBMapper {
 				break;
 			}
 
-			$deleteStepsBuilder = $this->db->getQueryBuilder();
-			$deleteStepsBuilder->delete('text_steps')
-				->where($deleteStepsBuilder->expr()->in('session_id', $deleteStepsBuilder->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
+			$deleteStepsQb = $this->db->getQueryBuilder();
+			$deleteStepsQb->delete('text_steps')
+				->where($deleteStepsQb->expr()->in('session_id', $deleteStepsQb->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
 				->setParameter('ids', $sessionIds, IQueryBuilder::PARAM_INT_ARRAY)
 				->executeStatement();
 
-			$deleteSessionsBuilder = $this->db->getQueryBuilder();
-			$batchDeleted = $deleteSessionsBuilder->delete('text_sessions')
-				->where($deleteSessionsBuilder->expr()->in('id', $deleteSessionsBuilder->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
+			$deleteSessionsQb = $this->db->getQueryBuilder();
+			$batchDeleted = $deleteSessionsQb->delete('text_sessions')
+				->where($deleteSessionsQb->expr()->in('id', $deleteSessionsQb->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY))
 				->setParameter('ids', $sessionIds, IQueryBuilder::PARAM_INT_ARRAY)
 				->executeStatement();
 

--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -138,6 +138,10 @@ class SessionService {
 		return $this->sessionMapper->deleteInactiveWithoutSteps($documentId);
 	}
 
+	public function removeOldSessions(int $ageInSeconds = 7776000): int {
+		return $this->sessionMapper->deleteOldSessions($ageInSeconds);
+	}
+
 	public function getSession(int $documentId, int $sessionId, string $token): ?Session {
 		if ($this->session !== null) {
 			return $this->session;

--- a/tests/unit/Db/SessionMapperTest.php
+++ b/tests/unit/Db/SessionMapperTest.php
@@ -9,12 +9,13 @@ class SessionMapperTest extends \Test\TestCase {
 
 	private SessionMapper $sessionMapper;
 	private StepMapper $stepMapper;
+	private DocumentMapper $documentMapper;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->sessionMapper = \OCP\Server::get(SessionMapper::class);
 		$this->stepMapper = \OCP\Server::get(StepMapper::class);
-
+		$this->documentMapper = \OCP\Server::get(DocumentMapper::class);
 	}
 
 	public function testDeleteInactiveWithoutSteps() {
@@ -100,23 +101,40 @@ class SessionMapperTest extends \Test\TestCase {
 	}
 
 	public function testDeleteOldSessions() {
-		$this->stepMapper->deleteAll(1);
-		$this->sessionMapper->deleteByDocumentId(1);
+		$this->documentMapper->clearAll();
+		$this->sessionMapper->clearAll();
+		$this->stepMapper->clearAll();
 
 		$fourMonthsAgo = time() - (120 * 24 * 60 * 60);
 		$oneWeekAgo = time() - (7 * 24 * 60 * 60);
 
-		// Create old and recent session
+		// Create document
+		$document = $this->documentMapper->insert(Document::fromParams([
+			'id' => 1,
+			'currentVersion' => 0,
+			'lastSavedVersion' => 100,
+			'lastSavedVersionTime' => time()
+		]));
+
+		// Create sessions
 		$oldSession = $this->sessionMapper->insert(Session::fromParams([
+			'id' => 1,
 			'userId' => 'admin',
-			'documentId' => 1,
+			'documentId' => $document->getId(),
+			'lastContact' => $fourMonthsAgo,
+			'token' => uniqid(),
+			'color' => '00ff00',
+		]));
+		$oldSessionWithNewVersion = $this->sessionMapper->insert(Session::fromParams([
+			'userId' => 'admin',
+			'documentId' => $document->getId(),
 			'lastContact' => $fourMonthsAgo,
 			'token' => uniqid(),
 			'color' => '00ff00',
 		]));
 		$recentSession = $this->sessionMapper->insert(Session::fromParams([
 			'userId' => 'admin',
-			'documentId' => 1,
+			'documentId' => $document->getId(),
 			'lastContact' => $oneWeekAgo,
 			'token' => uniqid(),
 			'color' => 'ff0000',
@@ -124,35 +142,46 @@ class SessionMapperTest extends \Test\TestCase {
 
 		// Create steps for old and recent session
 		$this->stepMapper->insert(Step::fromParams([
+			'id' => 1,
 			'sessionId' => $oldSession->getId(),
 			'documentId' => 1,
 			'data' => 'OLD_STEP',
 			'version' => 1,
 		]));
 		$this->stepMapper->insert(Step::fromParams([
+			'id' => 101,
+			'sessionId' => $oldSessionWithNewVersion->getId(),
+			'documentId' => 1,
+			'data' => 'OLD_STEP_NEW_VERSION',
+			'version' => 1,
+		]));
+		$this->stepMapper->insert(Step::fromParams([
+			'id' => 2,
 			'sessionId' => $recentSession->getId(),
 			'documentId' => 1,
 			'data' => 'RECENT_STEP',
 			'version' => 2,
 		]));
 
-		// Verify 2 sessions and 2 steps
-		self::assertCount(2, $this->sessionMapper->findAll(1));
-		self::assertCount(2, $this->stepMapper->find(1, 0));
+		// Verify 3 sessions and 3 steps
+		self::assertCount(3, $this->sessionMapper->findAll(1));
+		self::assertCount(3, $this->stepMapper->find(1, 0));
 
 		// Delete sessions older than 90 days
 		$threeMonths = 90 * 24 * 60 * 60;
 		$deletedCount = $this->sessionMapper->deleteOldSessions($threeMonths);
 		self::assertEquals(1, $deletedCount);
 
-		// Should have 1 recent session remaining
+		// Should have 2 sessions remaining
 		$remainingSessions = $this->sessionMapper->findAll(1);
-		self::assertCount(1, $remainingSessions);
-		self::assertEquals($recentSession->getId(), $remainingSessions[0]->getId());
+		self::assertCount(2, $remainingSessions);
+		self::assertEquals($oldSessionWithNewVersion->getId(), $remainingSessions[0]->getId());
+		self::assertEquals($recentSession->getId(), $remainingSessions[1]->getId());
 
-		// Should have 1 step from recent session remaining
+		// Should have 2 step remaining
 		$remainingSteps = $this->stepMapper->find(1, 0);
-		self::assertCount(1, $remainingSteps);
+		self::assertCount(2, $remainingSteps);
 		self::assertEquals($recentSession->getId(), $remainingSteps[0]->getSessionId());
+		self::assertEquals($oldSessionWithNewVersion->getId(), $remainingSteps[1]->getSessionId());
 	}
 }

--- a/tests/unit/Db/SessionMapperTest.php
+++ b/tests/unit/Db/SessionMapperTest.php
@@ -122,23 +122,8 @@ class SessionMapperTest extends \Test\TestCase {
 			'color' => 'ff0000',
 		]));
 
-		// Create steps for old and recent session
-		$this->stepMapper->insert(Step::fromParams([
-			'sessionId' => $oldSession->getId(),
-			'documentId' => 1,
-			'data' => 'OLD_STEP',
-			'version' => 1,
-		]));
-		$this->stepMapper->insert(Step::fromParams([
-			'sessionId' => $recentSession->getId(),
-			'documentId' => 1,
-			'data' => 'RECENT_STEP',
-			'version' => 2,
-		]));
-
-		// Verify 2 sessions and 2 steps
+		// Verify 2 sessions
 		self::assertCount(2, $this->sessionMapper->findAll(1));
-		self::assertCount(2, $this->stepMapper->find(1, 0));
 
 		// Delete sessions older than 90 days
 		$threeMonths = 90 * 24 * 60 * 60;
@@ -149,10 +134,5 @@ class SessionMapperTest extends \Test\TestCase {
 		$remainingSessions = $this->sessionMapper->findAll(1);
 		self::assertCount(1, $remainingSessions);
 		self::assertEquals($recentSession->getId(), $remainingSessions[0]->getId());
-
-		// Should have 1 step from recent session remaining
-		$remainingSteps = $this->stepMapper->find(1, 0);
-		self::assertCount(1, $remainingSteps);
-		self::assertEquals($recentSession->getId(), $remainingSteps[0]->getSessionId());
 	}
 }

--- a/tests/unit/Db/SessionMapperTest.php
+++ b/tests/unit/Db/SessionMapperTest.php
@@ -99,7 +99,7 @@ class SessionMapperTest extends \Test\TestCase {
 		self::assertCount(0, $this->sessionMapper->findAll(1));
 	}
 
-	public function testRemoveOldSessions() {
+	public function testDeleteOldSessions() {
 		$this->stepMapper->deleteAll(1);
 		$this->sessionMapper->deleteByDocumentId(1);
 

--- a/tests/unit/Db/SessionMapperTest.php
+++ b/tests/unit/Db/SessionMapperTest.php
@@ -98,4 +98,61 @@ class SessionMapperTest extends \Test\TestCase {
 
 		self::assertCount(0, $this->sessionMapper->findAll(1));
 	}
+
+	public function testRemoveOldSessions() {
+		$this->stepMapper->deleteAll(1);
+		$this->sessionMapper->deleteByDocumentId(1);
+
+		$fourMonthsAgo = time() - (120 * 24 * 60 * 60);
+		$oneWeekAgo = time() - (7 * 24 * 60 * 60);
+
+		// Create old and recent session
+		$oldSession = $this->sessionMapper->insert(Session::fromParams([
+			'userId' => 'admin',
+			'documentId' => 1,
+			'lastContact' => $fourMonthsAgo,
+			'token' => uniqid(),
+			'color' => '00ff00',
+		]));
+		$recentSession = $this->sessionMapper->insert(Session::fromParams([
+			'userId' => 'admin',
+			'documentId' => 1,
+			'lastContact' => $oneWeekAgo,
+			'token' => uniqid(),
+			'color' => 'ff0000',
+		]));
+
+		// Create steps for old and recent session
+		$this->stepMapper->insert(Step::fromParams([
+			'sessionId' => $oldSession->getId(),
+			'documentId' => 1,
+			'data' => 'OLD_STEP',
+			'version' => 1,
+		]));
+		$this->stepMapper->insert(Step::fromParams([
+			'sessionId' => $recentSession->getId(),
+			'documentId' => 1,
+			'data' => 'RECENT_STEP',
+			'version' => 2,
+		]));
+
+		// Verify 2 sessions and 2 steps
+		self::assertCount(2, $this->sessionMapper->findAll(1));
+		self::assertCount(2, $this->stepMapper->find(1, 0));
+
+		// Delete sessions older than 90 days
+		$threeMonths = 90 * 24 * 60 * 60;
+		$deletedCount = $this->sessionMapper->deleteOldSessions($threeMonths);
+		self::assertEquals(1, $deletedCount);
+
+		// Should have 1 recent session remaining
+		$remainingSessions = $this->sessionMapper->findAll(1);
+		self::assertCount(1, $remainingSessions);
+		self::assertEquals($recentSession->getId(), $remainingSessions[0]->getId());
+
+		// Should have 1 step from recent session remaining
+		$remainingSteps = $this->stepMapper->find(1, 0);
+		self::assertCount(1, $remainingSteps);
+		self::assertEquals($recentSession->getId(), $remainingSteps[0]->getSessionId());
+	}
 }

--- a/tests/unit/Db/SessionMapperTest.php
+++ b/tests/unit/Db/SessionMapperTest.php
@@ -9,13 +9,12 @@ class SessionMapperTest extends \Test\TestCase {
 
 	private SessionMapper $sessionMapper;
 	private StepMapper $stepMapper;
-	private DocumentMapper $documentMapper;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->sessionMapper = \OCP\Server::get(SessionMapper::class);
 		$this->stepMapper = \OCP\Server::get(StepMapper::class);
-		$this->documentMapper = \OCP\Server::get(DocumentMapper::class);
+
 	}
 
 	public function testDeleteInactiveWithoutSteps() {
@@ -101,40 +100,23 @@ class SessionMapperTest extends \Test\TestCase {
 	}
 
 	public function testDeleteOldSessions() {
-		$this->documentMapper->clearAll();
-		$this->sessionMapper->clearAll();
-		$this->stepMapper->clearAll();
+		$this->stepMapper->deleteAll(1);
+		$this->sessionMapper->deleteByDocumentId(1);
 
 		$fourMonthsAgo = time() - (120 * 24 * 60 * 60);
 		$oneWeekAgo = time() - (7 * 24 * 60 * 60);
 
-		// Create document
-		$document = $this->documentMapper->insert(Document::fromParams([
-			'id' => 1,
-			'currentVersion' => 0,
-			'lastSavedVersion' => 100,
-			'lastSavedVersionTime' => time()
-		]));
-
-		// Create sessions
+		// Create old and recent session
 		$oldSession = $this->sessionMapper->insert(Session::fromParams([
-			'id' => 1,
 			'userId' => 'admin',
-			'documentId' => $document->getId(),
-			'lastContact' => $fourMonthsAgo,
-			'token' => uniqid(),
-			'color' => '00ff00',
-		]));
-		$oldSessionWithNewVersion = $this->sessionMapper->insert(Session::fromParams([
-			'userId' => 'admin',
-			'documentId' => $document->getId(),
+			'documentId' => 1,
 			'lastContact' => $fourMonthsAgo,
 			'token' => uniqid(),
 			'color' => '00ff00',
 		]));
 		$recentSession = $this->sessionMapper->insert(Session::fromParams([
 			'userId' => 'admin',
-			'documentId' => $document->getId(),
+			'documentId' => 1,
 			'lastContact' => $oneWeekAgo,
 			'token' => uniqid(),
 			'color' => 'ff0000',
@@ -142,46 +124,35 @@ class SessionMapperTest extends \Test\TestCase {
 
 		// Create steps for old and recent session
 		$this->stepMapper->insert(Step::fromParams([
-			'id' => 1,
 			'sessionId' => $oldSession->getId(),
 			'documentId' => 1,
 			'data' => 'OLD_STEP',
 			'version' => 1,
 		]));
 		$this->stepMapper->insert(Step::fromParams([
-			'id' => 101,
-			'sessionId' => $oldSessionWithNewVersion->getId(),
-			'documentId' => 1,
-			'data' => 'OLD_STEP_NEW_VERSION',
-			'version' => 1,
-		]));
-		$this->stepMapper->insert(Step::fromParams([
-			'id' => 2,
 			'sessionId' => $recentSession->getId(),
 			'documentId' => 1,
 			'data' => 'RECENT_STEP',
 			'version' => 2,
 		]));
 
-		// Verify 3 sessions and 3 steps
-		self::assertCount(3, $this->sessionMapper->findAll(1));
-		self::assertCount(3, $this->stepMapper->find(1, 0));
+		// Verify 2 sessions and 2 steps
+		self::assertCount(2, $this->sessionMapper->findAll(1));
+		self::assertCount(2, $this->stepMapper->find(1, 0));
 
 		// Delete sessions older than 90 days
 		$threeMonths = 90 * 24 * 60 * 60;
 		$deletedCount = $this->sessionMapper->deleteOldSessions($threeMonths);
 		self::assertEquals(1, $deletedCount);
 
-		// Should have 2 sessions remaining
+		// Should have 1 recent session remaining
 		$remainingSessions = $this->sessionMapper->findAll(1);
-		self::assertCount(2, $remainingSessions);
-		self::assertEquals($oldSessionWithNewVersion->getId(), $remainingSessions[0]->getId());
-		self::assertEquals($recentSession->getId(), $remainingSessions[1]->getId());
+		self::assertCount(1, $remainingSessions);
+		self::assertEquals($recentSession->getId(), $remainingSessions[0]->getId());
 
-		// Should have 2 step remaining
+		// Should have 1 step from recent session remaining
 		$remainingSteps = $this->stepMapper->find(1, 0);
-		self::assertCount(2, $remainingSteps);
+		self::assertCount(1, $remainingSteps);
 		self::assertEquals($recentSession->getId(), $remainingSteps[0]->getSessionId());
-		self::assertEquals($oldSessionWithNewVersion->getId(), $remainingSteps[1]->getSessionId());
 	}
 }


### PR DESCRIPTION
### 📝 Summary

The oc_text_steps table was growing significantly. This adds a step to the cleanup cron which deletes sessions with their steps older than 90 days. The sessions are deleted in batches of 1000 and the execution is time-limited for 30 seconds.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
