### PR TITLE
chore(tests): no retries for the propfind spec

### DIFF
--- a/cypress/e2e/propfind.spec.js
+++ b/cypress/e2e/propfind.spec.js
@@ -7,7 +7,8 @@ import { randUser } from '../utils/index.js'
 
 const user = randUser()
 
-describe('Text PROPFIND extension ', function () {
+// Retries fail because folders / files already exist.
+describe('Text PROPFIND extension ', { retries: 0 }, function () {
 	const richWorkspace = '{http://nextcloud.org/ns}rich-workspace'
 
 	before(function () {


### PR DESCRIPTION
They fail anyways because the files / folders already exist.
This can hide the actual failure / lead to confusion.

See https://github.com/nextcloud/text/actions/runs/20364768903/job/58520805481?pr=8082