### PR TITLE
test(cypress): don't expect assistant modal input field to be visible

### DIFF
--- a/cypress/e2e/Assistant.spec.js
+++ b/cypress/e2e/Assistant.spec.js
@@ -46,9 +46,9 @@ describe('Assistant', () => {
 		cy.getActionEntry('assistant').click()
 		cy.get('.action-button').contains('Free text to text prompt').click()
 
-		cy.get('.assistant-modal--content #input-input').should('be.visible')
-
-		cy.get('.assistant-modal--content #input-input').type('Hello World')
+		cy.get('.assistant-modal--content #input-input').type('Hello World', {
+			force: true,
+		})
 		cy.get('.assistant-modal--content .submit-button').click()
 
 		// eslint-disable-next-line cypress/no-unnecessary-waiting


### PR DESCRIPTION
Apparently it's mostly covered by a "Choose file" button on small screens with latest assistant app version, but the test still should not fail.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
