### PR TITLE
Fix permission change in text doc

### DIFF
--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -261,6 +261,10 @@ class ApiService {
 			} catch (LockedException) {
 				// Ignore locked exception since it might happen due to an autosave action happening at the same time
 			}
+		} catch (NotPermittedException) {
+			return new DataResponse([
+				'error' => $this->l10n->t('Read-only permission cannot save document changes. Please reload the page.')
+			], Http::STATUS_PRECONDITION_FAILED);
 		} catch (NotFoundException) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		} catch (Exception $e) {

--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -174,9 +174,11 @@ class ApiService {
 			$this->addToPushQueue($document, [$awareness, ...array_values($steps)]);
 		} catch (InvalidArgumentException $e) {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_UNPROCESSABLE_ENTITY);
-		} catch (DoesNotExistException|NotPermittedException) {
+		} catch (DoesNotExistException) {
 			// Either no write access or session was removed in the meantime (#3875).
 			return new DataResponse(['error' => $this->l10n->t('Editing session has expired. Please reload the page.')], Http::STATUS_PRECONDITION_FAILED);
+		} catch (NotPermittedException) {
+			return new DataResponse(['error' => $this->l10n->t('This document is read-only.')], Http::STATUS_FORBIDDEN);
 		}
 		return new DataResponse($result);
 	}
@@ -214,6 +216,7 @@ class ApiService {
 
 			// ensure file is still present and accessible
 			$file = $this->documentService->getFileForSession($session, $shareToken);
+			$result['readOnly'] = $this->documentService->isReadOnly($file, $shareToken);
 			$this->documentService->assertNoOutsideConflict($document, $file);
 		} catch (NotPermittedException|NotFoundException|InvalidPathException $e) {
 			$this->logger->info($e->getMessage(), ['exception' => $e]);
@@ -264,7 +267,7 @@ class ApiService {
 		} catch (NotPermittedException) {
 			return new DataResponse([
 				'error' => $this->l10n->t('Read-only permission cannot save document changes. Please reload the page.')
-			], Http::STATUS_PRECONDITION_FAILED);
+			], Http::STATUS_FORBIDDEN);
 		} catch (NotFoundException) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		} catch (Exception $e) {

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -382,7 +382,7 @@ class DocumentService {
 		$documentId = $document->getId();
 
 		if ($this->isReadOnly($file, $shareToken)) {
-			return $document;
+			throw new NotPermittedException('Read-only permission cannot save document changes. Please reload the page.');
 		}
 
 		$this->assertNoOutsideConflict($document, $file, $force);
@@ -599,6 +599,13 @@ class DocumentService {
 	}
 
 	public function isReadOnlyCached(Session $session, ?string $shareToken = null): bool {
+		// since public share permissions can change while a guest tab is open,
+		// stale session cache is avoided and always re-evaluate.
+		if ($shareToken !== null) {
+			$file = $this->getFileForSession($session, $shareToken);
+			return $this->isReadOnly($file, $shareToken);
+		}
+
 		$cacheKey = 'read-only-' . $session->getId();
 		$isReadOnly = $this->cache->get($cacheKey);
 		if ($isReadOnly === null) {
@@ -612,15 +619,13 @@ class DocumentService {
 	}
 
 	public function isReadOnly(File $file, ?string $token): bool {
-		$readOnly = true;
+		$readOnly = !$file->isUpdateable();
 		if ($token !== null) {
 			try {
 				$this->checkSharePermissions($token, Constants::PERMISSION_UPDATE);
-				$readOnly = false;
 			} catch (NotFoundException $e) {
+				$readOnly = true;
 			}
-		} else {
-			$readOnly = !$file->isUpdateable();
 		}
 
 		$lockInfo = $this->getLockInfo($file);

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -218,7 +218,8 @@ class DocumentService {
 	 */
 	public function addStep(Document $document, Session $session, array $steps, int $version, ?int $recoveryAttempt, ?string $shareToken): array {
 		$documentId = $session->getDocumentId();
-		$readOnly = $this->isReadOnlyCached($session, $shareToken);
+		$file = $this->getFileForSession($session, $shareToken);
+		$readOnly = $this->isReadOnly($file, $shareToken);
 		$stepsToInsert = [];
 		$stepsIncludeQuery = false;
 		$documentState = null;
@@ -596,26 +597,6 @@ class DocumentService {
 			return $node;
 		}
 		throw new \InvalidArgumentException('No proper share data');
-	}
-
-	public function isReadOnlyCached(Session $session, ?string $shareToken = null): bool {
-		// since public share permissions can change while a guest tab is open,
-		// stale session cache is avoided and always re-evaluate.
-		if ($shareToken !== null) {
-			$file = $this->getFileForSession($session, $shareToken);
-			return $this->isReadOnly($file, $shareToken);
-		}
-
-		$cacheKey = 'read-only-' . $session->getId();
-		$isReadOnly = $this->cache->get($cacheKey);
-		if ($isReadOnly === null) {
-			$file = $this->getFileForSession($session, $shareToken);
-			$isReadOnly = $this->isReadOnly($file, $shareToken);
-			$this->cache->set($cacheKey, $isReadOnly, 60 * 5);
-			return $isReadOnly;
-		}
-
-		return $isReadOnly;
 	}
 
 	public function isReadOnly(File $file, ?string $token): bool {

--- a/src/apis/sync.ts
+++ b/src/apis/sync.ts
@@ -56,6 +56,7 @@ interface SyncResponse {
 		awareness: Record<string, string>
 		document: Document
 		sessions: Session[]
+		readOnly?: boolean
 	}
 }
 

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -97,6 +97,7 @@ import {
 } from './Editor.provider.ts'
 import ReadonlyBar from './Menu/ReadonlyBar.vue'
 
+import { showWarning } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
 import { generateRemoteUrl } from '@nextcloud/router'
 import { Awareness } from 'y-protocols/awareness.js'
@@ -548,6 +549,7 @@ export default defineComponent({
 			bus.on('stateChange', this.onStateChange)
 			bus.on('idle', this.onIdle)
 			bus.on('save', this.onSave)
+			bus.on('permissionChange', this.onPermissionChange)
 		},
 
 		unlistenSyncServiceEvents() {
@@ -559,6 +561,7 @@ export default defineComponent({
 			bus.off('stateChange', this.onStateChange)
 			bus.off('idle', this.onIdle)
 			bus.off('save', this.onSave)
+			bus.off('permissionChange', this.onPermissionChange)
 		},
 
 		reconnect() {
@@ -693,7 +696,15 @@ export default defineComponent({
 			}
 
 			if (type === ERROR_TYPE.PUSH_FORBIDDEN) {
-				this.hasConnectionIssue = true
+				this.readOnly = true
+				this.editMode = false
+				this.setEditable(this.editMode)
+				showWarning(
+					t(
+						'text',
+						'Your editing permissions have been revoked. The document is now read-only.',
+					),
+				)
 				this.emit('push:forbidden')
 				return
 			}
@@ -745,6 +756,24 @@ export default defineComponent({
 			this.$nextTick(() => {
 				this.emit('sync-service:save')
 			})
+		},
+
+		onPermissionChange({ readOnly }) {
+			this.readOnly = readOnly
+			this.editMode = !readOnly && !this.openReadOnlyEnabled
+			this.setEditable(this.editMode)
+			if (readOnly) {
+				showWarning(
+					t(
+						'text',
+						'Your editing permissions have been revoked. The document is now read-only.',
+					),
+				)
+			} else {
+				showWarning(
+					t('text', 'You now have edit permissions for this document.'),
+				)
+			}
 		},
 
 		onFocus() {

--- a/src/services/PollingBackend.ts
+++ b/src/services/PollingBackend.ts
@@ -60,6 +60,7 @@ interface PollData {
 	document: Document
 	sessions: Session[]
 	steps: Step[]
+	readOnly?: boolean
 }
 
 interface ConflictData extends PollData {
@@ -144,6 +145,16 @@ class PollingBackend {
 	_handleResponse({ data }: { data: PollData }) {
 		const { document, sessions } = data
 		this.#fetchRetryCounter = 0
+
+		if (data.readOnly !== undefined && data.readOnly !== this.#readOnly) {
+			this.#readOnly = data.readOnly
+			this.#syncService.bus.emit('permissionChange', {
+				readOnly: this.#readOnly,
+			})
+			if (data.readOnly) {
+				this.maximumReadOnlyTimer()
+			}
+		}
 
 		this.#syncService.bus.emit('change', { document, sessions })
 		this.#syncService.receiveSteps(data)

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { showError } from '@nextcloud/dialogs'
 import debounce from 'debounce'
 
 import type { ShallowRef } from 'vue'
 import { save, saveViaSendBeacon } from '../apis/save'
 import type { Connection } from '../composables/useConnection.ts'
 import { logger } from '../helpers/logger.js'
-import type { SyncService } from './SyncService'
+import { ERROR_TYPE, type SyncService } from './SyncService'
 
 /**
  * Interval to save the serialized document and the document state
@@ -74,6 +75,16 @@ class SaveService {
 			this.autosave.clear()
 		} catch (e) {
 			logger.error('Failed to save document.', { error: e })
+			const response = (e as { response?: { status?: number, data?: { error?: string } } }).response
+			if (response?.status === 412) {
+				this.emit('error', {
+					type: ERROR_TYPE.LOAD_ERROR,
+					data: response,
+				})
+				if (response.data?.error) {
+					showError(response.data.error)
+				}
+			}
 			throw e
 		}
 	}

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -75,7 +75,13 @@ class SaveService {
 			this.autosave.clear()
 		} catch (e) {
 			logger.error('Failed to save document.', { error: e })
-			const response = (e as { response?: { status?: number, data?: { error?: string } } }).response
+			const response = (
+				e as { response?: { status?: number; data?: { error?: string } } }
+			).response
+			if (response?.status === 403) {
+				// Document is now read-only; permissionChange from sync will update the UI
+				return
+			}
 			if (response?.status === 412) {
 				this.emit('error', {
 					type: ERROR_TYPE.LOAD_ERROR,

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -129,6 +129,9 @@ export declare type EventTypes = {
 
 	/* Emitted if the connection has been closed */
 	close: void
+
+	/* Emitted if the read only state of the document has changed */
+	permissionChange: { readOnly: boolean }
 }
 
 class SyncService {

--- a/tests/unit/Service/ApiServiceTest.php
+++ b/tests/unit/Service/ApiServiceTest.php
@@ -2,8 +2,8 @@
 
 namespace OCA\Text\Tests;
 
-use OCA\Text\Db\Session;
 use OCA\Text\Db\Document;
+use OCA\Text\Db\Session;
 use OCA\Text\Service\ApiService;
 use OCA\Text\Service\ConfigService;
 use OCA\Text\Service\DocumentService;

--- a/tests/unit/Service/ApiServiceTest.php
+++ b/tests/unit/Service/ApiServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace OCA\Text\Tests;
 
+use OCA\Text\Db\Session;
 use OCA\Text\Db\Document;
 use OCA\Text\Service\ApiService;
 use OCA\Text\Service\ConfigService;
@@ -68,6 +69,29 @@ class ApiServiceTest extends \PHPUnit\Framework\TestCase {
 		$this->documentService->method('getFileById')->willReturn($file);
 		$actual = $this->apiService->create(1234);
 		self::assertFalse($actual->getData()['hasOwner']);
+	}
+
+	public function testSaveWithNotPermittedException() {
+		$session = new Session();
+		$session->setDocumentId(123);
+
+		$document = new Document();
+
+		$file = $this->mockFile(123, 'admin');
+
+		$this->documentService->method('getFileForSession')->willReturn($file);
+		$this->documentService->method('autosave')->willThrowException(new  \OCP\Files\NotPermittedException());
+
+		$this->l10n->method('t')
+			->with('Read-only permission cannot save document changes. Please reload the page.')
+			->willReturn('Read-only permission cannot save document changes. Please reload the page.');
+
+		$response = $this->apiService->save($session, $document, 1, 'content', 'state');
+
+		self::assertEquals(\OCP\AppFramework\Http::STATUS_FORBIDDEN, $response->getStatus());
+		self::assertEquals('Read-only permission cannot save document changes. Please reload the page.',
+			$response->getData()['error']
+		);
 	}
 
 	private function mockFile(int $id, ?string $owner) {


### PR DESCRIPTION
### 📝 Summary

Make a permission change of an internal share visible for the user.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
