### PR TITLE
fix(headings): skip headings in details in table of contents

### DIFF
--- a/src/plugins/extractHeadings.ts
+++ b/src/plugins/extractHeadings.ts
@@ -31,6 +31,10 @@ export default function extractHeadings(doc: Node) {
 	}
 
 	doc.descendants((node, offset) => {
+		// Don't descent into detials blocks - their headings are hidden
+		if (node.type.name === 'details') {
+			return false
+		}
 		if (node.type.name !== 'heading') {
 			return
 		}

--- a/src/plugins/extractHeadings.ts
+++ b/src/plugins/extractHeadings.ts
@@ -31,8 +31,8 @@ export default function extractHeadings(doc: Node) {
 	}
 
 	doc.descendants((node, offset) => {
-		// Don't descent into detials blocks - their headings are hidden
-		if (node.type.name === 'details') {
+		// Don't descent into details/blockquote nodes - their headings are hidden
+		if (node.type.name === 'details' || node.type.name === 'blockquote') {
 			return false
 		}
 		if (node.type.name !== 'heading') {

--- a/src/tests/plugins/extractHeadings.spec.js
+++ b/src/tests/plugins/extractHeadings.spec.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { Blockquote } from '@tiptap/extension-blockquote'
 import Details from '../../nodes/Details.js'
 import Heading from '../../nodes/Heading.js'
 import extractHeadings from '../../plugins/extractHeadings.ts'
@@ -45,6 +46,19 @@ describe('extractHeadings', () => {
 			</details>
 		`
 		const doc = prepareDoc(content, [Details])
+		const headings = extractHeadings(doc)
+		expect(headings).toHaveLength(1)
+		expect(headings[0].text).toBe('Visible heading')
+	})
+
+	it('ignores headings inside a block quote block', () => {
+		const content = `
+			<h1>Visible heading</h1>
+			<blockquote>
+				<h1>Quoted heading</h1>
+			</blockquote>
+		`
+		const doc = prepareDoc(content, [Blockquote])
 		const headings = extractHeadings(doc)
 		expect(headings).toHaveLength(1)
 		expect(headings[0].text).toBe('Visible heading')

--- a/src/tests/plugins/extractHeadings.spec.js
+++ b/src/tests/plugins/extractHeadings.spec.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import Details from '../../nodes/Details.js'
 import Heading from '../../nodes/Heading.js'
 import extractHeadings from '../../plugins/extractHeadings.ts'
 import createCustomEditor from '../testHelpers/createCustomEditor.ts'
@@ -35,6 +36,20 @@ describe('extractHeadings', () => {
 		expect(headings).toEqual([])
 	})
 
+	it('ignores headings inside a details block', () => {
+		const content = `
+			<h1>Visible heading</h1>
+			<details>
+				<summary>Details summary</summary>
+				<div data-type="detailsContent"><h1>Hidden heading</h1></div>
+			</details>
+		`
+		const doc = prepareDoc(content, [Details])
+		const headings = extractHeadings(doc)
+		expect(headings).toHaveLength(1)
+		expect(headings[0].text).toBe('Visible heading')
+	})
+
 	it('creates unique ids with a counter', () => {
 		const content = `
 			<h1>Level 1 heading</h1>
@@ -46,8 +61,8 @@ describe('extractHeadings', () => {
 	})
 })
 
-const prepareDoc = (content) => {
-	const editor = createCustomEditor(content, [Heading])
+const prepareDoc = (content, extraExtensions = []) => {
+	const editor = createCustomEditor(content, [Heading, ...extraExtensions])
 	const doc = editor.state.doc
 	editor.destroy()
 	return doc


### PR DESCRIPTION
Fixes: #8582

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by me
