### PR TITLE
Center inserted images

### DIFF
--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -511,6 +511,7 @@ export default {
 
 .image__main {
 	max-height: calc(100vh - 50px - 50px);
+	margin: auto;
 }
 
 .image__main--broken-icon,


### PR DESCRIPTION


### 📝 Summary

This PR centers the inserted images and aligns them with their captions, which are already centered by default.
The issue was not apparent with large images that spanned the full width of the editing and display area.
However, with small images, the display was inconsistent.

This improvement will also have a positive impact on, for example, the content of the Collectives pages.

⚠️ **Not tested : Test from reviewers is required.**

#### 🖼️ Screenshots

| Before | After |
| ---|--- |
| <img width="1920" height="274" alt="2026-04-29_09-44_1" src="https://github.com/user-attachments/assets/684783ee-2814-4586-bd0a-de010a361ad7" /> | <img width="1920" height="274" alt="2026-04-29_09-44" src="https://github.com/user-attachments/assets/2e594bf6-7fa7-4fb7-ae1b-c34f8009ca56" /> |




