### PR TITLE
perf: Decrease amount of filecache SQL call

### DIFF
--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -11,33 +11,30 @@ namespace OCA\Text\Service;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\Files\StorageInvalidException;
 use OCP\IL10N;
 
 class WorkspaceService {
-	private IL10N $l10n;
-
 	private const SUPPORTED_STATIC_FILENAMES = [
 		'Readme.md',
 		'README.md',
 		'readme.md'
 	];
 
-	public function __construct(IL10N $l10n) {
-		$this->l10n = $l10n;
+	public function __construct(
+		private readonly IL10N $l10n,
+	) {
 	}
 
 	public function getFile(Folder $folder): ?File {
 		foreach ($this->getSupportedFilenames() as $filename) {
 			try {
-				$exists = $folder->getStorage()->getCache()->get($folder->getInternalPath() . '/' . $filename);
-				if ($exists) {
-					$file = $folder->get($filename);
-					if ($file instanceof File) {
-						return $file;
-					}
+				$file = $folder->get($filename);
+				if ($file instanceof File) {
+					return $file;
 				}
-			} catch (NotFoundException|StorageInvalidException) {
+			} catch (NotFoundException|NotPermittedException|StorageInvalidException) {
 				continue;
 			}
 		}


### PR DESCRIPTION
### 📝 Summary

Instead of checking for the existance of the file and then getting it, directly get it and catch the exceptions. Still called too many times in my opinion, but that should help a bit :)

<img width="866" height="740" alt="image" src="https://github.com/user-attachments/assets/27f99f4b-84d4-428b-b31d-c679db24661f" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
