### PR TITLE
fix(listeners): handle NonExistingFile gracefully

### DIFF
--- a/lib/Listeners/NodeWrittenResetDocumentListener.php
+++ b/lib/Listeners/NodeWrittenResetDocumentListener.php
@@ -39,6 +39,12 @@ class NodeWrittenResetDocumentListener implements IEventListener {
 		if (!$node instanceof File) {
 			return;
 		}
+		try {
+			$node->getId();
+		} catch (NotFoundException $e) {
+			// Handle non existing node (during creation).
+			return;
+		}
 		if (!$this->documentService->getDocument($node->getId())) {
 			return;
 		}


### PR DESCRIPTION
When creating a node
the `BeforeNodeWritten` event fires with a `NonExistingFile`
which will throw a `NotFoundException` when attempting to read the file id.

Handle this gracefully by returning early.

<details>
<summary>Full trace</summary>

```json
{
  "reqId": "sFoIVadRTE9euaXCOGcE",
  "level": 3,
  "time": "2026-05-13T06:07:10+00:00",
  "remoteAddr": "",
  "user": "admin",
  "app": "no app in context",
  "method": "",
  "url": "--",
  "scriptName": "/var/www/html/occ",
  "message": "Exception thrown: OCP\\Files\\NotFoundException",
  "userAgent": "--",
  "version": "34.0.0.6",
  "occ_command": [
    "/var/www/html/occ",
    "maintenance:install"
  ],
  "exception": {
    "Exception": "OCP\\Files\\NotFoundException",
    "Message": "",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/html/apps/text/lib/Listeners/NodeWrittenResetDocumentListener.php",
        "line": 42,
        "function": "getId",
        "class": "OC\\Files\\Node\\NonExistingFile",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 57,
        "function": "handle",
        "class": "OCA\\Text\\Listeners\\NodeWrittenResetDocumentListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 220,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          },
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 56,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            }
          ],
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent",
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 73,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          },
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 86,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent",
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Node/HookConnector.php",
        "line": 74,
        "function": "dispatchTyped",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/legacy/OC_Hook.php",
        "line": 87,
        "function": "write",
        "class": "OC\\Files\\Node\\HookConnector",
        "type": "->",
        "args": [
          {
            "path": "/Media/photo-1527668441211-67a036f77ab4.jpeg",
            "run": true
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/View.php",
        "line": 593,
        "function": "emit",
        "class": "OC_Hook",
        "type": "::",
        "args": [
          "OC_Filesystem",
          "write",
          {
            "path": "/Media/photo-1527668441211-67a036f77ab4.jpeg",
            "run": true
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/View.php",
        "line": 636,
        "function": "emit_file_hooks_pre",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***",
          "/admin/files/Media/photo-1527668441211-67a036f77ab4.jpeg",
          true
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Node/Folder.php",
        "line": 181,
        "function": "file_put_contents",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "/admin/files/Media/photo-1527668441211-67a036f77ab4.jpeg",
          null
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Template/TemplateManager.php",
        "line": 443,
        "function": "newFile",
        "class": "OC\\Files\\Node\\Folder",
        "type": "->",
        "args": [
          "photo-1527668441211-67a036f77ab4.jpeg",
          null
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Template/TemplateManager.php",
        "line": 435,
        "function": "copyr",
        "class": "OC\\Files\\Template\\TemplateManager",
        "type": "->",
        "args": [
          "/skeleton/Media",
          {
            "__class__": "OC\\Files\\Node\\Folder"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Template/TemplateManager.php",
        "line": 487,
        "function": "copyr",
        "class": "OC\\Files\\Template\\TemplateManager",
        "type": "->",
        "args": [
          "/skeleton",
          {
            "__class__": "OC\\Files\\Node\\Folder"
          }
        ]
      },
      {
        "file": "/var/www/html/apps/files/lib/Listener/UserFirstTimeLoggedInListener.php",
        "line": 40,
        "function": "copySkeleton",
        "class": "OC\\Files\\Template\\TemplateManager",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 57,
        "function": "handle",
        "class": "OCA\\Files\\Listener\\UserFirstTimeLoggedInListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\User\\Events\\UserFirstTimeLoggedInEvent"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 220,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\User\\Events\\UserFirstTimeLoggedInEvent"
          },
          "OCP\\User\\Events\\UserFirstTimeLoggedInEvent",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 56,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            }
          ],
          "OCP\\User\\Events\\UserFirstTimeLoggedInEvent",
          {
            "__class__": "OCP\\User\\Events\\UserFirstTimeLoggedInEvent"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 73,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\User\\Events\\UserFirstTimeLoggedInEvent"
          },
          "OCP\\User\\Events\\UserFirstTimeLoggedInEvent"
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 86,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          "OCP\\User\\Events\\UserFirstTimeLoggedInEvent",
          {
            "__class__": "OCP\\User\\Events\\UserFirstTimeLoggedInEvent"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/User/Session.php",
        "line": 537,
        "function": "dispatchTyped",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\User\\Events\\UserFirstTimeLoggedInEvent"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/User/Session.php",
        "line": 368,
        "function": "prepareUserLogin",
        "class": "OC\\User\\Session",
        "type": "->",
        "args": [
          true,
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/lib/private/User/Session.php",
        "line": 594,
        "function": "completeLogin",
        "class": "OC\\User\\Session",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/lib/private/User/Session.php",
        "line": 318,
        "function": "loginWithPassword",
        "class": "OC\\User\\Session",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/lib/private/Setup.php",
        "line": 497,
        "function": "login",
        "class": "OC\\User\\Session",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/core/Command/Maintenance/Install.php",
        "line": 81,
        "function": "install",
        "class": "OC\\Setup",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/console/Command/Command.php",
        "line": 326,
        "function": "execute",
        "class": "OC\\Core\\Command\\Maintenance\\Install",
        "type": "->",
        "args": [
          {
            "__class__": "Symfony\\Component\\Console\\Input\\ArgvInput"
          },
          {
            "__class__": "Symfony\\Component\\Console\\Output\\ConsoleOutput"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/console/Application.php",
        "line": 1083,
        "function": "run",
        "class": "Symfony\\Component\\Console\\Command\\Command",
        "type": "->",
        "args": [
          {
            "__class__": "Symfony\\Component\\Console\\Input\\ArgvInput"
          },
          {
            "__class__": "Symfony\\Component\\Console\\Output\\ConsoleOutput"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/console/Application.php",
        "line": 324,
        "function": "doRunCommand",
        "class": "Symfony\\Component\\Console\\Application",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\Core\\Command\\Maintenance\\Install"
          },
          {
            "__class__": "Symfony\\Component\\Console\\Input\\ArgvInput"
          },
          {
            "__class__": "Symfony\\Component\\Console\\Output\\ConsoleOutput"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/console/Application.php",
        "line": 175,
        "function": "doRun",
        "class": "Symfony\\Component\\Console\\Application",
        "type": "->",
        "args": [
          {
            "__class__": "Symfony\\Component\\Console\\Input\\ArgvInput"
          },
          {
            "__class__": "Symfony\\Component\\Console\\Output\\ConsoleOutput"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/Console/Application.php",
        "line": 188,
        "function": "run",
        "class": "Symfony\\Component\\Console\\Application",
        "type": "->",
        "args": [
          {
            "__class__": "Symfony\\Component\\Console\\Input\\ArgvInput"
          },
          {
            "__class__": "Symfony\\Component\\Console\\Output\\ConsoleOutput"
          }
        ]
      },
      {
        "file": "/var/www/html/console.php",
        "line": 92,
        "function": "run",
        "class": "OC\\Console\\Application",
        "type": "->",
        "args": [
          {
            "__class__": "Symfony\\Component\\Console\\Input\\ArgvInput"
          }
        ]
      },
      {
        "file": "/var/www/html/occ",
        "line": 33,
        "args": [
          "/var/www/html/console.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/html/lib/private/Files/Node/NonExistingFile.php",
    "Line": 41,
    "message": "",
    "exception": "{\"class\":\"OCP\\Files\\NotFoundException\",\"message\":\"\",\"code\":0,\"file\":\"/var/www/html/lib/private/Files/Node/NonExistingFile.php:41\",\"trace\":\"#0 /var/www/html/apps/text/lib/Listeners/NodeWrittenResetDocumentListener.php(42): OC\\Files\\Node\\NonExistingFile->getId()\\n#1 /var/www/html/lib/private/EventDispatcher/ServiceEventListener.php(57): OCA\\Text\\Listeners\\NodeWrittenResetDocumentListener->handle(Object(OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent))\\n#2 /var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php(220): OC\\EventDispatcher\\ServiceEventListener->__invoke(Object(OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent), 'OCP\\\\Files\\\\Event...', Object(Symfony\\Component\\EventDispatcher\\EventDispatcher))\\n#3 /var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php(56): Symfony\\Component\\EventDispatcher\\EventDispatcher->callListeners(Array, 'OCP\\\\Files\\\\Event...', Object(OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent))\\n#4 /var/www/html/lib/private/EventDispatcher/EventDispatcher.php(73): Symfony\\Component\\EventDispatcher\\EventDispatcher->dispatch(Object(OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent), 'OCP\\\\Files\\\\Event...')\\n#5 /var/www/html/lib/private/EventDispatcher/EventDispatcher.php(86): OC\\EventDispatcher\\EventDispatcher->dispatch('OCP\\\\Files\\\\Event...', Object(OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent))\\n#6 /var/www/html/lib/private/Files/Node/HookConnector.php(74): OC\\EventDispatcher\\EventDispatcher->dispatchTyped(Object(OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent))\\n#7 /var/www/html/lib/private/legacy/OC_Hook.php(87): OC\\Files\\Node\\HookConnector->write(Array)\\n#8 /var/www/html/lib/private/Files/View.php(593): OC_Hook::emit('OC_Filesystem', 'write', Array)\\n#9 /var/www/html/lib/private/Files/View.php(636): OC\\Files\\View->emit_file_hooks_pre(false, '/admin/files/Me...', true)\\n#10 /var/www/html/lib/private/Files/Node/Folder.php(181): OC\\Files\\View->file_put_contents('/admin/files/Me...', Resource id #1641)\\n#11 /var/www/html/lib/private/Files/Template/TemplateManager.php(443): OC\\Files\\Node\\Folder->newFile('photo-152766844...', Resource id #1641)\\n#12 /var/www/html/lib/private/Files/Template/TemplateManager.php(435): OC\\Files\\Template\\TemplateManager->copyr('/skeleton/Media', Object(OC\\Files\\Node\\Folder))\\n#13 /var/www/html/lib/private/Files/Template/TemplateManager.php(487): OC\\Files\\Template\\TemplateManager->copyr('/skeleton', Object(OC\\Files\\Node\\Folder))\\n#14 /var/www/html/apps/files/lib/Listener/UserFirstTimeLoggedInListener.php(40): OC\\Files\\Template\\TemplateManager->copySkeleton('admin')\\n#15 /var/www/html/lib/private/EventDispatcher/ServiceEventListener.php(57): OCA\\Files\\Listener\\UserFirstTimeLoggedInListener->handle(Object(OCP\\User\\Events\\UserFirstTimeLoggedInEvent))\\n#16 /var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php(220): OC\\EventDispatcher\\ServiceEventListener->__invoke(Object(OCP\\User\\Events\\UserFirstTimeLoggedInEvent), 'OCP\\\\User\\\\Events...', Object(Symfony\\Component\\EventDispatcher\\EventDispatcher))\\n#17 /var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php(56): Symfony\\Component\\EventDispatcher\\EventDispatcher->callListeners(Array, 'OCP\\\\User\\\\Events...', Object(OCP\\User\\Events\\UserFirstTimeLoggedInEvent))\\n#18 /var/www/html/lib/private/EventDispatcher/EventDispatcher.php(73): Symfony\\Component\\EventDispatcher\\EventDispatcher->dispatch(Object(OCP\\User\\Events\\UserFirstTimeLoggedInEvent), 'OCP\\\\User\\\\Events...')\\n#19 /var/www/html/lib/private/EventDispatcher/EventDispatcher.php(86): OC\\EventDispatcher\\EventDispatcher->dispatch('OCP\\\\User\\\\Events...', Object(OCP\\User\\Events\\UserFirstTimeLoggedInEvent))\\n#20 /var/www/html/lib/private/User/Session.php(537): OC\\EventDispatcher\\EventDispatcher->dispatchTyped(Object(OCP\\User\\Events\\UserFirstTimeLoggedInEvent))\\n#21 /var/www/html/lib/private/User/Session.php(368): OC\\User\\Session->prepareUserLogin(true, false)\\n#22 /var/www/html/lib/private/User/Session.php(594): OC\\User\\Session->completeLogin(Object(OC\\User\\User), Array, false)\\n#23 /var/www/html/lib/private/User/Session.php(318): OC\\User\\Session->loginWithPassword('admin', 'admin')\\n#24 /var/www/html/lib/private/Setup.php(497): OC\\User\\Session->login('admin', 'admin')\\n#25 /var/www/html/core/Command/Maintenance/Install.php(81): OC\\Setup->install(Array, NULL)\\n#26 /var/www/html/3rdparty/symfony/console/Command/Command.php(326): OC\\Core\\Command\\Maintenance\\Install->execute(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))\\n#27 /var/www/html/3rdparty/symfony/console/Application.php(1083): Symfony\\Component\\Console\\Command\\Command->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))\\n#28 /var/www/html/3rdparty/symfony/console/Application.php(324): Symfony\\Component\\Console\\Application->doRunCommand(Object(OC\\Core\\Command\\Maintenance\\Install), Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))\\n#29 /var/www/html/3rdparty/symfony/console/Application.php(175): Symfony\\Component\\Console\\Application->doRun(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))\\n#30 /var/www/html/lib/private/Console/Application.php(188): Symfony\\Component\\Console\\Application->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))\\n#31 /var/www/html/console.php(92): OC\\Console\\Application->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput))\\n#32 /var/www/html/occ(33): require_once('/var/www/html/c...')\\n#33 {main}\"}",
    "CustomMessage": "Exception thrown: OCP\\Files\\NotFoundException"
  }
}
```

</details>
