### PR TITLE
fix: increase websocket timeout for background throttling

### DIFF
--- a/src/services/y-websocket.js
+++ b/src/services/y-websocket.js
@@ -129,7 +129,7 @@ messageHandlers[messageAuth] = (
 }
 
 // @todo - this should depend on awareness.outdatedTime
-const messageReconnectTimeout = 40000
+const messageReconnectTimeout = 70000
 
 /**
  * @param {WebsocketProvider} provider


### PR DESCRIPTION
### 📝 Summary
Increase the messageReconnectTimeout to 70 seconds to account for the 60 second background JS timer throttle in Chromium.

This prevents false connection lost notifications when the editor tab is in the background.

Local tests showed throttled intervals of: 59892ms, 59929ms, 59867ms, 59929ms, 59864ms, 59880ms - consistently under 60 seconds. A 70 second timeout should provide enough buffer.