### PR TITLE
fix(previewOptions): only render link preview options if editor is editable

### DIFF
--- a/src/plugins/previewOptions.js
+++ b/src/plugins/previewOptions.js
@@ -51,6 +51,9 @@ export default function previewOptions({ editor }) {
 
 		props: {
 			decorations(state) {
+				if (!editor.options.editable) {
+					return DecorationSet.empty
+				}
 				return this.getState(state).decorations
 			},
 		},


### PR DESCRIPTION
### 📝 Summary

This previous fix #8257 did not resolve the bug entirely as sometimes it appeared and sometimes not. Now `editor.options.editable` is being checked in `props.decorations` on every view render, including after `sedEditable()`, regardless of whether a transaction was dispatched.

To reproduce:
- Add a link to a document
- create a public share of this document wird `view only` permissions
- open that share in another browser (as a non-logged in user)
- preview options of the link should not be editable at all

### 🏁 Checklist

- [X] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [X] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
