### PR TITLE
fix: Exclude Readme.md files from file locking in the text app

### DIFF
--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -131,8 +131,7 @@ class ApiService {
 
 		// Disable file locking for Readme.md files, because in the
 		// current setup, this makes it almost impossible to delete these files.
-		/** @psalm-suppress RedundantCastGivenDocblockType */
-		if (!$readOnly && strcasecmp((string)$file->getName(), 'Readme.md') !== 0) {
+		if (!$readOnly && strcasecmp($file->getName(), 'Readme.md') !== 0) {
 			$isLocked = $this->documentService->lock($file->getId());
 			if (!$isLocked) {
 				$readOnly = true;

--- a/tests/unit/Service/ApiServiceTest.php
+++ b/tests/unit/Service/ApiServiceTest.php
@@ -76,6 +76,7 @@ class ApiServiceTest extends \PHPUnit\Framework\TestCase {
 		$file->method('getStorage')->willReturn($storage);
 		$file->method('getId')->willReturn($id);
 		$file->method('getOwner')->willReturn($owner);
+		$file->method('getName')->willReturn('name');
 		$file->method('getContent')->willReturn('file content');
 		return $file;
 	}


### PR DESCRIPTION
### 📝 Summary

* Resolves: [README.md is almost always locked](https://github.com/nextcloud/files_lock/issues/101)

This PR excludes Readme files from file locking. Without it is almost impossible to delete these files as they are opened as soon as a user visits the directory of the file. This is meant as an intermediate solution until https://github.com/nextcloud/text/issues/5597 is implemented.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
