### PR TITLE
Fix: prevent the collision between y-websocket reconnectTimeout and polling interval

### DIFF
--- a/src/services/PollingBackend.ts
+++ b/src/services/PollingBackend.ts
@@ -43,7 +43,7 @@ const FETCH_INTERVAL_READ_ONLY = 30000
  * when a browser window is considered invisible by the page visibility API
  * https://developer.mozilla.org/de/docs/Web/API/Page_Visibility_API
  */
-const FETCH_INTERVAL_INVISIBLE = 30000
+const FETCH_INTERVAL_INVISIBLE = 20000
 
 const FETCH_INTERVAL_NOTIFY = 30000
 

--- a/src/services/y-websocket.js
+++ b/src/services/y-websocket.js
@@ -129,7 +129,7 @@ messageHandlers[messageAuth] = (
 }
 
 // @todo - this should depend on awareness.outdatedTime
-const messageReconnectTimeout = 30000
+const messageReconnectTimeout = 40000
 
 /**
  * @param {WebsocketProvider} provider


### PR DESCRIPTION
Minimal change to handle the timing more gracefully until we decide on a solution.