### PR TITLE
fix: disable open link button for unsafe link

### DIFF
--- a/src/components/Link/LinkBubbleView.vue
+++ b/src/components/Link/LinkBubbleView.vue
@@ -12,8 +12,9 @@
 			</div>
 			<!-- open link -->
 			<NcButton
-				:title="t('text', 'Open link')"
-				:aria-label="t('text', 'Open link')"
+				:disabled="!isSafeHref"
+				:title="openLinkTitle"
+				:aria-label="openLinkTitle"
 				variant="tertiary"
 				@click="openLink(href)">
 				<template #icon>
@@ -98,6 +99,7 @@ import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 
 import { useOpenLinkHandler } from '../../composables/useOpenLinkHandler.ts'
+import { PROTOCOLS_TO_LINK_TO } from '../../marks/Link.ts'
 import PreviewOptions from '../Editor/PreviewOptions.vue'
 
 const PROTOCOLS_WITH_PREVIEW = ['http:', 'https:']
@@ -169,6 +171,27 @@ export default {
 			} catch {
 				return false
 			}
+		},
+
+		isSafeHref() {
+			try {
+				const url = new URL(this.href, window.location)
+				return !!this.href && PROTOCOLS_TO_LINK_TO.includes(url.protocol)
+			} catch {
+				return false
+			}
+		},
+
+		openLinkTitle() {
+			if (this.isSafeHref) {
+				return t('text', 'Open link')
+			}
+
+			if (!this.href) {
+				return t('text', 'No link available to open')
+			}
+
+			return t('text', 'Cannot open links with unsafe protocols')
 		},
 	},
 

--- a/src/marks/Link.ts
+++ b/src/marks/Link.ts
@@ -13,7 +13,7 @@ import { defaultMarkdownSerializer } from 'prosemirror-markdown'
 import { domHref, parseHref } from '../helpers/links.js'
 import { linkClicking } from '../plugins/links'
 
-const PROTOCOLS_TO_LINK_TO = ['http:', 'https:', 'mailto:', 'tel:']
+export const PROTOCOLS_TO_LINK_TO = ['http:', 'https:', 'mailto:', 'tel:']
 
 const extractHrefFromMatch = (match: ExtendedRegExpMatchArray) => {
 	return { href: match.groups?.href }


### PR DESCRIPTION
### 📝 Summary

* Resolves: Disables the "Open link" button for unsafe links and updates the tooltip and aria-label to provide clear feedback to users.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI tools
- [ ] The AI-generated content was reviewed, comprehended and tested by a human
