### PR TITLE
fix(ImageView): Use `mouseenter` instead of `mouseover`

### DIFF
--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -16,7 +16,7 @@
 				v-if="canDisplayImage"
 				v-click-outside="() => (showIcons = false)"
 				class="image__view"
-				@mouseover="showIcons = true"
+				@mouseenter="showIcons = true"
 				@mouseleave="showIcons = false">
 				<transition name="fade">
 					<template v-if="!failed">


### PR DESCRIPTION
The mouseover event event bubbles, which means that hovering child elements also triggers it. This can lead to bad performance. Thus it's better to use mouseenter.

See https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseenter_event#usage_notes

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
