### PR TITLE
perf: get all markdown files in one SQL query

### DIFF
--- a/lib/DAV/WorkspacePlugin.php
+++ b/lib/DAV/WorkspacePlugin.php
@@ -10,7 +10,6 @@ namespace OCA\Text\DAV;
 
 use Exception;
 use OC\Files\Node\File;
-use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Files\FilesHome;
 use OCA\Text\Service\ConfigService;
 use OCA\Text\Service\WorkspaceService;
@@ -64,7 +63,7 @@ class WorkspacePlugin extends ServerPlugin {
 			return;
 		}
 
-		if (!$node instanceof Directory && !$node instanceof FilesHome) {
+		if (!$node instanceof FilesHome) {
 			return;
 		}
 

--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -10,8 +10,6 @@ namespace OCA\Text\Service;
 
 use OCP\Files\File;
 use OCP\Files\Folder;
-use OCP\Files\NotFoundException;
-use OCP\Files\StorageInvalidException;
 use OCP\IL10N;
 
 class WorkspaceService {
@@ -28,17 +26,13 @@ class WorkspaceService {
 	}
 
 	public function getFile(Folder $folder): ?File {
-		foreach ($this->getSupportedFilenames() as $filename) {
-			try {
-				$exists = $folder->getStorage()->getCache()->get($folder->getInternalPath() . '/' . $filename);
-				if ($exists) {
-					$file = $folder->get($filename);
-					if ($file instanceof File) {
-						return $file;
-					}
+		$content = $folder->getStorage()->getCache()->getFolderContents($folder->getInternalPath() . '/', 'text/markdown');
+		foreach ($content as $file) {
+			if (in_array($file->getName(), $this->getSupportedFilenames(), true)) {
+				$file = $folder->get($file->getPath());
+				if ($file instanceof File) {
+					return $file;
 				}
-			} catch (NotFoundException|StorageInvalidException) {
-				continue;
 			}
 		}
 		return null;


### PR DESCRIPTION
### 📝 Summary

Requires https://github.com/nextcloud/server/pull/57891

Directly get all markdown files from parent directory in one SQL query and then filter on it by name.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
