### PR TITLE
chore(migrate): scss use @use instead of @import

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -887,12 +887,11 @@ export default defineComponent({
 </style>
 
 <style lang="scss">
-@import './../css/style';
-@import './../css/print';
+@use './../css/style';
+@use './../css/print';
+@use './../css/prosemirror';
 
 .text-editor__wrapper {
-	@import './../css/prosemirror';
-
 	// relative position for the alignment of the menububble
 	.text-editor__main {
 		&.draggedOver {

--- a/src/components/Editor/MarkdownContentEditor.vue
+++ b/src/components/Editor/MarkdownContentEditor.vue
@@ -178,6 +178,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import './../../css/prosemirror';
-@import './../../css/print';
+@use './../../css/prosemirror';
+@use './../../css/print';
 </style>

--- a/src/components/HelpModal.vue
+++ b/src/components/HelpModal.vue
@@ -315,6 +315,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@use '../css/prosemirror';
+
 table {
 	margin-top: 24px;
 	border-collapse: collapse;
@@ -372,8 +374,6 @@ table {
 		border-radius: 6px;
 	}
 }
-
-@import '../css/prosemirror';
 
 div.ProseMirror {
 	display: inline;

--- a/src/components/RichTextReader.vue
+++ b/src/components/RichTextReader.vue
@@ -37,6 +37,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import './../css/prosemirror';
-@import './../css/print';
+@use './../css/prosemirror';
+@use './../css/print';
 </style>


### PR DESCRIPTION
Gets rid of the deprecation warning.

`@use` is per file / style block.
I.e. it is not possible to nest it inside a css selector
like we did in Editor.vue.
However I think our css is specific enough to not apply outside the editor anyway.
