### PR TITLE
fix(code): fix regex to not eat preceding character

### DIFF
--- a/playwright/e2e/input-rules.spec.ts
+++ b/playwright/e2e/input-rules.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, mergeTests } from '@playwright/test'
+import { test as editorTest } from '../support/fixtures/editor'
+import { test as uploadFileTest } from '../support/fixtures/upload-file'
+
+const test = mergeTests(editorTest, uploadFileTest)
+
+test('applies code mark input rule with preceding character (#5483)', async ({
+	editor,
+	open,
+}) => {
+	await open()
+	await editor.type('hello inline (`code`)')
+	await expect(editor.el.locator('code')).toHaveText('code')
+	await expect(editor.el.locator('p').first()).toHaveText('hello inline (code)')
+})

--- a/src/marks/Code.ts
+++ b/src/marks/Code.ts
@@ -3,11 +3,42 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { markInputRule, markPasteRule } from '@tiptap/core'
 import TipTapCode from '@tiptap/extension-code'
+
+/**
+ * Regular expressions to match inline code blocks enclosed in backticks.
+ * Reverts upstream PR https://github.com/ueberdosis/tiptap/pull/5916 which
+ * introduced isuee https://github.com/nextcloud/text/issues/5483.
+ */
+export const inputRegex = /(?<!`)`([^`]+)`(?!`)/
+
+/**
+ * Matches inline code while pasting.
+ */
+export const pasteRegex = /(?<!`)`([^`]+)`(?!`)/g
 
 const Code = TipTapCode.extend({
 	// List all enabled marks except 'code' and 'link' (issue #4900)
 	excludes: 'em strike strong underline',
+
+	addInputRules() {
+		return [
+			markInputRule({
+				find: inputRegex,
+				type: this.type,
+			}),
+		]
+	},
+
+	addPasteRules() {
+		return [
+			markPasteRule({
+				find: pasteRegex,
+				type: this.type,
+			}),
+		]
+	},
 })
 
 export default Code


### PR DESCRIPTION
Fixes: #5483

This bug got introduced in upstream Tiptap with https://github.com/ueberdosis/tiptap/pull/5916, which removes named capturing groups and lookbehind assertions from the regex in order to fix support for Safari < 16.4.

Upstream issue https://github.com/ueberdosis/tiptap/issues/6358 tracks this bug a ping some months back whether it would be an option to revert this change nowadays didn't get any reply.

So let's overwrite the regexes on our side.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
