### PR TITLE
Performance: Only check permissions when changing content

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -218,16 +218,11 @@ class DocumentService {
 	 */
 	public function addStep(Document $document, Session $session, array $steps, int $version, ?int $recoveryAttempt, ?string $shareToken): array {
 		$documentId = $session->getDocumentId();
-		$file = $this->getFileForSession($session, $shareToken);
-		$readOnly = $this->isReadOnly($file, $shareToken);
 		$stepsToInsert = [];
 		$stepsIncludeQuery = false;
 		$documentState = null;
 		foreach ($steps as $step) {
 			$message = YjsMessage::fromBase64($step);
-			if ($readOnly && $message->isUpdate()) {
-				continue;
-			}
 			// Only accept sync protocol
 			if ($message->getYjsMessageType() !== YjsMessage::YJS_MESSAGE_SYNC) {
 				continue;
@@ -240,10 +235,10 @@ class DocumentService {
 			}
 		}
 		if (count($stepsToInsert) > 0) {
-			if ($readOnly) {
-				throw new NotPermittedException('Read-only client tries to push steps with changes');
+			$file = $this->getFileForSession($session, $shareToken);
+			if (!$this->isReadOnly($file, $shareToken)) {
+				$this->insertSteps($document, $session, $stepsToInsert);
 			}
-			$this->insertSteps($document, $session, $stepsToInsert);
 		}
 
 		// By default, send all steps the user has not received yet.


### PR DESCRIPTION
Avoid setting up the file system for read only shares.

Also clarify the behavior:
Updates are silently dropped as they were before.

Previously `stepsToInsert` would always be empty for readonly requests,
due to the continue in the loop collecting the steps.
So there was no way to trigger the
```
NotPermittedException('Read-only client tries to push steps with changes')
```

Keep this behavior for now so we can backport this commit.

## Background

Clients on readonly shares regularly push updates to the server
to update their awareness state - i.e. let others know they are still around.

These requests trigger the `addStep` function
even if they do not actually change the content of the file.
