### PR TITLE
fix(ci): Always use main branch for assistant app

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -40,16 +40,11 @@ jobs:
           ref: ${{ matrix.server-versions }}
           path: apps/viewer
 
-      - name: Register assistant Git reference
-        run: |
-          assistant_app_ref="$(if [ "${{ matrix.server-versions }}" = "master" ]; then echo -n "main"; else echo -n "${{ matrix.server-versions }}"; fi)"
-          echo "assistant_app_ref=$assistant_app_ref" >> $GITHUB_ENV
-
       - name: Checkout assistant
         uses: actions/checkout@v4.1.1
         with:
           repository: nextcloud/assistant
-          ref: '${{ env.assistant_app_ref }}'
+          ref: main
           path: apps/assistant
 
       - name: Checkout app


### PR DESCRIPTION
The assistant app doesn follow the branch strategy of server.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
