### PR TITLE
test(ci): pin server repo to commit before `@nextcloud/files` v4

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           persist-credentials: false
           repository: nextcloud/server
-          ref: ${{ matrix.server-versions }}
+          # TODO: revert after viewer is fixed with latest server and `@nextcloud/files` v4.x
+          #ref: ${{ matrix.server-versions }}
+          ref: 282341a8d67b552a89768a1f91c1efe59b6ae254
           submodules: true
 
       - name: Checkout viewer


### PR DESCRIPTION
Currently all Cypress tests fail because server already upgraded to `@nextcloud/files` v4 but viewer and assistant app weren't updated yet.

This is a temporary fix to get back meaningful e2e tests that needs to be reverted once viewer and assistant apps got updated to be compatible with latest server and `@nextcloud/files` v4.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
