### PR TITLE
chore(test): fix race condition in attachments test

### DIFF
--- a/cypress/e2e/attachments.spec.js
+++ b/cypress/e2e/attachments.spec.js
@@ -365,8 +365,7 @@ describe('Test all attachment insertion methods', () => {
 					cy.moveFile(fileName, 'subFolder/test.md')
 				})
 
-			cy.visit('/apps/files')
-			cy.openFolder('subFolder')
+			cy.visit('/apps/files?dir=/subFolder')
 			cy.getFile('test.md')
 				.should('exist')
 				.should('have.attr', 'data-cy-files-list-row-fileid')


### PR DESCRIPTION
Load the `subFolder` file was moved into directly.
Otherwise we would sometimes get the id of the `test.md` file in the root folder
and then fail to find an `.attachments` folder with that id.
