### PR TITLE
fix(attachments): adjust fileId in attachments folder+path on folder copy

### DIFF
--- a/lib/Listeners/NodeCopiedListener.php
+++ b/lib/Listeners/NodeCopiedListener.php
@@ -13,6 +13,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeCopiedEvent;
 use OCP\Files\File;
+use OCP\Files\Folder;
 use OCP\Lock\ILockingProvider;
 
 /**
@@ -41,6 +42,8 @@ class NodeCopiedListener implements IEventListener {
 			AttachmentService::replaceAttachmentFolderId($source, $target);
 			AttachmentService::replaceAttachmentFileIds($target, $fileIdMapping);
 			$target->lock(ILockingProvider::LOCK_SHARED);
+		} elseif ($source instanceof Folder && $target instanceof Folder) {
+			$this->attachmentService->copyAttachmentsInFolder($source, $target);
 		}
 	}
 }

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -689,6 +689,40 @@ readonly class AttachmentService {
 		return $fileIdMapping;
 	}
 
+	public function copyAttachmentsInFolder(Folder $sourceFolder, Folder $targetFolder): void {
+		foreach ($sourceFolder->getDirectoryListing() as $sourceNode) {
+			if ($sourceNode instanceof Folder && !str_starts_with($sourceNode->getName(), '.attachments.')) {
+				try {
+					$targetNode = $targetFolder->get($sourceNode->getName());
+				} catch (NotFoundException) {
+					// ignore if target node doesn't exist
+					continue;
+				}
+
+				if ($targetNode instanceof Folder) {
+					$this->copyAttachmentsInFolder($sourceNode, $targetNode);
+				}
+			} elseif ($sourceNode instanceof File
+				&& $sourceNode->getMimeType() === 'text/markdown') {
+				$sourceAttachmentDirName = '.attachments.' . $sourceNode->getId();
+				try {
+					$sourceAttachmentDir = $sourceFolder->get($sourceAttachmentDirName);
+					$targetNode = $targetFolder->get($sourceNode->getName());
+					$targetAttachmentDirName = '.attachments.' . $targetNode->getId();
+					$targetAttachmentDir = $targetFolder->get($sourceAttachmentDirName);
+				} catch (NotFoundException) {
+					// ignore if either of the attachment dirs don't exist
+					continue;
+				}
+
+				if ($targetNode instanceof File && $targetAttachmentDir instanceof Folder) {
+					$targetAttachmentDir->move($targetFolder->getPath() . '/' . $targetAttachmentDirName);
+					self::replaceAttachmentFolderId($sourceNode, $targetNode);
+				}
+			}
+		}
+	}
+
 	/**
 	 * @throws NotFoundException
 	 * @throws NotPermittedException


### PR DESCRIPTION
Fixes: nextcloud/collectives#2086

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
