### PR TITLE
fix(math): fix lost content after math node

### DIFF
--- a/src/markdownit/mathematics.ts
+++ b/src/markdownit/mathematics.ts
@@ -21,7 +21,7 @@ const escapeHtml = (unsafe: string) =>
 		.replace(/'/g, '&#039;')
 
 const renderBlock = (content: string) =>
-	`<div data-type="block-math" data-latex="${escapeHtml(content)}" />`
+	`<div data-type="block-math" data-latex="${escapeHtml(content)}"></div>`
 
 const renderInline = (content: string) =>
 	`<span data-type="inline-math" data-latex="${escapeHtml(content)}">${escapeHtml(content)}</span>`

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -346,6 +346,12 @@ describe('Markdown serializer from html', () => {
 			'<details>\n<summary>**summary**</summary>\n```\ncode\n```\n\n</details>\n',
 		)
 	})
+
+	test('math (content following math stays, #8654)', () => {
+		const test =
+			'Content above\n\n$$\n\\sum_{i=1}^n i = \\frac{n(n+1)}{2}\n$$\n\nContent below'
+		expect(markdownThroughEditor(test)).toBe(test)
+	})
 })
 
 describe('Trailing nodes', () => {

--- a/src/tests/markdownit/mathematics.spec.ts
+++ b/src/tests/markdownit/mathematics.spec.ts
@@ -30,7 +30,7 @@ $$
 		expect(stripIndent(rendered)).toBe(
 			stripIndent(`
 			<p>Here is some more math:</p>
-			<div data-type="block-math" data-latex="1 + 1 + 1 = 3" />
+			<div data-type="block-math" data-latex="1 + 1 + 1 = 3"></div>
 			<p>.</p>`),
 		)
 	})


### PR DESCRIPTION
Properly close div element in markdown-it plugin. Div elements cannot be a void element with self-closing slash, so all content after the div became part of this div element.

Fixes: #8654

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
