### PR TITLE
fix: enable notify_push by default

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -45,7 +45,7 @@ class ConfigService {
 	}
 
 	public function isNotifyPushSyncEnabled(): bool {
-		return $this->appConfig->getValueBool(Application::APP_NAME, 'notify_push');
+		return $this->appConfig->getValueBool(Application::APP_NAME, 'notify_push', true);
 
 	}
 

--- a/src/services/NotifyService.ts
+++ b/src/services/NotifyService.ts
@@ -21,7 +21,7 @@ declare global {
 }
 
 if (!window._nc_text_notify) {
-	const isPushEnabled = loadState('text', 'notify_push', false)
+	const isPushEnabled = loadState('text', 'notify_push', true)
 	const useNotifyPush = isPushEnabled
 		? listen(
 				'text_steps',


### PR DESCRIPTION
This seems stable enought these days to turn it on by default if notify_push is available