### PR TITLE
chore(ci): stable31 is end of life

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -28,7 +28,6 @@ jobs:
           - ${{ github.event.repository.default_branch }}
           - 'stable33'
           - 'stable32'
-          - 'stable31'
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -28,7 +28,6 @@ jobs:
           - ${{ github.event.repository.default_branch }}
           - 'stable33'
           - 'stable32'
-          - 'stable31'
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
 	"rangeStrategy": "bump",
 	"rebaseWhen": "conflicted",
 	"ignoreUnstable": false,
-	"baseBranchPatterns": ["main", "stable33", "stable32", "stable31"],
+	"baseBranchPatterns": ["main", "stable33", "stable32"],
 	"enabledManagers": ["npm"],
 	"ignoreDeps": ["node", "npm"],
 	"packageRules": [
@@ -51,12 +51,12 @@
 		},
 		{
 			"matchUpdateTypes": ["major"],
-			"matchBaseBranches": ["stable33", "stable32", "stable31"],
+			"matchBaseBranches": ["stable33", "stable32"],
 			"enabled": false
 		},
 		{
 			"matchUpdateTypes": ["major", "minor"],
-			"matchBaseBranches": ["stable33", "stable32", "stable31"],
+			"matchBaseBranches": ["stable33", "stable32"],
 			"enabled": false
 		},
 		{
@@ -66,7 +66,7 @@
 				"@nextcloud/cypress",
 				"@cypress/{/,}**"
 			],
-			"matchBaseBranches": ["stable33", "stable32", "stable31"],
+			"matchBaseBranches": ["stable33", "stable32"],
 			"enabled": false
 		},
 		{


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
