### PR TITLE
chore(eslint): set ESLINT_USE_FLAT_CONFIG=false

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "build": "NODE_ENV=production NODE_OPTIONS='--max-old-space-size=4096' vite --mode production build",
     "dev": "NODE_ENV=development NODE_OPTIONS='--max-old-space-size=4096' vite --mode development build",
-    "lint": "tsc && eslint --ext .js,.ts,.vue src cypress",
-    "lint:fix": "tsc && eslint --ext .js,.ts,.vue src cypress --fix",
+    "lint": "tsc && ESLINT_USE_FLAT_CONFIG=false eslint --ext .js,.ts,.vue src cypress",
+    "lint:fix": "tsc && ESLINT_USE_FLAT_CONFIG=false eslint --ext .js,.ts,.vue src cypress --fix",
     "prettier": "prettier --check .",
     "prettier:change": "git diff HEAD --name-only | xargs prettier --write --no-error-on-unmatched-pattern",
     "prettier:fix": "prettier --write .",


### PR DESCRIPTION
This prevents eslint from importing the flat config file from server repository when the text repository is checked out in a subdirectory.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
