### PR TITLE
[stable32] fix(tests): wait for btn in attachments.spec to be visible before cli…

### DIFF
--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -195,7 +195,9 @@ describe('Test all attachment insertion methods', () => {
 				cy.get('.file-picker [data-filename="a"]').click()
 				cy.get('.file-picker [data-filename="a.png"]').click()
 
-				cy.get('.dialog__actions button.button-vue--vue-primary').click()
+				cy.get('.dialog__actions button.button-vue--vue-primary')
+					.should('be.visible')
+					.click()
 
 				return waitForRequestAndCheckAttachment(requestAlias)
 			})
@@ -212,7 +214,9 @@ describe('Test all attachment insertion methods', () => {
 				cy.get('.file-picker [data-filename="b"]').click()
 				cy.get('.file-picker [data-filename="b.png"]').click()
 
-				cy.get('.dialog__actions button.button-vue--vue-primary').click()
+				cy.get('.dialog__actions button.button-vue--vue-primary')
+					.should('be.visible')
+					.click()
 
 				return waitForRequestAndCheckAttachment(requestAlias)
 			})
@@ -229,7 +233,9 @@ describe('Test all attachment insertion methods', () => {
 				cy.log('Select the file in the filepicker')
 				cy.get('.file-picker [data-filename="github.png"]').click()
 				cy.log('Click OK in the filepicker')
-				cy.get('.dialog__actions button.button-vue--vue-primary').click()
+				cy.get('.dialog__actions button.button-vue--vue-primary')
+					.should('be.visible')
+					.click()
 
 				return waitForRequestAndCheckAttachment(requestAlias)
 			})


### PR DESCRIPTION
### 📝 Summary

Fix failing tests in attachments.spec.js

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
