### PR TITLE
fix(editor): make editor container grow on empty/short content

### DIFF
--- a/playwright/e2e/design.spec.ts
+++ b/playwright/e2e/design.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, mergeTests } from '@playwright/test'
+import { test as editorTest } from '../support/fixtures/editor'
+import { test as uploadFileTest } from '../support/fixtures/upload-file'
+
+const test = mergeTests(editorTest, uploadFileTest)
+
+test.beforeEach(async ({ open }) => {
+	await open()
+})
+
+test('Editor container grows vertically', async ({ editor }) => {
+	await expect(editor.menubar).toBeVisible()
+	await expect(editor.content).toBeVisible()
+
+	const editorBox = (await editor.el.boundingBox())!
+	const menubarBox = (await editor.menubar.boundingBox())!
+	const contentBox = (await editor.content.boundingBox())!
+	const suggestionsContainerBox =
+		(await editor.suggestionsContainer.boundingBox())!
+
+	const expectedContentHeight =
+		editorBox.height - menubarBox.height - suggestionsContainerBox.height
+
+	// Allow up to 2px tolerance for borders etc.
+	expect(Math.abs(expectedContentHeight - contentBox.height)).toBeLessThan(2)
+})

--- a/playwright/support/sections/EditorSection.ts
+++ b/playwright/support/sections/EditorSection.ts
@@ -8,6 +8,7 @@ import { expect } from '@playwright/test'
 
 export class EditorSection {
 	public readonly el: Locator
+	public readonly menubar: Locator
 	public readonly content: Locator
 	public readonly formattingHelp: Locator
 	public readonly offlineState: Locator
@@ -15,11 +16,13 @@ export class EditorSection {
 	public readonly referenceWidget: Locator
 	public readonly saveIndicator: Locator
 	public readonly sessionList: Locator
+	public readonly suggestionsContainer: Locator
 	public readonly suggestions: Locator
 
 	// eslint-disable-next-line no-useless-constructor
 	constructor(public readonly page: Page) {
 		this.el = this.page.locator('.editor').first()
+		this.menubar = this.el.getByRole('region')
 		this.content = this.el.getByRole('textbox')
 		this.formattingHelp = this.page.getByRole('dialog', {
 			name: 'Formatting and shortcuts',
@@ -29,6 +32,7 @@ export class EditorSection {
 		this.referenceWidget = this.page.locator('.reference-widget')
 		this.saveIndicator = this.el.locator('.save-status')
 		this.sessionList = this.el.locator('.session-list')
+		this.suggestionsContainer = this.page.locator('.container-suggestions')
 		this.suggestions = this.page.locator('.tippy-box .suggestion-list')
 	}
 

--- a/src/components/BaseReader.vue
+++ b/src/components/BaseReader.vue
@@ -67,10 +67,12 @@ export default {
 
 <style scoped lang="scss">
 .editor__content-wrapper {
+	display: flex;
 	flex-grow: 1;
 }
 
 .editor__content {
+	flex-grow: 1;
 	max-width: var(--text-editor-max-width);
 	margin: 0 auto;
 	position: relative;

--- a/src/components/Editor/ContentContainer.vue
+++ b/src/components/Editor/ContentContainer.vue
@@ -64,10 +64,12 @@ export default {
 
 <style scoped lang="scss">
 .editor__content-wrapper {
+	display: flex;
 	flex-grow: 1;
 }
 
 .editor__content {
+	flex-grow: 1;
 	max-width: var(--text-editor-max-width);
 	margin: 0 auto;
 	position: relative;

--- a/src/components/Editor/MainContainer.vue
+++ b/src/components/Editor/MainContainer.vue
@@ -30,6 +30,7 @@ export default {
 .editor {
 	display: flex;
 	flex-direction: column;
+	flex-grow: 1;
 	background: var(--color-main-background);
 	color: var(--color-main-text);
 	background-clip: padding-box;


### PR DESCRIPTION
Also tested with folder descriptions.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1760" height="1054" alt="image" src="https://github.com/user-attachments/assets/6ab4ba4e-c45a-4bf2-ae52-4517605d636c" /> | <img width="1760" height="1054" alt="image" src="https://github.com/user-attachments/assets/8686f234-0920-4984-a306-2c4ac1276a53" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
