### PR TITLE
fix(editor): pass missing noLazyImages props

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -324,6 +324,7 @@ window.OCA.Text.createEditor = async function ({
 							active: true,
 							autofocus,
 							showOutlineOutside: data.showOutlineOutside,
+							noLazyImages,
 						},
 						scopedSlots,
 					})
@@ -335,6 +336,7 @@ window.OCA.Text.createEditor = async function ({
 							shareToken,
 							readOnly: data.readOnly,
 							showOutlineOutside: data.showOutlineOutside,
+							noLazyImages,
 						},
 						scopedSlots,
 					})

--- a/src/extensions/RichText.js
+++ b/src/extensions/RichText.js
@@ -64,6 +64,7 @@ export default Extension.create({
 			extensions: [],
 			relativePath: null,
 			isEmbedded: false,
+			noLazyImages: false,
 		}
 	},
 


### PR DESCRIPTION
I have overlooked passing some props in this backport: https://github.com/nextcloud/text/pull/8726


### 🏁 Checklist

- [X] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [X] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
