### PR TITLE
fix(workspace): reuse WorkspaceService file lookup in direct()

### DIFF
--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -1,31 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
- */
-
-declare(strict_types=1);
-/**
- * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
- *
- * @author Julius Härtl <jus@bitgrid.net>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
 namespace OCA\Text\Controller;
@@ -174,9 +153,13 @@ class WorkspaceController extends OCSController {
 			/** @psalm-suppress PossiblyNullArgument */
 			$folder = $this->rootFolder->getUserFolder($this->userId)->get($path);
 			if ($folder instanceof Folder) {
-				$file = $this->getFile($folder);
+				$file = $this->workspaceService->getFile($folder);
 				if ($file === null) {
-					$token = $this->directEditingManager->create($path . '/' . $this->workspaceService->getSupportedFilenames()[0], Application::APP_NAME, TextDocumentCreator::CREATOR_ID);
+					$token = $this->directEditingManager->create(
+						$path . '/' . $this->workspaceService->getSupportedFilenames()[0],
+						Application::APP_NAME,
+						TextDocumentCreator::CREATOR_ID
+					);
 				} else {
 					$token = $this->directEditingManager->open($path . '/' . $file->getName(), Application::APP_NAME);
 				}
@@ -190,19 +173,5 @@ class WorkspaceController extends OCSController {
 		}
 
 		return new DataResponse(['message' => 'No workspace file found'], Http::STATUS_NOT_FOUND);
-	}
-
-	private function getFile(Folder $folder): ?File {
-		$file = null;
-		foreach ($this->workspaceService->getSupportedFilenames() as $filename) {
-			try {
-				$node = $folder->get($filename);
-				if ($node instanceof File) {
-					$file = $node;
-				}
-			} catch (NotFoundException) {
-			}
-		}
-		return $file;
 	}
 }

--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -22,7 +22,6 @@ use OCP\Constants;
 use OCP\DirectEditing\IManager as IDirectEditingManager;
 use OCP\DirectEditing\RegisterDirectEditorEvent;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -52,12 +51,16 @@ class WorkspaceController extends OCSController {
 	}
 
 	/**
-	 * Checks for available files in the current folder and returns required details to present
-	 * the rich workspace
+	 * Checks for available files in the current folder and returns required
+	 * details to present the rich workspace.
+	 *
+	 * Returns 200 with file metadata and folder permissions if a README is found,
+	 * or 404 with folder permissions if not (so the client can still offer to create one).
+	 *
+	 * @param string $path Path relative to the user's root folder
 	 */
 	#[NoAdminRequired]
 	public function folder(string $path = '/'): DataResponse {
-		/**  */
 		try {
 			/** @psalm-suppress PossiblyNullArgument */
 			$userFolder = $this->rootFolder->getUserFolder($this->userId);
@@ -96,9 +99,11 @@ class WorkspaceController extends OCSController {
 	}
 
 	/**
-	 * Checks for available files in the current folder and returns required details to present
-	 * the rich workspace
-	 * @api
+	 * Checks for available files in a publicly shared folder and returns required
+	 * details to present the rich workspace.
+	 *
+	 * @param string $shareToken Public share token
+	 * @param string $path Path relative to the share root
 	 */
 	#[NoAdminRequired]
 	#[PublicPage]
@@ -145,6 +150,14 @@ class WorkspaceController extends OCSController {
 		return new DataResponse(['message' => 'No workspace file found'], Http::STATUS_NOT_FOUND);
 	}
 
+	/**
+	 * Returns a direct editing URL for the workspace README in the given folder.
+	 *
+	 * If a README file already exists, opens it for editing. If not, creates a new
+	 * file using the first entry of getSupportedFilenames() as the default name.
+	 *
+	 * @param string $path Path to the folder, relative to the user's root folder
+	 */
 	#[NoAdminRequired]
 	public function direct(string $path): DataResponse {
 		$this->eventDispatcher->dispatchTyped(new RegisterDirectEditorEvent($this->directEditingManager));

--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -36,7 +36,7 @@ class WorkspaceService {
 		} catch (StorageInvalidException) {
 			return null;
 		}
-	
+
 		foreach ($this->getSupportedFilenames() as $filename) {
 			try {
 				$cacheEntry = $cache->get($internalPath . '/' . $filename);

--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 /**
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
@@ -8,6 +9,7 @@
 
 namespace OCA\Text\Service;
 
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
@@ -28,16 +30,23 @@ class WorkspaceService {
 	}
 
 	public function getFile(Folder $folder): ?File {
+		try {
+			$cache = $folder->getStorage()->getCache();
+			$internalPath = $folder->getInternalPath();
+		} catch (StorageInvalidException) {
+			return null;
+		}
+	
 		foreach ($this->getSupportedFilenames() as $filename) {
 			try {
-				$exists = $folder->getStorage()->getCache()->get($folder->getInternalPath() . '/' . $filename);
-				if ($exists) {
+				$cacheEntry = $cache->get($internalPath . '/' . $filename);
+				if ($cacheEntry !== false && $cacheEntry->getMimeType() !== ICacheEntry::DIRECTORY_MIMETYPE) {
 					$file = $folder->get($filename);
 					if ($file instanceof File) {
 						return $file;
 					}
 				}
-			} catch (NotFoundException|StorageInvalidException) {
+			} catch (NotFoundException) {
 				continue;
 			}
 		}

--- a/tests/unit/Service/WorkspaceServiceTest.php
+++ b/tests/unit/Service/WorkspaceServiceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Text\Tests\Service;
+
+use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\Storage\IStorage;
+use OCP\Files\StorageInvalidException;
+use OCP\IL10N;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class WorkspaceServiceTest extends TestCase {
+	private IL10N&MockObject $l10n;
+	private WorkspaceService $workspaceService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->with('Readme')->willReturn('Readme');
+
+		$this->workspaceService = new WorkspaceService($this->l10n);
+	}
+
+	public function testGetFileReturnsFirstMatchingFileInPriorityOrder(): void {
+		$folder = $this->createMock(Folder::class);
+		$storage = $this->createMock(IStorage::class);
+		$cache = $this->createMock(ICache::class);
+		$readmeFile = $this->createMock(File::class);
+
+		$folder->method('getStorage')->willReturn($storage);
+		$storage->method('getCache')->willReturn($cache);
+		$folder->method('getInternalPath')->willReturn('docs');
+
+		$readmeEntry = $this->createMock(ICacheEntry::class);
+		$readmeEntry->method('getMimeType')->willReturn('text/markdown');
+
+		$uppercaseEntry = $this->createMock(ICacheEntry::class);
+		$uppercaseEntry->method('getMimeType')->willReturn('text/markdown');
+
+		$cache->method('get')->willReturnMap([
+			['docs/Readme.md', $readmeEntry],
+			['docs/README.md', $uppercaseEntry],
+			['docs/readme.md', false],
+		]);
+
+		$folder->expects($this->once())
+			->method('get')
+			->with('Readme.md')
+			->willReturn($readmeFile);
+
+		$result = $this->workspaceService->getFile($folder);
+
+		$this->assertSame($readmeFile, $result);
+	}
+
+	public function testGetFileSkipsDirectoryCacheEntries(): void {
+		$folder = $this->createMock(Folder::class);
+		$storage = $this->createMock(IStorage::class);
+		$cache = $this->createMock(ICache::class);
+
+		$folder->method('getStorage')->willReturn($storage);
+		$storage->method('getCache')->willReturn($cache);
+		$folder->method('getInternalPath')->willReturn('docs');
+
+		$directoryEntry = $this->createMock(ICacheEntry::class);
+		$directoryEntry->method('getMimeType')->willReturn(ICacheEntry::DIRECTORY_MIMETYPE);
+
+		$cache->method('get')->willReturnMap([
+			['docs/Readme.md', $directoryEntry],
+			['docs/README.md', false],
+			['docs/readme.md', false],
+		]);
+
+		$folder->expects($this->never())->method('get');
+
+		$result = $this->workspaceService->getFile($folder);
+
+		$this->assertNull($result);
+	}
+
+	public function testGetFileReturnsNullWhenStorageIsInvalid(): void {
+		$folder = $this->createMock(Folder::class);
+
+		$folder->method('getStorage')
+			->willThrowException(new StorageInvalidException());
+
+		$folder->expects($this->never())->method('getInternalPath');
+		$folder->expects($this->never())->method('get');
+
+		$result = $this->workspaceService->getFile($folder);
+
+		$this->assertNull($result);
+	}
+}

--- a/tests/unit/Service/WorkspaceServiceTest.php
+++ b/tests/unit/Service/WorkspaceServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Text\Tests\Service;
 
+use OCA\Text\Service\WorkspaceService;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\File;


### PR DESCRIPTION
## 📝 Summary

<!-- Write a summary of your change and some reasoning if needed -->

The `direct()` action had a private `getFile()` helper that duplicated file-discovery logic already implemented in `WorkspaceService::getFile()`.

This caused `direct()` to behave differently from `folder()` and `publicFolder()` in one important way: the private helper used `continue` rather than an early `return`, so it returned the *last* matched file in the priority-ordered filename list rather than the first. `WorkspaceService::getFile()` correctly returns on the first match.

By switching `direct()` to `WorkspaceService::getFile()`, it now also benefits from the service’s cache-based lookup and storage-invalid handling.

### Changes

- Remove `WorkspaceController::getFile()`
- Replace its use in `direct()` with `$this->workspaceService->getFile()`
- Remove the now-unused `use OCP\Files\File` import
- Collapse the redundant legacy `@copyright`/`@author`/`@license` docblock into
  the existing SPDX header

### Testing

Add minimal unit coverage for `WorkspaceService::getFile()` to verify:

- first-match priority is preserved
- directory cache entries are ignored
- invalid storage returns `null`

`direct()` now reuses the same lookup implementation as `folder()` and `publicFolder()`.

P.S. The namespaces used for our unit test classes in this repo are inconsistent; not a functional problem but some are in a clearly dedicated "test" space while others use production code namespaces.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
