### PR TITLE
chore(cy): fix version assertion after push request

### DIFF
--- a/cypress/e2e/api/SessionApi.spec.js
+++ b/cypress/e2e/api/SessionApi.spec.js
@@ -82,7 +82,7 @@ describe('The session Api', function () {
 					const version = 0
 					cy.pushSteps({ connection, steps, version })
 						.its('version')
-						.should('be.at.least', 1)
+						.should('eql', 0)
 					cy.syncSteps(connection)
 						.its('steps[0].data')
 						.should('eql', steps)
@@ -134,7 +134,7 @@ describe('The session Api', function () {
 		it('saves', function () {
 			cy.pushSteps({ connection, steps: [messages.update], version })
 				.its('version')
-				.should('be.at.least', 1)
+				.should('eql', 0)
 			cy.save(connection, {
 				version: 1,
 				autosaveContent: '# Heading 1',
@@ -147,7 +147,7 @@ describe('The session Api', function () {
 			const documentState = 'Base64 encoded string'
 			cy.pushSteps({ connection, steps: [messages.update], version })
 				.its('version')
-				.should('be.at.least', 1)
+				.should('eql', 0)
 			cy.save(connection, {
 				version: 1,
 				autosaveContent: '# Heading 1',
@@ -208,7 +208,7 @@ describe('The session Api', function () {
 		it('saves public', function () {
 			cy.pushSteps({ connection, steps: [messages.update], version })
 				.its('version')
-				.should('be.at.least', 1)
+				.should('eql', 0)
 			cy.save(connection, {
 				version: 1,
 				autosaveContent: '# Heading 1',
@@ -222,7 +222,7 @@ describe('The session Api', function () {
 			const documentState = 'Base64 encoded string'
 			cy.pushSteps({ connection, steps: [messages.update], version })
 				.its('version')
-				.should('be.at.least', 1)
+				.should('eql', 0)
 			cy.save(connection, {
 				version: 1,
 				autosaveContent: '# Heading 1',
@@ -281,7 +281,7 @@ describe('The session Api', function () {
 			let joining
 			cy.pushSteps({ connection, steps: [messages.update], version })
 				.its('version')
-				.should('be.at.least', 1)
+				.should('eql', 0)
 			cy.openConnection({ filePath: '', token: shareToken })
 				.then(({ connection: con, data }) => {
 					joining = con
@@ -321,7 +321,7 @@ describe('The session Api', function () {
 			cy.log('Initial user pushes steps')
 			cy.pushSteps({ connection, steps: [messages.update], version })
 				.its('version')
-				.should('be.at.least', 1)
+				.should('eql', 0)
 			cy.log('Other user creates session')
 			cy.openConnection({ filePath: '', token: shareToken }).then(
 				({ connection: con }) => {


### PR DESCRIPTION
We now return 0 as long as no document state is send.
