### PR TITLE
feat(tables): enable text alignment rendering in HTML output

### DIFF
--- a/src/nodes/Table/TableCell.js
+++ b/src/nodes/Table/TableCell.js
@@ -36,7 +36,16 @@ export default TableCell.extend({
 			...this.parent?.(),
 			textAlign: {
 				rendered: true,
-				parseHTML: (element) => element.style.textAlign || null,
+				default: null,
+				renderHTML: attributes => {
+					if (!attributes.textAlign) {
+						return {}
+					}
+					return {
+						style: `text-align: ${attributes.textAlign}`,
+					}
+				},
+				parseHTML: element => element.style.textAlign || null,
 			},
 		}
 	},

--- a/src/nodes/Table/TableHeader.js
+++ b/src/nodes/Table/TableHeader.js
@@ -43,7 +43,16 @@ export default TableHeader.extend({
 			...this.parent?.(),
 			textAlign: {
 				rendered: true,
-				parseHTML: (element) => element.style.textAlign || null,
+				default: null,
+				renderHTML: attributes => {
+					if (!attributes.textAlign) {
+						return {}
+					}
+					return {
+						style: `text-align: ${attributes.textAlign}`,
+					}
+				},
+				parseHTML: element => element.style.textAlign || null,
 			},
 		}
 	},


### PR DESCRIPTION
This PR is needed for text alignment of tables in Whiteboard: https://github.com/nextcloud/whiteboard/pull/957

Change rendered flag from false to true for textAlign attribute in TableCell and TableHeader to include alignment in DOM output.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
