### PR TITLE
fix(files): Disable suggestions bar output for not rich workspace

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -56,7 +56,8 @@
 					v-show="contentLoaded"
 					ref="contentWrapper"
 					:read-only="!editMode" />
-				<SuggestionsBar v-if="isRichEditor && contentLoaded" />
+				<SuggestionsBar
+					v-if="isRichEditor && contentLoaded && !isRichWorkspace" />
 			</MainContainer>
 			<Reader
 				v-if="isResolvingConflict"


### PR DESCRIPTION
### 📝 Summary

* Resolves: https://github.com/nextcloud/text/issues/7874

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1280" height="394" alt="image" src="https://github.com/user-attachments/assets/e4f324dc-c1d9-48f1-ad8f-ed059a14e473" /> | <img width="2053" height="632" alt="image" src="https://github.com/user-attachments/assets/134fc957-edf3-447c-9436-b8c295a8bfa9" />
