### PR TITLE
fix(folderDescription): always use 'Readme.md' as filename

### DIFF
--- a/cypress/e2e/workspace.spec.js
+++ b/cypress/e2e/workspace.spec.js
@@ -173,11 +173,11 @@ describe('Workspace', function () {
 			cy.get('#rich-workspace .ProseMirror').should('contain', 'Hello world')
 		})
 
-		it('creates description with localized name properly rendered', function () {
+		it('creates description with default name', function () {
 			cy.modifyUser(user, 'language', 'es')
 			cy.visitTestFolder()
 			cy.createDescription('Añadir descripción a carpeta')
-			cy.getFile('Léeme.md')
+			cy.getFile('Readme.md')
 			cy.get('#rich-workspace .editor__content').should('be.visible')
 		})
 

--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -169,7 +169,7 @@ class WorkspaceController extends OCSController {
 				$file = $this->workspaceService->getFile($folder);
 				if ($file === null) {
 					$token = $this->directEditingManager->create(
-						$path . '/' . $this->workspaceService->getSupportedFilenames()[0],
+						$path . '/' . WorkspaceService::DEFAULT_FILENAME,
 						Application::APP_NAME,
 						TextDocumentCreator::CREATOR_ID
 					);

--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -19,10 +19,13 @@ use OCP\IL10N;
 class WorkspaceService {
 	private IL10N $l10n;
 
+	public const DEFAULT_FILENAME = 'Readme.md';
+
 	private const SUPPORTED_STATIC_FILENAMES = [
-		'Readme.md',
+		self::DEFAULT_FILENAME,
 		'README.md',
-		'readme.md'
+		'readme.md',
+		'.Readme.md',
 	];
 
 	public function __construct(IL10N $l10n) {

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -24,7 +24,7 @@ const FILE_ACTION_IDENTIFIER = 'Edit with text app'
 
 export const addMenuRichWorkspace = () => {
 	const descriptionFile =
-		t('text', 'Readme') + '.' + loadState('text', 'default_file_extension')
+		'Readme' + '.' + loadState('text', 'default_file_extension')
 	addNewFileMenuEntry({
 		id: 'rich-workspace-init',
 		displayName: t('text', 'Add folder description'),

--- a/src/views/RichWorkspace.vue
+++ b/src/views/RichWorkspace.vue
@@ -46,9 +46,11 @@ const WORKSPACE_URL = generateOcsUrl(
 	'apps/text' + (IS_PUBLIC ? '/public' : '') + '/workspace',
 	2,
 )
-const descriptionFile =
+const descriptionFile = 'Readme' + '.' + loadState('text', 'default_file_extension')
+const translatedDescriptionFile =
 	t('text', 'Readme') + '.' + loadState('text', 'default_file_extension')
 const SUPPORTED_STATIC_FILENAMES = [
+	translatedDescriptionFile,
 	descriptionFile,
 	'Readme.md',
 	'README.md',

--- a/tests/unit/Service/WorkspaceServiceTest.php
+++ b/tests/unit/Service/WorkspaceServiceTest.php
@@ -53,6 +53,7 @@ class WorkspaceServiceTest extends TestCase {
 			['docs/Readme.md', $readmeEntry],
 			['docs/README.md', $uppercaseEntry],
 			['docs/readme.md', false],
+			['docs/.Readme.md', false],
 		]);
 
 		$folder->expects($this->once())
@@ -81,6 +82,7 @@ class WorkspaceServiceTest extends TestCase {
 			['docs/Readme.md', $directoryEntry],
 			['docs/README.md', false],
 			['docs/readme.md', false],
+			['docs/.Readme.md', false],
 		]);
 
 		$folder->expects($this->never())->method('get');


### PR DESCRIPTION
Fixes: #5953

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by me
