### PR TITLE
fix(code): don't wrap lines in code blocks, only in plaintext documents

### DIFF
--- a/src/css/prosemirror.scss
+++ b/src/css/prosemirror.scss
@@ -199,7 +199,8 @@ div.ProseMirror {
 	}
 
 	pre {
-		white-space: pre-wrap;
+		white-space: pre;
+		overflow-x: auto;
 		background-color: var(--color-background-dark);
 		border-radius: var(--border-radius);
 		padding: 1em 1.3em;
@@ -214,6 +215,12 @@ div.ProseMirror {
 			font-size: 0.6rem;
 		}
 		code {
+			// We want line wrapping in plaintext documents only
+			white-space: pre !important;
+			&.language-plaintext {
+				white-space: pre-wrap !important;
+			}
+
 			.hljs-comment,
 			.hljs-quote {
 				color: #999999;


### PR DESCRIPTION
We want line wrapping in code blocks in plaintext txt documents only.

Fixes: #7601

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1474" height="868" alt="image" src="https://github.com/user-attachments/assets/8bc63ade-d7f7-45dd-b7aa-856adcf2fe33" /> | <img width="1474" height="822" alt="image" src="https://github.com/user-attachments/assets/1054d0bb-0de1-4e1a-aeda-a2f793ca57d5" />
<img width="1474" height="776" alt="image" src="https://github.com/user-attachments/assets/bad9ccf1-c46e-4901-9866-200613e89c89" /> | <img width="1474" height="636" alt="image" src="https://github.com/user-attachments/assets/d8e6a8d6-83f7-436b-85d5-7996b20f4562" />
<img width="1474" height="730" alt="image" src="https://github.com/user-attachments/assets/77994fe2-e7e5-4504-a3da-d39ffbaaf647" /> | <img width="1474" height="730" alt="image" src="https://github.com/user-attachments/assets/4aa7eca5-fffb-4fdf-8c16-44d758058738" />


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
