### PR TITLE
fix: Rename mobile editing file creator name to leave out "New" prefix

### DIFF
--- a/lib/DirectEditing/TextDocumentCreator.php
+++ b/lib/DirectEditing/TextDocumentCreator.php
@@ -34,7 +34,7 @@ class TextDocumentCreator extends ACreateEmpty {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('text document');
+		return $this->l10n->t('Text document');
 	}
 
 	public function getExtension(): string {

--- a/lib/Listeners/RegisterTemplateCreatorListener.php
+++ b/lib/Listeners/RegisterTemplateCreatorListener.php
@@ -32,7 +32,7 @@ class RegisterTemplateCreatorListener implements IEventListener {
 		}
 
 		$event->getTemplateManager()->registerTemplateFileCreator(function () {
-			$markdownFile = new TemplateFileCreator(Application::APP_NAME, $this->l10n->t('New text file'), '.' . $this->configService->getDefaultFileExtension());
+			$markdownFile = new TemplateFileCreator(Application::APP_NAME, $this->l10n->t('Text document'), '.' . $this->configService->getDefaultFileExtension());
 			$markdownFile->addMimetype('text/markdown');
 			$markdownFile->addMimetype('text/plain');
 			$markdownFile->setIconSvgInline((string)file_get_contents($this->appManager->getAppPath('text') . '/img/article.svg'));

--- a/src/components/Menu/ActionAttachmentUpload.vue
+++ b/src/components/Menu/ActionAttachmentUpload.vue
@@ -122,7 +122,7 @@ export default {
 			}
 			return (
 				templates
-					// Exclude "New text file" as it doesn't make much sense from a text file
+					// Exclude "Text document" as it doesn't make much sense from a text file
 					.filter((t) => !(t.app === 'text' && t.extension === '.md'))
 			)
 		},

--- a/tests/unit/DirectEditing/TextDocumentCreatorTest.php
+++ b/tests/unit/DirectEditing/TextDocumentCreatorTest.php
@@ -31,9 +31,9 @@ class TextDocumentCreatorTest extends \PHPUnit\Framework\TestCase {
 	public function testGetName(): void {
 		$this->l10n->expects($this->once())
 			->method('t')
-			->with('text document')
-			->willReturn('text document');
-		$this->assertEquals('text document', $this->textDocumentCreator->getName());
+			->with('Text document')
+			->willReturn('Text document');
+		$this->assertEquals('Text document', $this->textDocumentCreator->getName());
 	}
 
 	public function testGetDefaultExtension(): void {


### PR DESCRIPTION
Signed-off-by: Julius Knorr <jus@bitgrid.net>

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI tools
- [ ] The AI-generated content was reviewed, comprehended and tested by a human
