### PR TITLE
fix(ActionInsertLink): allow to get title from link picker

### DIFF
--- a/src/components/Menu/ActionInsertLink.vue
+++ b/src/components/Menu/ActionInsertLink.vue
@@ -235,20 +235,22 @@ export default {
 		linkCustomAction() {
 			this.menubarLinkCustomAction
 				.action()
-				.then((link) => {
-					this.insertLink(link)
+				.then((result) => {
+					this.insertLink(result)
 				})
 				.catch((error) => {
 					console.error('Custom link action promise rejected', error)
 				})
 		},
-		insertLink(link) {
-			if (!link) {
+		insertLink(result) {
+			if (!result) {
 				return
 			}
+			const { link, title = '' } =
+				typeof result === 'string' ? { link: result } : result
 			const chain = this.editor?.chain()
 			if (this.editor?.view.state?.selection.empty) {
-				chain.focus().insertPreview(link).run()
+				chain.focus().insertPreview(link, title).run()
 			} else {
 				chain.setLink({ href: link }).focus().run()
 			}

--- a/src/nodes/Preview.js
+++ b/src/nodes/Preview.js
@@ -144,10 +144,12 @@ export default Node.create({
 			 * Insert a preview for given link.
 			 *
 			 * @param {string} link - the link URL
+			 * @param {string|null} title - the link title (optional)
 			 */
 			insertPreview:
-				(link) =>
+				(link, title = '') =>
 				({ state, chain }) => {
+					title = title.trim() || link
 					return chain()
 						.insertContent({
 							type: 'preview',
@@ -161,7 +163,7 @@ export default Node.create({
 											attrs: { href: link },
 										},
 									],
-									text: link,
+									text: title,
 								},
 							],
 						})


### PR DESCRIPTION
Requires nextcloud-libraries/nextcloud-vue#8532 to have an effect.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
