### PR TITLE
[stable31] Fix/hide link decoration in read-only mode

### DIFF
--- a/src/plugins/previewOptions.js
+++ b/src/plugins/previewOptions.js
@@ -27,7 +27,7 @@ export default function previewOptions({ editor }) {
 		state: {
 			init(_, { doc }) {
 				if (!editor.options.editable) {
-					return { decorations: DecorationSet.create() }
+					return { linkParagraphs: [], decorations: DecorationSet.empty }
 				}
 				const linkParagraphs = extractLinkParagraphs(doc)
 				return {
@@ -36,10 +36,11 @@ export default function previewOptions({ editor }) {
 				}
 			},
 			apply(tr, value, _oldState, newState) {
-				if (!tr.docChanged) {
-					return value
-				}
+				// Always return empty decorations if editor is not editable
 				if (!editor.options.editable) {
+					return { linkParagraphs: [], decorations: DecorationSet.empty }
+				}
+				if (!tr.docChanged) {
 					return value
 				}
 				const linkParagraphs = extractLinkParagraphs(newState.doc)


### PR DESCRIPTION
### 📝 Summary

Note: This bug only happens in Nextcloud 31 and already has been fixed in NC 32.

#### Problem
When a Text file is shared in read-only mode, users can access and interact with link preview options (toggle preview mode, delete link, open in new tab). Changes appear to work but don't persist after reopening the file, creating a confusing UX.

#### Solution
Fixed the `previewOptions` plugin to check `editor.options.editable` at the beginning of the `apply()` function, before checking if the document changed. This ensures decorations (and thus the PreviewOptions component) are never created when the editor is read-only.


### 🏁 Checklist

- [X] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [X] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
