### PR TITLE
fix(LinkBubble): don't display dismiss edit button when read-only

### DIFF
--- a/src/components/Link/LinkBubbleView.vue
+++ b/src/components/Link/LinkBubbleView.vue
@@ -53,7 +53,7 @@
 				@toggle="setPreview"
 				@delete="removeLink" />
 			<NcButton
-				v-else
+				v-else-if="isEditable"
 				:title="t('text', 'Cancel')"
 				:aria-label="t('text', 'Cancel')"
 				variant="tertiary"


### PR DESCRIPTION
#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="616" height="259" alt="image" src="https://github.com/user-attachments/assets/0d4b4253-86a5-4d69-9e37-d8b837e712e8" /> | <img width="637" height="264" alt="image" src="https://github.com/user-attachments/assets/46c50c2c-6cb5-47bf-aab4-04e40a785820" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
