### PR TITLE
fix(files): don't offer "folder description" in file drop folders

### DIFF
--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -36,7 +36,11 @@ export const addMenuRichWorkspace = () => {
 			if (Number(context.attributes['rich-workspace-file'])) {
 				return false
 			}
-			return (context.permissions & Permission.CREATE) !== 0
+			// Check read permission to not show option in file drop shares
+			return (
+				(context.permissions & Permission.READ) !== 0
+				&& (context.permissions & Permission.CREATE) !== 0
+			)
 		},
 		iconSvgInline: TextSvg,
 		async handler(context, content) {


### PR DESCRIPTION
Contributes to nextcloud/server#59661

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1917" height="928" alt="image" src="https://github.com/user-attachments/assets/3c453430-18e4-4e7f-8a1c-1e9de09d00b5" /> | <img width="1917" height="928" alt="image" src="https://github.com/user-attachments/assets/595a0e88-5fd7-4cbc-ba21-1b71075fb113" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
