### PR TITLE
fix(files.js): check,ether "show folder descr." is set or not

### DIFF
--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -31,6 +31,9 @@ export const addMenuRichWorkspace = () => {
 		displayName: t('text', 'Add folder description'),
 		category: NewMenuEntryCategory.Other,
 		enabled(context) {
+			if (!window?.OCA?.Text?.RichWorkspaceEnabled) {
+				return false
+			}
 			if (Number(context.attributes['rich-workspace-file'])) {
 				return false
 			}


### PR DESCRIPTION
### 📝 Summary

* Resolves: #7573

With this PR, the option 'Add folder description' is not more visible, if 'Show folder description' is turned off.
The user has to reload the page though, since the function, that checks the state of this setting, is somehow only called when the site gets reloaded.

### 🚧 TODO

- [ ] check value of `"files-setting-richworkspace"` (FilesSettings.vue) when '+New' menu is opened ?

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
