### PR TITLE
chore: Bump composer autoloader files with composer 2.9.0

### DIFF
--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitText
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Text\\' => 9,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Text\\' => 
+        'OCA\\Text\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),


### PR DESCRIPTION
Seems composer 2.9 changed the output slightly. Files commited after updating with `composer self-update` locally