### PR TITLE
fix: constrain height of video preview

### DIFF
--- a/src/nodes/Preview.vue
+++ b/src/nodes/Preview.vue
@@ -92,6 +92,20 @@ export default {
 	}
 }
 
+:deep(.plyr__video-wrapper) {
+	max-height: 400px;
+	overflow: hidden;
+}
+
+:deep(video),
+:deep(iframe) {
+	max-height: 400px;
+	height: auto;
+	width: 100%;
+	display: block;
+	object-fit: contain;
+}
+
 // Align in upper right corner of preview image
 .link-preview-header {
 	position: absolute;


### PR DESCRIPTION
### 📝 Summary

* Resolves: #8114 

The height of embedded videos is too big. This PR adds styling constraints to the video-wrapper.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
<img width="578" height="970" alt="Screenshot from 2025-12-22 15-31-47" src="https://github.com/user-attachments/assets/38d09f16-8e62-4989-824b-f2dc513e1bbc" />
|
<img width="582" height="546" alt="Screenshot from 2025-12-22 15-32-15" src="https://github.com/user-attachments/assets/fb1d4476-3ca7-49b7-94f9-58f83b5dbf2e" />

B | A


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
