### PR TITLE
fix(Db): fix type errors of $id with latest server with snowflake IDs

### DIFF
--- a/lib/Db/Document.php
+++ b/lib/Db/Document.php
@@ -27,7 +27,6 @@ use OCP\AppFramework\Db\Entity;
  * @method setChecksum(?string $checksum): void
  */
 class Document extends Entity implements \JsonSerializable {
-	public $id = null;
 	// TODO: Remove obsolete field `currentVersion`
 	protected int $currentVersion = 0;
 	protected int $lastSavedVersion = 0;
@@ -38,7 +37,6 @@ class Document extends Entity implements \JsonSerializable {
 	protected ?string $checksum = null;
 
 	public function __construct() {
-		$this->addType('id', 'integer');
 		$this->addType('currentVersion', 'integer');
 		$this->addType('lastSavedVersion', 'integer');
 		$this->addType('lastSavedVersionTime', 'integer');

--- a/lib/Db/Session.php
+++ b/lib/Db/Session.php
@@ -27,7 +27,6 @@ use OCP\AppFramework\Db\Entity;
  * @method void setDocumentId(int $documentId)
  */
 class Session extends Entity implements JsonSerializable {
-	public $id;
 	protected ?string $userId = null;
 	protected string $token = '';
 	protected string $color = '';
@@ -37,7 +36,6 @@ class Session extends Entity implements JsonSerializable {
 	protected int $documentId = 0;
 
 	public function __construct() {
-		$this->addType('id', 'integer');
 		$this->addType('documentId', 'integer');
 		$this->addType('lastContact', 'integer');
 	}

--- a/lib/Db/Step.php
+++ b/lib/Db/Step.php
@@ -31,7 +31,6 @@ class Step extends Entity implements JsonSerializable {
 	 */
 	public const VERSION_STORED_IN_ID = 2147483647;
 
-	public $id = null;
 	protected string $data = '';
 	protected int $version = 0;
 	protected int $sessionId = 0;
@@ -39,7 +38,6 @@ class Step extends Entity implements JsonSerializable {
 	protected int $timestamp = 0;
 
 	public function __construct() {
-		$this->addType('id', 'integer');
 		$this->addType('version', 'integer');
 		$this->addType('documentId', 'integer');
 		$this->addType('sessionId', 'integer');


### PR DESCRIPTION
Defining the empty variable is not needed anyway and already happens in parent class Entity.php.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
