### PR TITLE
fix(mediaHandler): strip relevant bidi chars in filenames

### DIFF
--- a/src/components/Editor/MediaHandler.vue
+++ b/src/components/Editor/MediaHandler.vue
@@ -228,7 +228,10 @@ export default {
 			this.editor.chain().focus().insertPreview(href).run()
 		},
 		insertAttachment(name, fileId, mimeType, position = null, dirname = '') {
-			const sanitizedName = name.replaceAll('\u202E', '')
+			const sanitizedName = name.replace(
+				/[\u200E\u200F\u202A-\u202E\u2066-\u2069]/g,
+				'',
+			)
 			// inspired by the fixedEncodeURIComponent function suggested in
 			// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
 			const src =


### PR DESCRIPTION
### 📝 Summary

Strip more bidirectional characters than just `U+202E`.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required