### PR TITLE
fix(sync): Reset document sessions on upgrade

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 - **💾 Open format:** Files are saved as [Markdown](https://en.wikipedia.org/wiki/Markdown), so you can edit them from any other text app too.
 - **✊ Strong foundation:** We use [🐈 tiptap](https://tiptap.scrumpy.io) which is based on [🦉 ProseMirror](https://prosemirror.net) – huge thanks to them!
 	]]></description>
-	<version>7.0.0-dev.1</version>
+	<version>7.0.0-dev.2</version>
 	<licence>agpl</licence>
 	<author mail="jus@bitgrid.net">Julius Härtl</author>
 	<namespace>Text</namespace>

--- a/lib/Migration/ResetSessionsBeforeYjs.php
+++ b/lib/Migration/ResetSessionsBeforeYjs.php
@@ -29,7 +29,7 @@ class ResetSessionsBeforeYjs implements IRepairStep {
 	public function run(IOutput $output): void {
 		$appVersion = $this->config->getValueString('text', 'installed_version');
 
-		if (!$appVersion || version_compare($appVersion, '4.0.1') !== -1) {
+		if (!$appVersion || version_compare($appVersion, '7.0.0-dev.2') !== -1) {
 			return;
 		}
 


### PR DESCRIPTION
A bug in synchronizing the document state might have resulted in a Yjs document state with missing steps being persisted into the Ydoc that we store on the server. If no client that had the missing step did an autosave afterwards, future sync session members will never recover from this situation.

We implemented several improvements recently that should result in less out-of-sync situations where a step becomes missing. To start with fresh editing sessions and not carry on with possibly unrecoverable document states, let's reset all editing sessions with the next app update.

See #7692 for further context.

Resolved #7692

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
