### PR TITLE
fix(ci): needs.input.outputs.head_ref not defined

### DIFF
--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -80,9 +80,7 @@ jobs:
 
       - name: Add and commit
         if: steps.changes.outputs.CHANGED != ''
-        env:
-          HEAD_REF: ${{ github.head_ref }}
         run: |
           git add --force js/ css/
           git commit --signoff -m 'chore(assets): recompile assets'
-          git push origin "$HEAD_REF"
+          git push origin ${{ github.head_ref }}


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
