### PR TITLE
fix(css): always set highlighted background for inline code

### DIFF
--- a/src/css/prosemirror.scss
+++ b/src/css/prosemirror.scss
@@ -279,7 +279,7 @@ div.ProseMirror {
 		padding-bottom: 0.5em;
 	}
 
-	p code {
+	code {
 		background-color: var(--color-background-dark);
 		border-radius: var(--border-radius);
 		padding: 0.1em 0.3em;


### PR DESCRIPTION
Fixes: #5303

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1138" height="236" alt="image" src="https://github.com/user-attachments/assets/c66c7d53-5de4-44e5-a1fc-35a8b01443d2" /> | <img width="1138" height="236" alt="image" src="https://github.com/user-attachments/assets/9e463a4a-ce8f-4d14-8951-c07d89307412" />


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
