### PR TITLE
fix: expose getHtml() to editor api

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -94,6 +94,11 @@ class TextEditorEmbed {
 		return this
 	}
 
+	getHTML() {
+		const editor = this.#getEditorComponent()?.editor
+		return editor?.getHTML()
+	}
+
 	setSearchQuery(query, matchAll) {
 		const editor = this.#getEditorComponent()?.editor
 		editor?.commands.setSearchQuery(query, matchAll)


### PR DESCRIPTION
### 📝 Summary

Exposing [Tiptaps getHtml() ](https://tiptap.dev/docs/guides/output-json-html#option-2-html)in the editor API is needed to fix the insertion of tables in the Whiteboard App: https://github.com/nextcloud/whiteboard/pull/902


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
