### PR TITLE
fix(css): Adjust status icon colors to Nextcloud 32 variable names

### DIFF
--- a/src/components/Assistant.vue
+++ b/src/components/Assistant.vue
@@ -520,10 +520,10 @@ ul {
 }
 
 .icon-status--success {
-	color: var(--color-success);
+	color: var(--color-element-success);
 }
 
 .icon-status--failed {
-	color: var(--color-error);
+	color: var(--color-element-error);
 }
 </style>

--- a/src/nodes/Callout.vue
+++ b/src/nodes/Callout.vue
@@ -91,22 +91,22 @@ export default {
 	// Info (default) variables
 	&,
 	&--info {
-		--callout-border: var(--color-info, #006aa3);
+		--callout-border: var(--color-element-info, #006aa3);
 	}
 
 	// Warn variables
 	&--warn {
-		--callout-border: var(--color-warning);
+		--callout-border: var(--color-element-warning);
 	}
 
 	// Error variables
 	&--error {
-		--callout-border: var(--color-error);
+		--callout-border: var(--color-element-error);
 	}
 
 	// Success variables
 	&--success {
-		--callout-border: var(--color-success);
+		--callout-border: var(--color-element-success);
 	}
 }
 </style>


### PR DESCRIPTION
Fixes: #7717

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1476" height="758" alt="image" src="https://github.com/user-attachments/assets/8a233012-42bb-4289-9430-7be99faa1132" /> | <img width="1476" height="758" alt="image" src="https://github.com/user-attachments/assets/b80f39bf-6412-4c9e-9467-cb209b9c6372" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
