### PR TITLE
fix(sync): Apply document state from create request

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -106,6 +106,7 @@ import { CollaborationCursor } from '../extensions/index.js'
 import { exposeForDebugging, removeFromDebugging } from '../helpers/debug.js'
 import { logger } from '../helpers/logger.js'
 import { setInitialYjsState } from '../helpers/setInitialYjsState.js'
+import { applyDocumentState } from '../helpers/yjs.ts'
 import { ERROR_TYPE, IDLE_TIMEOUT } from '../services/SyncService.ts'
 import { fetchNode } from '../services/WebdavClient.ts'
 import {
@@ -458,7 +459,6 @@ export default defineComponent({
 			const bus = this.syncService.bus
 			bus.on('opened', this.onOpened)
 			bus.on('change', this.onChange)
-			bus.on('loaded', this.onLoaded)
 			bus.on('sync', this.onSync)
 			bus.on('error', this.onError)
 			bus.on('stateChange', this.onStateChange)
@@ -470,7 +470,6 @@ export default defineComponent({
 			const bus = this.syncService.bus
 			bus.off('opened', this.onOpened)
 			bus.off('change', this.onChange)
-			bus.off('loaded', this.onLoaded)
 			bus.off('sync', this.onSync)
 			bus.off('error', this.onError)
 			bus.off('stateChange', this.onStateChange)
@@ -517,7 +516,9 @@ export default defineComponent({
 			// Fetch the document state after syntax highlights are loaded
 			this.lowlightLoaded.then(() => {
 				this.syncService.startSync()
-				if (!documentState) {
+				if (documentState) {
+					applyDocumentState(this.ydoc, documentState, this.syncProvider)
+				} else {
 					setInitialYjsState(this.ydoc, content, {
 						isRichEditor: this.isRichEditor,
 					})

--- a/src/services/y-websocket.js
+++ b/src/services/y-websocket.js
@@ -223,11 +223,6 @@ const setupWS = (provider) => {
 					status: 'connected',
 				},
 			])
-			// always send sync step 1 when connected
-			const encoder = encoding.createEncoder()
-			encoding.writeVarUint(encoder, messageSync)
-			syncProtocol.writeSyncStep1(encoder, provider.doc)
-			websocket.send(encoding.toUint8Array(encoder))
 			// broadcast local awareness state
 			if (provider.awareness.getLocalState() !== null) {
 				const encoderAwarenessState = encoding.createEncoder()


### PR DESCRIPTION
Prevents possible race condition when steps from first sync request got applied before documentState from first push request (answer to SyncStep1) arrived.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
