### PR TITLE
fix(sync): lastSavedVersion is version send with the request

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -391,7 +391,7 @@ class DocumentService {
 			if ($documentState !== null) {
 				$this->writeDocumentState($file->getId(), $documentState);
 			}
-			$document->setLastSavedVersion($stepsVersion);
+			$document->setLastSavedVersion($version);
 			$document->setLastSavedVersionTime($file->getMTime());
 			$document->setLastSavedVersionEtag($file->getEtag());
 			$this->documentMapper->update($document);
@@ -411,7 +411,7 @@ class DocumentService {
 					$this->writeDocumentState($file->getId(), $documentState);
 				}
 			});
-			$document->setLastSavedVersion($stepsVersion);
+			$document->setLastSavedVersion($version);
 			$document->setLastSavedVersionTime($file->getMTime());
 			$document->setLastSavedVersionEtag($file->getEtag());
 			$this->documentMapper->update($document);


### PR DESCRIPTION
See #7692 .

In the save request the client sends:
* the serialized content of the document (maybe plus local edits that were not synced yet).
* the document state according to the steps it received until that point
* the version (i.e. id) of the last step it has received from the server (`$version`)

`$stepsVersion` is the latest version the server has seen until now.

`lastSavedVersion` should be `$version` - i.e. the version the client has processed
at the time it initiated the save request.

Otherwise when loading the document
or attempting to recover from missing steps
the steps between `$version` and `$stepsVersion` will be left out.

## Network captures

Left is client that saved, right is client that was sending changes constantly.
Left client saved with `"version":14830451`. Document is saved with `lastSavedVersion` set to 14830508.

<img width="1920" height="552" alt="image" src="https://github.com/user-attachments/assets/32f0fb4b-ed79-4846-999f-95a70064f5a0" />


## Impact

While this does explain why the client could not recover from missing a step it does not explain why it did not process the step it received in the first place.