### PR TITLE
fix: allow dots in markdown link text

### DIFF
--- a/playwright/e2e/input-rules.spec.ts
+++ b/playwright/e2e/input-rules.spec.ts
@@ -18,3 +18,16 @@ test('applies code mark input rule with preceding character (#5483)', async ({
 	await expect(editor.el.locator('code')).toHaveText('code')
 	await expect(editor.el.locator('p').first()).toHaveText('hello inline (code)')
 })
+
+test('applies link mark input rule with dot in text (#7872)', async ({
+	editor,
+	open,
+}) => {
+	await open()
+	await editor.type('[example.org](https://example.org)')
+	await expect(editor.el.locator('a').first()).toHaveText('example.org')
+	await expect(editor.el.locator('a').first()).toHaveAttribute(
+		'href',
+		'https://example.org',
+	)
+})

--- a/src/marks/Link.ts
+++ b/src/marks/Link.ts
@@ -161,7 +161,7 @@ const Link = TipTapLink.extend<RelativePathLinkOptions>({
 	},
 
 	addInputRules() {
-		const linkInputRegex = /(?:^|\s)\[([\w|\s|-]+)\]\((?<href>.+?)\)$/gm
+		const linkInputRegex = /(?:^|\s)\[([^[\]]+)\]\((?<href>.+?)\)$/gm
 		return [
 			markInputRule({
 				find: linkInputRegex,


### PR DESCRIPTION
## Summary
- loosen the markdown link input rule so link text can contain dots
- add a regression test for `[something.cloud](https://something.cloud/page)`

Fixes #7872

## Tests
- npx vitest run src/tests/marks/Link.spec.js