### PR TITLE
fix(search): also search for user mentions

### DIFF
--- a/src/plugins/searchDecorations.js
+++ b/src/plugins/searchDecorations.js
@@ -91,18 +91,34 @@ export function runSearch(doc, query, options) {
 		}
 	}
 
+	const mentionQuery = query.trim().startsWith('@')
+		? query.trim().slice(1).toLowerCase()
+		: query.trim().toLowerCase()
+
 	doc.descendants((node, offset, _position) => {
-		if (!node.isText) {
+		// Add decorations for text matches
+		if (node.isText) {
+			const matches = node.text.matchAll(new RegExp(query, 'gi'))
+
+			for (const match of matches) {
+				results.push({
+					from: match.index + offset,
+					to: match.index + offset + query.length,
+				})
+			}
+
 			return
 		}
 
-		const matches = node.text.matchAll(new RegExp(query, 'gi'))
-
-		for (const match of matches) {
-			results.push({
-				from: match.index + offset,
-				to: match.index + offset + query.length,
-			})
+		// Add decorations for mention matches
+		if (node.type.name === 'mention' && mentionQuery !== '') {
+			if (node.attrs.label.toLowerCase().startsWith(mentionQuery)) {
+				results.push({
+					from: offset,
+					to: offset + node.nodeSize,
+					mention: true,
+				})
+			}
 		}
 	})
 
@@ -142,7 +158,9 @@ export function highlightResults(doc, results) {
 		decorations.push(
 			Decoration.inline(result.from, result.to, {
 				'data-text-el': 'search-decoration',
-				style: 'background-color: #ead637; color: black; border-radius: 2px;',
+				style: result.mention
+					? 'outline: 2px solid #ead637; background-color: #ead637; color: black; border-radius: 2px;'
+					: 'background-color: #ead637; color: black; border-radius: 2px;',
 			}),
 		)
 	})

--- a/src/tests/plugins/searchDecorations.spec.js
+++ b/src/tests/plugins/searchDecorations.spec.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import Mentions from '../../extensions/Mention.js'
 import { highlightResults, runSearch } from '../../plugins/searchDecorations.js'
 import createCustomEditor from '../testHelpers/createCustomEditor.ts'
 
@@ -76,10 +77,34 @@ describe('search plugin', () => {
 
 		testSearch(doc, 'cat', expected)
 	})
+
+	it('finds matches with mentions', () => {
+		const doc =
+			'<p>janes task, mention <span class="mention" data-type="user" data-id="jane.doe" data-label="Jane Doe">Jane Doe</span></p>'
+
+		const expected = {
+			results: [
+				{ from: 1, to: 5 },
+				{ from: 21, to: 22, mention: true },
+			],
+		}
+
+		testSearch(doc, 'jane', expected)
+	})
+
+	it('finds matches with mentions with @', () => {
+		const doc =
+			'<p>janes task, mention <span class="mention" data-type="user" data-id="jane.doe" data-label="Jane Doe">Jane Doe</span></p>'
+
+		const expected = {
+			results: [{ from: 21, to: 22, mention: true }],
+		}
+		testSearch(doc, '@jane', expected)
+	})
 })
 
 const testSearch = (content, query, expectedSearchResults) => {
-	const editor = createCustomEditor(content)
+	const editor = createCustomEditor(content, [Mentions])
 	const doc = editor.state.doc
 	const searched = runSearch(doc, query)
 	expect(searched).toHaveProperty('results', expectedSearchResults.results)


### PR DESCRIPTION
Adds user mentions to results if the display name starts with search query.

If search query starts with `@`, strip it before checking if user mention matches.

Contributes to nextcloud/collectives#2299

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1760" height="1080" alt="image" src="https://github.com/user-attachments/assets/c1a8fb73-00aa-41b3-bda1-86008aec6096" /> | <img width="1760" height="1134" alt="image" src="https://github.com/user-attachments/assets/e382dcbc-2596-452c-8728-3752e8e16d2f" />
<img width="1760" height="1080" alt="image" src="https://github.com/user-attachments/assets/a1b55836-f632-44ae-867d-f8d994ca4079" /> | <img width="1760" height="1134" alt="image" src="https://github.com/user-attachments/assets/4851bffc-c7d6-4e60-b3ac-f18c37477893" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
