### PR TITLE
chore(cy): fix reload file list selector

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -266,7 +266,7 @@ Cypress.Commands.add('propfindFolder', (path, depth = 0) => {
 })
 
 Cypress.Commands.add('reloadFileList', () => {
-	cy.get('[data-cy-files-content-breadcrumbs] li:last-child').click()
+	cy.get('[title="Reload current directory"] button').click()
 	return cy.get('button').contains('Reload content').click()
 })
 


### PR DESCRIPTION
The breadcrumbs now contain nested lists.
So the `li:last-child` selector matches two elements.

The outer list is the crumbs themselves.
The inner list is the dropdown menu that has the actual reload button.

Should fix these failures: https://github.com/nextcloud/text/actions/runs/21450570466/job/61793381443?pr=8202

<img width="1280" height="720" alt="Share with attachments -- handle file operations by recipient user (failed)" src="https://github.com/user-attachments/assets/ce72b24e-9ed9-4406-9009-f2482c879479" />


