### PR TITLE
fix(useEditorWidth): no full width toggle in rich workspace and on mobile

### DIFF
--- a/src/composables/useEditorWidth.ts
+++ b/src/composables/useEditorWidth.ts
@@ -22,6 +22,7 @@ import axios from '@nextcloud/axios'
 import { emit, subscribe } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 import { generateUrl } from '@nextcloud/router'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import {
 	computed,
 	inject,
@@ -32,6 +33,7 @@ import {
 	type InjectionKey,
 	type Ref,
 } from 'vue'
+import { useEditorFlags } from './useEditorFlags'
 
 // Keep the current value around when leaving the editor and reopening
 let valueSingleton = loadState('text', 'is_full_width_editor', false)
@@ -83,9 +85,14 @@ export const provideEditorWidth = () => {
 }
 
 export const useEditorWidth = () => {
+	const isMobile = useIsMobile()
+	const { isRichWorkspace } = useEditorFlags()
+
 	// This will be null if the width is already configured outside of text.
 	const isFullWidth = inject(editorWidthKey)
-	if (isFullWidth === null) {
+
+	// Disable if `editorWidthKey` got `null` injected or if in rich workspace or mobile view
+	if (isFullWidth === null || isRichWorkspace || isMobile.value) {
 		return { canToggleWidth: false }
 	}
 	const setFullWidth = (checked: boolean) => {

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -7,3 +7,8 @@ declare module '*?raw' {
 	const content: string
 	export default content
 }
+
+declare module '@nextcloud/vue/composables/useIsMobile' {
+	import { Ref } from 'vue'
+	export function useIsMobile(): Ref<boolean>
+}


### PR DESCRIPTION
There's no use in toggling full width in either of them.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
