### PR TITLE
fix(Editor): emit modified fileNode size on save

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -734,6 +734,7 @@ export default defineComponent({
 		onSave() {
 			if (this.fileNode) {
 				this.fileNode.mtime = new Date()
+				this.fileNode.size = new Blob([this.serialize()]).size
 				emit('files:node:updated', this.fileNode)
 			}
 			this.$nextTick(() => {


### PR DESCRIPTION
### 📝 Summary

* Resolves: alternative to https://github.com/nextcloud/server/pull/60527
  * emitted event is interpreted by Files app correctly to update the UI (for modified date)
  * now covering updated file size

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="432" height="33" alt="image" src="https://github.com/user-attachments/assets/407ffaa6-9b57-465f-8a68-1d77e855473b" /> | <img width="438" height="33" alt="image" src="https://github.com/user-attachments/assets/8ec187cc-1f4e-476d-950b-89b68b18c1c6" />


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
