### PR TITLE
fix(print): Overwrite `display: grid` to prevent cut content

### DIFF
--- a/src/css/print.scss
+++ b/src/css/print.scss
@@ -99,21 +99,14 @@
 				th {
 					color: black !important;
 					font-weight: bold !important;
-					border-width: 0 1px 2px 0 !important;
+					border-width: 1px !important;
+					border-bottom-width: 2px !important;
 					border-color: gray !important;
-					border-style: none solid solid none !important;
-				}
-				th:last-of-type {
-					border-width: 0 0 2px 0 !important;
 				}
 
 				td {
-					border-style: none solid none none !important;
 					border-width: 1px !important;
 					border-color: gray !important;
-				}
-				td:last-of-type {
-					border: none !important;
 				}
 			}
 			.container-suggestions {

--- a/src/css/print.scss
+++ b/src/css/print.scss
@@ -57,8 +57,8 @@
 			// Hide menu bar
 			display: none !important;
 		}
-		.action-item {
-			// Hide table settings
+		.action-item, .table-add-column, .table-add-row {
+			// Hide table buttons
 			display: none !important;
 		}
 		.content-wrapper .editor__content {
@@ -93,7 +93,6 @@
 					page-break-inside: avoid;
 					// Some more indention
 					max-width: 90% !important;
-					margin: 5vw auto 5vw 5% !important;
 				}
 
 				// Add some borders below header and between columns

--- a/src/css/print.scss
+++ b/src/css/print.scss
@@ -88,11 +88,11 @@
 				.image,
 				img,
 				table {
+					// make sure table content fits page width
+					overflow-wrap: anywhere;
 					// try no page breaks within tables or images
 					break-inside: avoid-page;
 					page-break-inside: avoid;
-					// Some more indention
-					max-width: 90% !important;
 				}
 
 				// Add some borders below header and between columns

--- a/src/css/print.scss
+++ b/src/css/print.scss
@@ -62,6 +62,8 @@
 			display: none !important;
 		}
 		.content-wrapper .editor__content {
+			// Prevent cut lines (due to `display: grid`)
+			display: block;
 			// Margins set by page rule
 			max-width: 100%;
 		}


### PR DESCRIPTION
Fixes: #7553

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="2205" height="1791" alt="image" src="https://github.com/user-attachments/assets/0f45583b-5fd5-470e-8423-47978187a01e" /> | <img width="2206" height="1792" alt="image" src="https://github.com/user-attachments/assets/1ac0981e-3698-4681-9588-2ea0048b7aed" />
<img width="1759" height="1789" alt="image" src="https://github.com/user-attachments/assets/88a892a0-fcde-49c7-9067-10456a1ea252" /> | <img width="1764" height="1788" alt="image" src="https://github.com/user-attachments/assets/27989665-7995-486f-9998-48d0cf65f757" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
