### PR TITLE
chore(psalm): invert condition on Folder / File

### DIFF
--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -138,7 +138,7 @@ class WorkspaceController extends OCSController {
 			}
 
 			$shareNode = $share->getNode();
-			$node = $shareNode instanceof File ? $shareNode : $shareNode->get($path);
+			$node = $shareNode instanceof Folder ? $shareNode->get($path) : $shareNode;
 			if ($node instanceof Folder) {
 				$file = $this->workspaceService->getFile($node);
 				if ($file === null) {


### PR DESCRIPTION
Psalm does not know `$shareNode` is a `Folder`
if it is not a `File`

