### PR TITLE
Revert "test(ci): pin server repo to commit before `@nextcloud/files` v4

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -34,9 +34,7 @@ jobs:
         with:
           persist-credentials: false
           repository: nextcloud/server
-          # TODO: revert after viewer is fixed with latest server and `@nextcloud/files` v4.x
-          #ref: ${{ matrix.server-versions }}
-          ref: 282341a8d67b552a89768a1f91c1efe59b6ae254
+          ref: ${{ matrix.server-versions }}
           submodules: true
 
       - name: Checkout viewer


### PR DESCRIPTION
This reverts commit fe8abbe6239456361a1e6a3ff93ec0ed4f8aa137.

To be merged once viewer and assistant apps are updated to work with latest server and `@nextcloud/files` v4.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
