### PR TITLE
fix(autofocus): persist cursor positions in localStorage

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -85,7 +85,7 @@ import { Collaboration } from '@tiptap/extension-collaboration'
 import { useElementSize } from '@vueuse/core'
 import { defineComponent, inject, ref, shallowRef, watch } from 'vue'
 import { Doc, logUpdate } from 'yjs'
-import Autofocus from '../extensions/Autofocus.js'
+import Autofocus from '../extensions/Autofocus.ts'
 
 import { provideEditor } from '../composables/useEditor.ts'
 import { provideEditorFlags } from '../composables/useEditorFlags.ts'

--- a/src/extensions/Autofocus.ts
+++ b/src/extensions/Autofocus.ts
@@ -40,14 +40,14 @@ export default Extension.create<AutofocusOptions>({
 		}
 
 		const pos = editor.state.selection.$anchor.pos
-		sessionStorage.setItem('text-lastPos-' + this.options.fileId, String(pos))
+		localStorage.setItem('text-lastPos-' + this.options.fileId, String(pos))
 	},
 	addCommands() {
 		return {
 			autofocus:
 				() =>
 				({ commands }) => {
-					const pos = sessionStorage.getItem(
+					const pos = localStorage.getItem(
 						'text-lastPos-' + this.options.fileId,
 					)
 					if (pos) {

--- a/src/extensions/Autofocus.ts
+++ b/src/extensions/Autofocus.ts
@@ -5,7 +5,19 @@
 
 import { Extension } from '@tiptap/core'
 
-export default Extension.create({
+export interface AutofocusOptions {
+	fileId: number | null
+}
+
+declare module '@tiptap/core' {
+	interface Commands<ReturnType> {
+		autofocus: {
+			autofocus: () => ReturnType
+		}
+	}
+}
+
+export default Extension.create<AutofocusOptions>({
 	addOptions() {
 		return {
 			fileId: null,
@@ -28,18 +40,18 @@ export default Extension.create({
 		}
 
 		const pos = editor.state.selection.$anchor.pos
-		sessionStorage.setItem('text-lastPos-' + this.options.fileId, pos)
+		sessionStorage.setItem('text-lastPos-' + this.options.fileId, String(pos))
 	},
 	addCommands() {
 		return {
 			autofocus:
 				() =>
-				({ commands, editor }) => {
+				({ commands }) => {
 					const pos = sessionStorage.getItem(
 						'text-lastPos-' + this.options.fileId,
 					)
 					if (pos) {
-						return commands.focus(pos)
+						return commands.focus(Number(pos))
 					}
 
 					return commands.focus('start')


### PR DESCRIPTION
Fixes: #8699

This makes the autofocus feature much more usable, as it persists the cursor position per device, not only per browser tab.

Also migrates Autofocus extension to TypeScript.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
