### PR TITLE
fix(menubar): lower z-index: on top of document content, but below modals

### DIFF
--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -249,7 +249,8 @@ export default {
 	top: 0;
 	bottom: 0;
 	width: 100%;
-	z-index: 10021; // above modal-header so menubar is always on top
+	// Display above link previews and tables, but below dialogs and calendar event popover
+	z-index: 4;
 	background-color: var(--color-main-background-translucent);
 	backdrop-filter: var(--background-blur);
 	border-bottom: 1px solid var(--color-border);

--- a/src/components/Menu/ReadonlyBar.vue
+++ b/src/components/Menu/ReadonlyBar.vue
@@ -114,7 +114,8 @@ export default defineComponent({
 	top: 0;
 	bottom: var(--default-grid-baseline);
 	width: 100%;
-	z-index: 10021; // above modal-header so menubar is always on top
+	// Display above link previews and tables, but below dialogs and calendar event popover
+	z-index: 4;
 	background-color: var(--color-main-background-translucent);
 	backdrop-filter: var(--background-blur);
 	max-height: var(


### PR DESCRIPTION
Contributes to nextcloud/collectives#2357

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="2493" height="1900" alt="image" src="https://github.com/user-attachments/assets/4678bed2-193c-49a6-b3f1-f19b9b9d86b7" /> | <img width="2493" height="1900" alt="image" src="https://github.com/user-attachments/assets/3161ff05-b7c8-412d-ba9c-23a80d9a2a9a" />


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
