### PR TITLE
Remove unneeded max-height from text-menubar which caused a bug

### DIFF
--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -252,9 +252,6 @@ export default {
 	z-index: 10021; // above modal-header so menubar is always on top
 	background-color: var(--color-main-background-translucent);
 	backdrop-filter: var(--background-blur);
-	max-height: var(
-		--default-clickable-area
-	); // important for mobile so that the buttons are always inside the container
 	border-bottom: 1px solid var(--color-border);
 	padding-block: var(--default-grid-baseline);
 


### PR DESCRIPTION
### ☑️ Resolves

- Fixing second part of https://github.com/nextcloud/text/issues/7961

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1569" height="144" alt="Screenshot from 2026-03-06 12-01-13" src="https://github.com/user-attachments/assets/6dcb8efa-f664-4d3c-8caa-428244770075" /> | <img width="1569" height="144" alt="Screenshot from 2026-03-06 11-50-54" src="https://github.com/user-attachments/assets/00938882-977a-4245-83df-1671a0e74bb6" />

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
