### PR TITLE
fix(PreviewOptions): set active radio button on open

### DIFF
--- a/src/components/Editor/PreviewOptions.vue
+++ b/src/components/Editor/PreviewOptions.vue
@@ -17,7 +17,7 @@
 				data-text-preview-option="text-only"
 				name="preview-option"
 				value="text-only"
-				:checked="type === 'text-only'"
+				:model-value="type"
 				@change="(e) => toggle(e.currentTarget.value)">
 				{{ t('text', 'Text only') }}
 			</NcActionRadio>
@@ -25,7 +25,7 @@
 				data-text-preview-option="link-preview"
 				name="preview-option"
 				value="link-preview"
-				:checked="type === 'link-preview'"
+				:model-value="type"
 				@change="(e) => toggle(e.currentTarget.value)">
 				{{ t('text', 'Show link preview') }}
 			</NcActionRadio>


### PR DESCRIPTION
Fixes: #7544

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="179" height="193" alt="image" src="https://github.com/user-attachments/assets/9b44647f-94c5-4e20-9e8e-b463cd4d1352" /> | <img width="179" height="193" alt="image" src="https://github.com/user-attachments/assets/a489a3fa-86d7-471a-a7e5-acceb4fffaaa" />


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
