### PR TITLE
Security: Unbounded `limit` parameter in user search can be abused for resource exhaustion

### DIFF
--- a/lib/Controller/UserApiController.php
+++ b/lib/Controller/UserApiController.php
@@ -55,6 +55,7 @@ class UserApiController extends ApiController implements ISessionAwareController
 
 		if (!$this->getSession()->isGuest()) {
 			// Add other users to the autocomplete list
+			$limit = min($limit, 50);
 			[$result] = $this->collaboratorSearch->search($filter, [IShare::TYPE_USER], false, $limit, 0);
 			$userSearch = array_merge($result['users'], $result['exact']['users']);
 

--- a/lib/Controller/UserApiController.php
+++ b/lib/Controller/UserApiController.php
@@ -37,6 +37,7 @@ class UserApiController extends ApiController implements ISessionAwareController
 	#[NoAdminRequired]
 	#[RequireDocumentSession]
 	public function index(string $filter = '', int $limit = 5): DataResponse {
+		$limit = min($limit, 50);
 		$sessions = $this->sessionService->getAllSessions($this->getSession()->getDocumentId());
 
 		$users = [];


### PR DESCRIPTION
## Summary

Security: Unbounded `limit` parameter in user search can be abused for resource exhaustion

## Problem

**Severity**: `Medium` | **File**: `lib/Controller/UserApiController.php:L39`

The `index(string $filter = '', int $limit = 5)` method accepts client-controlled `limit` and passes it directly to collaborator search. Without an upper bound, an attacker can request very large limits, causing expensive directory lookups and increased response size.

## Solution

Enforce a strict maximum (e.g., 10-50) for `limit` before invoking search, and consider server-side rate limiting for this endpoint.

## Changes

- `lib/Controller/UserApiController.php` (modified)