### PR TITLE
fix(link): use folder icon for "Link to file or folder" action

### DIFF
--- a/src/components/Menu/ActionInsertLink.vue
+++ b/src/components/Menu/ActionInsertLink.vue
@@ -46,7 +46,7 @@
 			:data-text-action-entry="`${actionEntry.key}-file`"
 			@click="linkFileAndCloseMenu">
 			<template #icon>
-				<Document />
+				<Folder />
 			</template>
 			{{ t('text', 'Link to file or folder') }}
 		</NcActionButton>
@@ -99,7 +99,7 @@ import { useFileProps } from '../../composables/useFileProps.ts'
 import { useLinkFile } from '../../composables/useLinkFile.ts'
 import { useNetworkState } from '../../composables/useNetworkState.ts'
 import { HOOK_MENUBAR_LINK_CUSTOM_ACTION } from '../Editor.provider.ts'
-import { Document, LinkOff, Loading, Shape, Web } from '../icons.js'
+import { Folder, LinkOff, Loading, Shape, Web } from '../icons.js'
 import { BaseActionEntry } from './BaseActionEntry.js'
 import { useMenuIDMixin } from './MenuBar.provider.js'
 
@@ -109,7 +109,7 @@ export default {
 		NcActions,
 		NcActionButton,
 		NcActionInput,
-		Document,
+		Folder,
 		Loading,
 		LinkOff,
 		Web,

--- a/src/components/SuggestionsBar.vue
+++ b/src/components/SuggestionsBar.vue
@@ -13,7 +13,7 @@
 				class="suggestions--button"
 				@click="linkFile">
 				<template #icon>
-					<Document :size="20" />
+					<Folder :size="20" />
 				</template>
 				{{ t('text', 'Link to file or folder') }}
 			</NcButton>
@@ -60,7 +60,7 @@
 import { t } from '@nextcloud/l10n'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import { getLinkWithPicker } from '@nextcloud/vue/dist/Components/NcRichText.js'
-import { Document, Shape, Table as TableIcon, Upload } from '../components/icons.js'
+import { Folder, Shape, Table as TableIcon, Upload } from '../components/icons.js'
 import { useConnection } from '../composables/useConnection.ts'
 import { useEditor } from '../composables/useEditor.ts'
 import { useFileProps } from '../composables/useFileProps.ts'
@@ -73,7 +73,7 @@ export default {
 	name: 'SuggestionsBar',
 	components: {
 		TableIcon,
-		Document,
+		Folder,
 		NcButton,
 		Shape,
 		Upload,


### PR DESCRIPTION
Contributes to nextcloud/collectives#2351

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1893" height="928" alt="image" src="https://github.com/user-attachments/assets/f441717b-b14d-4cf0-a249-d9afa9b11e81" /> | <img width="1893" height="928" alt="image" src="https://github.com/user-attachments/assets/d3bc4fe1-d57f-45ab-8698-90ded1958d31" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
