### PR TITLE
fix(editor): restore default editor width while not breaking drag handle

### DIFF
--- a/cypress/e2e/MenuBar.spec.js
+++ b/cypress/e2e/MenuBar.spec.js
@@ -63,10 +63,7 @@ describe('Test the rich text editor menu bar', function () {
 
 		it('applys default', function () {
 			cy.openTestFile()
-			cy.get('@maxWidth').should(
-				'equal',
-				'calc(80ch + 2 * 15 * var(--default-grid-baseline))',
-			)
+			cy.get('@maxWidth').should('equal', '80ch')
 		})
 
 		it('toggles value', function () {

--- a/src/components/Editor/ContentContainer.vue
+++ b/src/components/Editor/ContentContainer.vue
@@ -110,5 +110,6 @@ export default {
 	position: absolute;
 	left: -60px;
 	transform: translate(0, -20%);
+	padding-right: 24px;
 }
 </style>

--- a/src/components/Editor/PreviewOptions.vue
+++ b/src/components/Editor/PreviewOptions.vue
@@ -120,6 +120,8 @@ div[contenteditable='false'] {
 	left: -44px;
 	top: 50%;
 	transform: translate(0, -50%);
+	// Required to overlay the drag handler padding
+	z-index: 10000;
 }
 
 // Inside details, button needs to be shifted further

--- a/src/composables/useEditorWidth.ts
+++ b/src/composables/useEditorWidth.ts
@@ -71,11 +71,7 @@ export const provideEditorWidth = () => {
 		valueSingleton = value
 		isFullWidth.value = value
 	})
-	const width = computed(() =>
-		isFullWidth.value
-			? '100%'
-			: 'calc(80ch + 2 * 15 * var(--default-grid-baseline))',
-	)
+	const width = computed(() => (isFullWidth.value ? '100%' : '80ch'))
 	const applyEditorWidth = () => {
 		document.documentElement.style.setProperty(
 			'--text-editor-max-width',

--- a/src/css/prosemirror.scss
+++ b/src/css/prosemirror.scss
@@ -15,7 +15,7 @@ div.ProseMirror {
 	white-space: pre-wrap;
 	-webkit-font-variant-ligatures: none;
 	font-variant-ligatures: none;
-	padding: 4px calc(15 * var(--default-grid-baseline)) 50px calc(15 * var(--default-grid-baseline));
+	padding: 4px 8px 50px 14px;
 	line-height: 150%;
 	font-size: var(--default-font-size);
 	outline: none;


### PR DESCRIPTION
This way the drag handle overflows the editor width just like all the other action buttons left and right of the editor already did before.

To make sure the drag handle stays when leaving the editor container with the pointer while trying to reach the drag handle, the latter gets an extra `padding-right` to close the gap.

Since the link preview options three-dot menu is in that gap, it needs a higher z-index to stay accessible.

FIxes: #7649
Fixes: nextcloud/collectives#2020

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="2364" height="2652" alt="image" src="https://github.com/user-attachments/assets/3cb61750-5c2d-49be-9f9a-96bfaef8cc81" /> | <img width="2364" height="2652" alt="image" src="https://github.com/user-attachments/assets/aaa3c318-84a0-44c3-92a3-5142bf1d7f3c" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
