### PR TITLE
fix(editor): enhance editor readiness and connection handling

### DIFF
--- a/src/components/Editor/ContentContainer.vue
+++ b/src/components/Editor/ContentContainer.vue
@@ -16,6 +16,7 @@
 		<slot />
 		<FloatingButtons v-if="showFloatingButtons" />
 		<EditorContent
+			v-if="editorReady"
 			role="document"
 			class="editor__content text-editor__content"
 			:editor="editor" />
@@ -54,6 +55,11 @@ export default {
 		const { isFullWidth } = useEditorWidth()
 		return { editor, isMobile, isFullWidth, isRichEditor, isRichWorkspace }
 	},
+	data() {
+		return {
+			editorReady: false,
+		}
+	},
 	computed: {
 		showOutline() {
 			return this.$outlineState.visible
@@ -67,6 +73,9 @@ export default {
 				&& !this.isRichWorkspace
 			)
 		},
+	},
+	mounted() {
+		this.editorReady = true
 	},
 }
 </script>

--- a/src/components/Editor/MarkdownContentEditor.vue
+++ b/src/components/Editor/MarkdownContentEditor.vue
@@ -28,7 +28,7 @@ import Wrapper from './Wrapper.vue'
 /* eslint-disable import/no-named-as-default */
 import { getCurrentUser } from '@nextcloud/auth'
 import { UndoRedo } from '@tiptap/extensions'
-import { provide, watch } from 'vue'
+import { provide, watch, onMounted } from 'vue'
 import { provideEditor } from '../../composables/useEditor.ts'
 import { editorFlagsKey } from '../../composables/useEditorFlags.ts'
 import { useEditorMethods } from '../../composables/useEditorMethods.ts'
@@ -38,6 +38,8 @@ import AttachmentResolver from '../../services/AttachmentResolver.js'
 import { ATTACHMENT_RESOLVER } from '../Editor.provider.ts'
 import ReadonlyBar from '../Menu/ReadonlyBar.vue'
 import ContentContainer from './ContentContainer.vue'
+import { provideConnection } from '../../composables/useConnection.ts'
+import { provideEditorWidth } from '../../composables/useEditorWidth.ts'
 
 export default {
 	name: 'MarkdownContentEditor',
@@ -116,6 +118,20 @@ export default {
 			isPublic: false,
 			isRichEditor: true,
 			isRichWorkspace: false,
+		})
+
+		const { openConnection } = provideConnection({
+			fileId: props.fileId,
+			relativePath: props.relativePath,
+			shareToken: props.shareToken,
+		})
+
+		const { applyEditorWidth } = provideEditorWidth()
+		onMounted(() => {
+			applyEditorWidth()
+			if (props.fileId) {
+				openConnection().catch(() => {})
+			}
 		})
 		return { editor, setContent }
 	},


### PR DESCRIPTION
### 📝 Summary

In Tables, I was seeing the following errors in the browser console. For large tables with many rich text cells, there are thousands of these logs. This gets rid of them:
```
editor.js:77 [Vue warn]: It looks like you are using a custom button as a <NcPopover> or other popover #trigger. If you are not using <NcButton> as a trigger, you need to bind attrs from the #trigger slot props to your custom button. See <NcPopover> docs for an example.

found in

---> <NcPopover>
       <NcActions>
         <ActionList> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Menu/ActionList.vue
           <MenuBar> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Menu/MenuBar.vue
             <MainContainer> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/MainContainer.vue
               <Wrapper> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/Wrapper.vue
                 <MarkdownContentEditor> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/MarkdownContentEditor.vue
                   <Root>
render @ editor.js:77
window.OCA.Text.createEditor @ editor.js:282Understand this error
useConnection.ts:77 [Vue warn]: injection "Symbol(text:opendata)" not found.

found in

---> <ActionAttachmentUpload> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Menu/ActionAttachmentUpload.vue
       <MenuBar> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Menu/MenuBar.vue
         <MainContainer> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/MainContainer.vue
           <Wrapper> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/Wrapper.vue
             <MarkdownContentEditor> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/MarkdownContentEditor.vue
               <Root>

render @ editor.js:77
window.OCA.Text.createEditor @ editor.js:282Understand this error
useEditorWidth.ts:87 [Vue warn]: injection "Symbol(text:editor:width)" not found.

found in

---> <ContentContainer> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/ContentContainer.vue
       <MainContainer> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/MainContainer.vue
         <Wrapper> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/Wrapper.vue
           <MarkdownContentEditor> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/MarkdownContentEditor.vue
             <Root>
render @ editor.js:77
window.OCA.Text.createEditor @ editor.js:282Understand this error
editor.js:77 [Vue warn]: "class" is a reserved attribute and cannot be used as component prop.

found in

---> <DragHandleVue>
       <FloatingButtons> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/FloatingButtons.vue
         <ContentContainer> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/ContentContainer.vue
           <MainContainer> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/MainContainer.vue
             <Wrapper> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/Wrapper.vue
               <MarkdownContentEditor> at /Users/cleopatra/Desktop/nc/nextcloud-docker-dev/workspace/server/apps-extra/text/src/components/Editor/MarkdownContentEditor.vue
                 <Root>
```
```
editor.js:82 Error: [tiptap error]: The editor view is not available. Cannot access view['dom']. The editor may not be mounted yet.
    at Object.get (index.js:4696:17)
    at VueComponent.beforeDestroy (index.js:56:29)
    at invokeWithErrorHandling (vue.runtime.esm.js:3033:61)
    at callHook$1 (vue.runtime.esm.js:4048:13)
    at Vue2.$destroy (vue.runtime.esm.js:3818:9)
    at destroy (vue.runtime.esm.js:4463:35)
    at invokeDestroyHook (vue.runtime.esm.js:6724:17)
    at invokeDestroyHook (vue.runtime.esm.js:6730:17)
    at VueComponent.patch2 [as __patch__] 
```


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
