### PR TITLE
fix(files): Fix unneeded space below menu bar on mobile views

### DIFF
--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -230,7 +230,7 @@ export default {
 	--background-blur: blur(10px);
 	position: sticky;
 	top: 0;
-	bottom: var(--default-grid-baseline);
+	bottom: 0;
 	width: 100%;
 	z-index: 10021; // above modal-header so menubar is always on top
 	background-color: var(--color-main-background-translucent);


### PR DESCRIPTION
### 📝 Summary

* Resolves: https://github.com/nextcloud/text/issues/7583

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="241" height="540" alt="image" src="https://github.com/user-attachments/assets/d88e3a29-b373-4704-a279-43d13c68c4b1" /> | <img width="388" height="223" alt="Screenshot from 2025-11-04 19-48-15" src="https://github.com/user-attachments/assets/6c0801d4-cadb-40ac-a7a8-9636b9c3ad28" />
