### PR TITLE
fix: Properly check for array of authenticated share ids

### DIFF
--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -131,8 +131,8 @@ class WorkspaceController extends OCSController {
 			}
 			/** @psalm-suppress RedundantConditionGivenDocblockType */
 			if ($share->getPassword() !== null) {
-				$shareId = $this->session->get('public_link_authenticated');
-				if ($share->getId() !== $shareId) {
+				$shareIds = $this->session->get('public_link_authenticated');
+				if ($share->getId() !== $shareIds && (is_array($shareIds) && !in_array($share->getId(), $shareIds, true))) {
 					throw new ShareNotFound();
 				}
 			}

--- a/lib/Middleware/SessionMiddleware.php
+++ b/lib/Middleware/SessionMiddleware.php
@@ -143,8 +143,8 @@ class SessionMiddleware extends Middleware {
 			}
 
 			if ($share->getPassword() !== null) {
-				$shareId = $this->session->get('public_link_authenticated');
-				if ($share->getId() !== $shareId) {
+				$shareIds = $this->session->get('public_link_authenticated');
+				if ($share->getId() !== $shareIds && (is_array($shareIds) && !in_array($share->getId(), $shareIds, true))) {
 					throw new InvalidSessionException();
 				}
 			}


### PR DESCRIPTION
This was a regression from server 32.0.2 that the share link authentication session value is now an array, so we should check this as well.

Fix #7966 