### PR TITLE
chore(test): use retrying assertion

### DIFF
--- a/playwright/e2e/versions.spec.ts
+++ b/playwright/e2e/versions.spec.ts
@@ -75,7 +75,7 @@ test.describe('Versions with distant timestamps', () => {
  * @param editor editor section to inspect for headings
  */
 async function checkVersions(versions: Locator, editor: EditorSection) {
-	expect(await versions.getByRole('link').count()).toBe(3)
+	expect(await versions.getByRole('link')).toHaveCount(3)
 	// the oldest version is at the end of the versions list
 	await versions.getByRole('link').nth(2).click()
 	await expect(editor.getHeading({ name: 'V1' })).toBeVisible()


### PR DESCRIPTION
This will wait for the versions to show. See https://github.com/nextcloud/text/actions/runs/21105448730?pr=8168 for a failing CI run before this fix.
<img width="936" height="327" alt="grafik" src="https://github.com/user-attachments/assets/5468149c-177a-4a2c-9663-52236d8fec31" />


The test will still fail due to https://github.com/nextcloud/viewer/issues/3052
but at least we get there.
