### PR TITLE
chore(ci): add stable34 to branches that receive updates

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         branches:
           - ${{ github.event.repository.default_branch }}
+          - 'stable34'
           - 'stable33'
           - 'stable32'
 

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         branches:
           - ${{ github.event.repository.default_branch }}
+          - 'stable34'
           - 'stable33'
           - 'stable32'
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
 	"rangeStrategy": "bump",
 	"rebaseWhen": "conflicted",
 	"ignoreUnstable": false,
-	"baseBranchPatterns": ["main", "stable33", "stable32"],
+	"baseBranchPatterns": ["main", "stable34", "stable33", "stable32"],
 	"enabledManagers": ["npm"],
 	"ignoreDeps": ["node", "npm"],
 	"packageRules": [
@@ -51,12 +51,12 @@
 		},
 		{
 			"matchUpdateTypes": ["major"],
-			"matchBaseBranches": ["stable33", "stable32"],
+			"matchBaseBranches": ["stable34", "stable33", "stable32"],
 			"enabled": false
 		},
 		{
 			"matchUpdateTypes": ["major", "minor"],
-			"matchBaseBranches": ["stable33", "stable32"],
+			"matchBaseBranches": ["stable34", "stable33", "stable32"],
 			"enabled": false
 		},
 		{
@@ -66,7 +66,7 @@
 				"@nextcloud/cypress",
 				"@cypress/{/,}**"
 			],
-			"matchBaseBranches": ["stable33", "stable32"],
+			"matchBaseBranches": ["stable34", "stable33", "stable32"],
 			"enabled": false
 		},
 		{


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
