### PR TITLE
fix(SaveService): Don't save if yjs reports pendingStructs

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -801,6 +801,10 @@ export default defineComponent({
 			this.translateModal = false
 		},
 
+		hasYjsPendingStructs() {
+			return !!this.ydoc.store.pendingStructs
+		},
+
 		saveBeforeUnload() {
 			this.saveService.saveViaSendBeacon()
 		},

--- a/src/components/Editor/Status.vue
+++ b/src/components/Editor/Status.vue
@@ -11,7 +11,9 @@
 			:class="saveStatusClass">
 			<NcButton
 				type="tertiary"
-				:aria-label="t('text', 'Save document')"
+				:disabled="saveService.hasYjsPendingStructs()"
+				:title="saveTitle"
+				:aria-label="saveAriaLabel"
 				@click="onClickSave">
 				<template #icon>
 					<NcSavingIndicatorIcon
@@ -121,6 +123,16 @@ export default {
 				return 'error'
 			}
 			return this.dirtyStateIndicator ? 'saving' : 'saved'
+		},
+		saveTitle() {
+			return this.saveService.hasYjsPendingStructs()
+				? ('text', 'Cannot save due to inconsistent sync state')
+				: ''
+		},
+		saveAriaLabel() {
+			return this.saveService.hasYjsPendingStructs()
+				? ('text', 'Cannot save due to inconsistent sync state')
+				: ('text', 'Save document')
 		},
 		lastSavedString() {
 			// Make this a dependent of refreshMoment, so it will be recomputed

--- a/src/composables/useSaveService.ts
+++ b/src/composables/useSaveService.ts
@@ -23,6 +23,7 @@ export const provideSaveService = (
 		syncService,
 		serialize,
 		getDocumentState: () => getDocumentState(ydoc),
+		hasYjsPendingStructs: () => !!ydoc.store.pendingStructs,
 	})
 	provide(saveServiceKey, saveService)
 	return { saveService }

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -23,6 +23,7 @@ class SaveService {
 	syncService
 	serialize
 	getDocumentState
+	hasYjsPendingStructs
 	autosave
 
 	constructor({
@@ -30,16 +31,19 @@ class SaveService {
 		syncService,
 		serialize,
 		getDocumentState,
+		hasYjsPendingStructs,
 	}: {
 		connection: ShallowRef<Connection | undefined>
 		syncService: SyncService
 		serialize: () => string
 		getDocumentState: () => string
+		hasYjsPendingStructs: () => boolean
 	}) {
 		this.connection = connection
 		this.syncService = syncService
 		this.serialize = serialize
 		this.getDocumentState = getDocumentState
+		this.hasYjsPendingStructs = hasYjsPendingStructs
 		this.autosave = debounce(this._autosave.bind(this), AUTOSAVE_INTERVAL)
 		this.syncService.on('close', () => {
 			this.autosave.clear()
@@ -64,6 +68,11 @@ class SaveService {
 			logger.warn('Could not save due to missing connection')
 			return
 		}
+		// Don't save if we have pendingStructs (i.e. document state misses a step)
+		if (this.hasYjsPendingStructs()) {
+			logger.debug('[SaveService] not saving due to inconsistent yjs state')
+			return
+		}
 		try {
 			const response = await save(this.connection.value, {
 				version: this.version,
@@ -84,6 +93,10 @@ class SaveService {
 
 	saveViaSendBeacon() {
 		if (!this.connection.value) {
+			return
+		}
+		// Don't save if we have pendingStructs (i.e. document state misses a step)
+		if (this.hasYjsPendingStructs()) {
 			return
 		}
 		saveViaSendBeacon(this.connection.value, {


### PR DESCRIPTION
Yjs pendingStructs mean that the local yjs document state is missing a step. So let's not allow to save such an inconstent state to the server.

### Screenshot

| Disabled save button |
| --- |
| <img width="679" height="292" alt="disabled_save" src="https://github.com/user-attachments/assets/08cb7919-c01d-4d8f-a76d-a4fbac761cb1" /> |

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
