### PR TITLE
fix(keepSyntax): correct regex to avoid unnecessary escaping of speci…

### DIFF
--- a/src/markdownit/keepSyntax.js
+++ b/src/markdownit/keepSyntax.js
@@ -10,7 +10,7 @@
  */
 export default function keepSyntax(md) {
 	// Extracting named groups as positive lookbehind patterns are not supported by Safari
-	const escaped = /(\n(?<linestart>[#\-*+>])|(?<special>[`*\\~[\]]+))/
+	const escaped = /(\n(?<linestart>[#\-*+>])|(?<special>[`*\\~[\]]))/
 
 	md.core.ruler.before('text_join', 'tag-markdown-syntax', (state) => {
 		const open = new state.Token('keep_md_open', 'span', 1)


### PR DESCRIPTION
Before, when you would simply open a Markdown file that had Wikilinks in it, (for example: **[[Test Link]]** ) NextCloud would automatically escape the double brackets to look like this: \[\[Test\]\]
This caused programs like Obsidian to lose the linking capability. The regex in the keepSyntax.js file was corrected to handle characters individually.

### 📝 Summary

* Resolves: #4795

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="491" height="100" alt="image" src="https://github.com/user-attachments/assets/7de14d42-8c8c-45c6-bb9a-3eae7a26d593" /> | <img width="454" height="92" alt="image" src="https://github.com/user-attachments/assets/8c17dacb-550f-4fb2-b959-d6f27345f760" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
