### PR TITLE
test: detect out of sync state and recovery via yjs pendingStructs

### DIFF
--- a/src/tests/fixtures/steps_two_clients.js
+++ b/src/tests/fixtures/steps_two_clients.js
@@ -1,0 +1,13 @@
+// 10 steps each inserting one character ("abcdefghij"), alternating between two clients
+export default [
+	["AAI+AgPir\/+VDAAoAAAAA2RpcgF3A2x0cgcAAAAGBADir\/+VDAEBYQEAAAcBB2RlZmF1bHQDCXBhcmFncmFwaAA="],
+	["AAISAQGa2Iz7AwCE4q\/\/lQwCAWIA"],
+	["AAISAQHir\/+VDAOEmtiM+wMAAWMA"],
+	["AAISAQGa2Iz7AwGE4q\/\/lQwDAWQA"],
+	["AAISAQHir\/+VDASEmtiM+wMBAWUA"],
+	["AAISAQGa2Iz7AwKE4q\/\/lQwEAWYA"],
+	["AAISAQHir\/+VDAWEmtiM+wMCAWcA"],
+	["AAISAQGa2Iz7AwOE4q\/\/lQwFAWgA"],
+	["AAISAQHir\/+VDAaEmtiM+wMDAWkA"],
+	["AAISAQGa2Iz7AwSE4q\/\/lQwGAWoA"],
+]


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
