### PR TITLE
fix(editorApi): fix callbacks on editor events

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -7,7 +7,7 @@ import { defineComponent, h, nextTick, ref, watch } from 'vue'
 import Editor from './Editor.vue'
 
 export default defineComponent({
-	emits: ['focus', 'ready'],
+	emits: ['focus', 'ready', 'create:content', 'update:content'],
 	props: Editor.props,
 	setup(props, { attrs, emit, slots }) {
 		const reloading = ref(false)
@@ -27,6 +27,8 @@ export default defineComponent({
 					focus: () => emit('focus'),
 					ready: () => emit('ready'),
 					reload: () => (reloading.value = true),
+					'create:content': (content) => emit('create:content', content),
+					'update:content': (content) => emit('update:content', content),
 				},
 				scopedSlots: slots,
 			})

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -937,7 +937,6 @@ export default defineComponent({
 		resolved() {
 			localStorage.removeItem(this.indexedDbConflictKey)
 			this.indexedDbConflictContent = ''
-			this.$emit('resolved')
 		},
 	},
 })

--- a/src/editor.js
+++ b/src/editor.js
@@ -325,6 +325,13 @@ window.OCA.Text.createEditor = async function ({
 							active: true,
 							autofocus,
 						},
+						on: {
+							ready: () => vm.$emit('ready'),
+							'create:content': (content) =>
+								vm.$emit('create:content', content),
+							'update:content': (content) =>
+								vm.$emit('update:content', content),
+						},
 						scopedSlots,
 					})
 				: h(MarkdownContentEditor, {


### PR DESCRIPTION
The new Editor.js wrapper component that got introduced in the indexedb PR broke event propagation from Editor.vue component to editorApi consumers.

Fixes loading editor and updating read-only content in Collectives.

The `resolved` emit was a leftover (dead code) so I removed it.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
