### PR TITLE
[stable32] fix(SessionService): sanitize displayName to utf8 encoding

### DIFF
--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -32,6 +32,7 @@ class SessionService {
 	private IAvatarManager $avatarManager;
 	private ?string $userId;
 	private ICache $cache;
+	private EncodingService $encodingService;
 
 	/** @var ?Session cache current session in the request */
 	private ?Session $session = null;
@@ -46,12 +47,14 @@ class SessionService {
 		IManager $directManager,
 		?string $userId,
 		ICacheFactory $cacheFactory,
+		EncodingService $encodingService,
 	) {
 		$this->sessionMapper = $sessionMapper;
 		$this->secureRandom = $secureRandom;
 		$this->timeFactory = $timeFactory;
 		$this->userManager = $userManager;
 		$this->avatarManager = $avatarManager;
+		$this->encodingService = $encodingService;
 		$this->userId = $userId;
 
 		$token = $request->getParam('token');
@@ -99,7 +102,8 @@ class SessionService {
 		return array_map(function (Session $session) {
 			$result = $session->jsonSerialize();
 			if (!$session->isGuest()) {
-				$result['displayName'] = $this->userManager->getDisplayName($session->getUserId());
+				$displayName = $this->userManager->getDisplayName($session->getUserId()) ?? '';
+				$result['displayName'] = $this->encodingService->encodeToUtf8($displayName) ?? $displayName;
 			}
 			return $result;
 		}, $sessions);
@@ -114,7 +118,8 @@ class SessionService {
 		return array_map(function (Session $session) {
 			$result = $session->jsonSerialize();
 			if (!$session->isGuest()) {
-				$result['displayName'] = $this->userManager->getDisplayName($session->getUserId());
+				$displayName = $this->userManager->getDisplayName($session->getUserId()) ?? '';
+				$result['displayName'] = $this->encodingService->encodeToUtf8($displayName) ?? $displayName;
 			}
 			return $result;
 		}, $sessions);
@@ -122,7 +127,8 @@ class SessionService {
 
 	public function getNameForSession(Session $session): ?string {
 		if (!$session->isGuest()) {
-			return $this->userManager->getDisplayName($session->getUserId());
+			$displayName = $this->userManager->getDisplayName($session->getUserId()) ?? '';
+			return $this->encodingService->encodeToUtf8($displayName) ?? $displayName;
 		}
 
 		return $session->getGuestName();


### PR DESCRIPTION
### 📝 Summary

A user reported that they can not open text/md files and were getting the following error message: "Malformed UTF-8 characters, possibly incorrectly encoded", while most other users could open the same file without a problem.

This PR uses `EncodingService` to convert display names from external backends (e.g. LDAP/AD) to UTF-8 before including them in JSON responses.

### 🏁 Checklist

- [X] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [X] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
