### PR TITLE
[stable33] Revert "perf: Decrease amount of filecache SQL call"

### DIFF
--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -11,30 +11,33 @@ namespace OCA\Text\Service;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
 use OCP\Files\StorageInvalidException;
 use OCP\IL10N;
 
 class WorkspaceService {
+	private IL10N $l10n;
+
 	private const SUPPORTED_STATIC_FILENAMES = [
 		'Readme.md',
 		'README.md',
 		'readme.md'
 	];
 
-	public function __construct(
-		private readonly IL10N $l10n,
-	) {
+	public function __construct(IL10N $l10n) {
+		$this->l10n = $l10n;
 	}
 
 	public function getFile(Folder $folder): ?File {
 		foreach ($this->getSupportedFilenames() as $filename) {
 			try {
-				$file = $folder->get($filename);
-				if ($file instanceof File) {
-					return $file;
+				$exists = $folder->getStorage()->getCache()->get($folder->getInternalPath() . '/' . $filename);
+				if ($exists) {
+					$file = $folder->get($filename);
+					if ($file instanceof File) {
+						return $file;
+					}
 				}
-			} catch (NotFoundException|NotPermittedException|StorageInvalidException) {
+			} catch (NotFoundException|StorageInvalidException) {
 				continue;
 			}
 		}


### PR DESCRIPTION
This reverts commit c060aa826f831fdd7c1906c2be06931e0563ef2d.

This is actually not that good in a production environement :(

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
