### PR TITLE
chore(DocumentService): Raise log level for SyncStep2 message to error

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -230,19 +230,19 @@ class DocumentService {
 			$newVersion = $this->insertSteps($document, $session, $stepsToInsert);
 		}
 
-		// By default send all steps the user has not received yet.
+		// By default, send all steps the user has not received yet.
 		$getStepsSinceVersion = $version;
 		if ($stepsIncludeQuery) {
-			$this->logger->debug('Loading document state for ' . $documentId);
+			$this->logger->error('Loading document state for ' . $documentId);
 			try {
 				$stateFile = $this->getStateFile($documentId);
 				$documentState = $stateFile->getContent();
 				$this->logger->debug('Existing document, state file loaded ' . $documentId);
-				// If there were any queries in the steps send all steps since last save.
+				// If there were any queries in the steps, send all steps since last save.
 				$getStepsSinceVersion = $document->getLastSavedVersion();
 			} catch (NotFoundException $e) {
 				$this->logger->debug('Existing document, but no state file found for ' . $documentId);
-				// If there is no state file include all the steps.
+				// If there is no state file, include all the steps.
 				$getStepsSinceVersion = 0;
 			}
 		}


### PR DESCRIPTION
This happens if the client tries to recover from a missing step, which should not happen anyway. So let's log it as error to get a better understanding of how often this happens in practice.

Related: #7692

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
