### PR TITLE
feat: add downloadCallback for Viewer handler

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -34,7 +34,9 @@ if (typeof OCA.Viewer === 'undefined') {
 			if (editors instanceof Set) {
 				for (const editor of editors) {
 					if (editor?.fileId === fileInfo.fileid && editor?.dirty) {
-						logger.debug('Saving file before download', { fileId: fileInfo.fileid })
+						logger.debug('Saving file before download', {
+							fileId: fileInfo.fileid,
+						})
 						await editor.save()
 						return
 					}


### PR DESCRIPTION
### 📝 Summary

This PR is related to [this](https://github.com/nextcloud/viewer/pull/3001) PR in Viewer and in combination they resolve [this](https://github.com/nextcloud-gmbh/customer-feature-requests/issues/1059) issue in customer-feature-requests.

<!-- Write a summary of your change and some reasoning if needed -->

### Before:
When editing a markdown document online in files and download it from the editor/viewer without saving it manually, the last saved version is downloaded. The last saved version may not include what was just added/edited after the previous `save` operation. So the downloaded file may differ from the file one sees online.

### Now:
Clicking on `Download` now triggers an automatic `save` operation of the document. If the saving for some reason fails, the last saved version is still being downloaded.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
