### PR TITLE
fix(links): allow inline code within links

### DIFF
--- a/src/extensions/RichText.js
+++ b/src/extensions/RichText.js
@@ -7,7 +7,6 @@ import { t } from '@nextcloud/l10n'
 import { Extension } from '@tiptap/core'
 /* eslint-disable import/no-named-as-default */
 import Blockquote from '@tiptap/extension-blockquote'
-import Code from '@tiptap/extension-code'
 import Document from '@tiptap/extension-document'
 import HorizontalRule from '@tiptap/extension-horizontal-rule'
 import { ListItem } from '@tiptap/extension-list'
@@ -27,6 +26,7 @@ import Search from './../extensions/Search.ts'
 import TextDirection from './../extensions/TextDirection.ts'
 import Typography from './../extensions/Typography.ts'
 import {
+	Code,
 	Highlight,
 	Italic,
 	Link,

--- a/src/marks/Code.ts
+++ b/src/marks/Code.ts
@@ -1,0 +1,13 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import TipTapCode from '@tiptap/extension-code'
+
+const Code = TipTapCode.extend({
+	// List all enabled marks except 'code' and 'link' (issue #4900)
+	excludes: 'em strike strong underline',
+})
+
+export default Code

--- a/src/marks/index.js
+++ b/src/marks/index.js
@@ -4,6 +4,7 @@
  */
 
 import TipTapItalic from '@tiptap/extension-italic'
+import Code from './Code.ts'
 import Highlight from './Highlight.ts'
 import Link from './Link.ts'
 import Strike from './Strike.js'
@@ -14,4 +15,4 @@ const Italic = TipTapItalic.extend({
 	name: 'em',
 })
 
-export { Highlight, Italic, Link, Strike, Strong, Underline }
+export { Code, Highlight, Italic, Link, Strike, Strong, Underline }

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -69,6 +69,11 @@ describe('Markdown though editor', () => {
 		expect(markdownThroughEditor('[bar\\\\]: /uri\n\n[bar\\\\]')).toBe(
 			'[bar\\\\](/uri)',
 		)
+		// Issue #4900
+		expect(markdownThroughEditor('[`code`](foo)')).toBe('[`code`](foo)')
+		expect(markdownThroughEditor('[text with `code` inside](foo)')).toBe(
+			'[text with `code` inside](foo)',
+		)
 	})
 	test('images', () => {
 		// Inline images


### PR DESCRIPTION
The Tiptap inline code mark extension excludes all other mark types from coexisting with itself. This makes sense for most mark types, but link is an exception.

Unfortunately there's no way to dynamically create a list of all marks when `excludes` is initialized, as this happens when compiling the editor schema, so the latter is not available yet.

Thus to fix the bug while keeping the side effects small, we have to explicitely list all mark types except link and code in `excludes` in the code mark definition.

Fixes: #4900

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
