### PR TITLE
fix(sync): handle empty push requests

### DIFF
--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -181,9 +181,6 @@ class ApiService {
 			// Session was removed in the meantime. #3875
 			return new DataResponse(['error' => $this->l10n->t('Editing session has expired. Please reload the page.')], Http::STATUS_PRECONDITION_FAILED);
 		}
-		if (empty($steps)) {
-			return new DataResponse([]);
-		}
 		try {
 			$result = $this->documentService->addStep($document, $session, $steps, $version, $token);
 			$this->addToPushQueue($document, [$awareness, ...array_values($steps)]);


### PR DESCRIPTION
* Distribute the awareness state via notify push.
* Respond with the steps that arrived in the meantime.
