### PR TITLE
fix: first action in empty document cannot be undone

### DIFF
--- a/playwright/e2e/history.spec.ts
+++ b/playwright/e2e/history.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, mergeTests } from '@playwright/test'
+import { test as editorTest } from '../support/fixtures/editor'
+import { test as uploadFileTest } from '../support/fixtures/upload-file'
+
+const test = mergeTests(editorTest, uploadFileTest)
+
+test.beforeEach(async ({ open }) => {
+	await open()
+})
+
+test.describe('Undo manager', () => {
+	test('Can undo first action in empty document', async ({ editor }) => {
+		await editor.type('a')
+		await expect(editor.content).toContainText('a')
+
+		const undoButton = editor.getMenu('Undo')
+		await expect(undoButton).not.toBeDisabled()
+		await undoButton.click()
+
+		await expect(editor.content).not.toContainText('a')
+	})
+})

--- a/src/extensions/TextDirection.ts
+++ b/src/extensions/TextDirection.ts
@@ -78,8 +78,6 @@ function TextDirectionPlugin({ types }: { types: string[] }) {
 			)
 			const changes = getChangedRanges(transform)
 
-			tr.setMeta('addToHistory', false)
-
 			changes.forEach(({ newRange }) => {
 				const nodes = findChildrenInRange(newState.doc, newRange, (node) =>
 					types.includes(node.type.name),


### PR DESCRIPTION
## Description
Fixes an issue where the first user action (e.g. typing or pasting) in an empty collaborative document cannot be undone. All actions after that work fine.

## Root Cause
The Yjs UndoManager tracks changes using a `lastChange` timestamp. When `lastChange` is `0`, the undo manager sets the timestamp but skips tracking that transaction. The first action in an empty document has `lastChange = 0`, so it gets skipped.

**Why `lastChange` is `0` on first action:**

The `TextDirection` extension detects and sets text direction (LTR/RTL) on the first user action. The extension sets `tr.setMeta('addToHistory', false)` to prevent the direction change from being tracked as a separate undo step.

This causes the following:
1. y-tiptap sync plugin sees `addToHistory: false` and calls `undoManager.stopCapturing()` ([sync-plugin.js:223](https://github.com/ueberdosis/y-tiptap/blob/main/src/plugins/sync-plugin.js#L223))
2. `stopCapturing()` resets `lastChange = 0` ([UndoManager.js:333](https://github.com/yjs/yjs/blob/main/src/utils/UndoManager.js#L333))
3. User's first action runs with `lastChange = 0` and is not added to undo stack

After the first action, the TextDirection extension skips processing, so no `addToHistory: false` is set and undo works normally.

## Solution
Remove `tr.setMeta('addToHistory', false)` from the TextDirection extension. The direction change is now tracked together with the user's text input. 

Tested with both LTR and RTL languages - the `addToHistory: false` flag is not needed for correct text direction and consistent undo behavior.

## Regression Test
Added `playwright/e2e/history.spec.ts` to prevent this bug from reoccurring. The test verifies that the first action in an empty document can be undone.