### PR TITLE
Revert "chore(DocumentService): Raise log level for SyncStep2 message to error"

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -234,7 +234,7 @@ class DocumentService {
 		// By default, send all steps the user has not received yet.
 		$getStepsSinceVersion = $version;
 		if ($stepsIncludeQuery) {
-			$this->logger->error('Loading document state for ' . $documentId);
+			$this->logger->debug('Loading document state for ' . $documentId);
 			try {
 				$stateFile = $this->getStateFile($documentId);
 				$documentState = $stateFile->getContent();


### PR DESCRIPTION
This reverts commit db3a398d01b4ca53b39d787df5f08338d0b34fdf.

Other than thought, the logging happens each time a document is opened, not only when the frontend tries to recover from a `pendingStructs` situation.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
