### PR TITLE
fix(code): don't apply inline code CSS rules to code blocks

### DIFF
--- a/src/css/prosemirror.scss
+++ b/src/css/prosemirror.scss
@@ -282,7 +282,7 @@ div.ProseMirror {
 		padding-bottom: 0.5em;
 	}
 
-	code {
+	code:not(pre code) {
 		background-color: var(--color-background-dark);
 		border-radius: var(--border-radius);
 		padding: 0.1em 0.3em;


### PR DESCRIPTION
Removes superfluous padding in first line of code blocks introduced in f340afed5d32a1d08a3f54b061369aa699ab3ba6.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1152" height="685" alt="image" src="https://github.com/user-attachments/assets/c7e58296-be81-482a-821e-7d4a79e17e19" /> | <img width="1152" height="685" alt="image" src="https://github.com/user-attachments/assets/601d2e6d-0111-435a-9030-b3c3f50425b8" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
