### PR TITLE
Bring back assertion broken by viewer regression

### DIFF
--- a/playwright/e2e/versions.spec.ts
+++ b/playwright/e2e/versions.spec.ts
@@ -81,6 +81,5 @@ async function checkVersions(versions: Locator, editor: EditorSection) {
 	await expect(editor.getHeading({ name: 'V2' })).toBeVisible()
 	// current version
 	await versions.getByRole('link').nth(0).click()
-	// https://github.com/nextcloud/viewer/issues/3052
-	// await expect(editor.getHeading({ name: 'V3' })).toBeVisible()
+	await expect(editor.getHeading({ name: 'V3' })).toBeVisible()
 }


### PR DESCRIPTION
* Reverts commit 59d9cab4a862fd48d4efa4fe3f5642387aaf6387.
* Blocked by https://github.com/nextcloud/viewer/issues/3052 .
