### PR TITLE
fix: enable workspace header in "Personal files"

### DIFF
--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -85,7 +85,7 @@ let FilesHeaderRichWorkspaceInstance
 let latestFolder
 
 const enabled = (_, view) => {
-	return ['files', 'favorites', 'public-share'].includes(view.id)
+	return ['files', 'favorites', 'public-share', 'personal'].includes(view.id)
 }
 
 /**


### PR DESCRIPTION
### 📝 Summary

The "Personal files" view is missing the workspace header displaying the content of README.md files on top of directories. The PR adds that.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
| <img width="1029" height="670" alt="Screenshot_20260306_143320" src="https://github.com/user-attachments/assets/9290e245-e90d-4773-993d-e35853483ca8" /> | <img width="1029" height="670" alt="Screenshot_20260306_143429" src="https://github.com/user-attachments/assets/a2b0068f-9e75-4df3-ac45-58639606ff15" /> |


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
