### PR TITLE
fix(editor): preserve leading newlines in plain text editor

### DIFF
--- a/src/composables/useEditorMethods.ts
+++ b/src/composables/useEditorMethods.ts
@@ -25,7 +25,7 @@ export const useEditorMethods = (editor: Editor) => {
 			editor.extensionManager.extensions.includes(Markdown)
 		const html = hasMarkdownContent
 			? markdownit.render(content) + '<p/>'
-			: `<pre>${escapeHtml(content)}</pre>`
+			: `<pre>\n${escapeHtml(content)}</pre>`
 		editor
 			.chain()
 			.setContent(html, { emitUpdate: addToHistory })

--- a/src/helpers/setInitialYjsState.ts
+++ b/src/helpers/setInitialYjsState.ts
@@ -17,7 +17,7 @@ export const setInitialYjsState = (
 ) => {
 	const html = isRichEditor
 		? markdownit.render(content) + '<p/>'
-		: `<pre>${escapeHtml(content)}</pre>`
+		: `<pre>\n${escapeHtml(content)}</pre>`
 
 	const editor = isRichEditor ? createRichEditor() : createPlainEditor()
 	editor.commands.setContent(html)

--- a/src/helpers/updateFromContent.ts
+++ b/src/helpers/updateFromContent.ts
@@ -30,7 +30,7 @@ const setContent = (
 ) => {
 	const html = isRichEditor
 		? markdownit.render(content) + '<p/>'
-		: `<pre>${escapeHtml(content)}</pre>`
+		: `<pre>\n${escapeHtml(content)}</pre>`
 	const editor = isRichEditor
 		? createRichEditor({
 				extensions: [Collaboration.configure({ document: doc })],

--- a/src/tests/plaintext.spec.js
+++ b/src/tests/plaintext.spec.js
@@ -18,7 +18,7 @@ const escapeHTML = (s) => {
 }
 
 const plaintextThroughEditor = (markdown) => {
-	const content = '<pre>' + escapeHTML(markdown) + '</pre>'
+	const content = '<pre>\n' + escapeHTML(markdown) + '</pre>'
 	const tiptap = createPlainEditor()
 	tiptap.commands.setContent(content)
 	const plaintext = serializePlainText(tiptap.state.doc) || 'failed'
@@ -27,14 +27,7 @@ const plaintextThroughEditor = (markdown) => {
 }
 
 describe('commonmark as plaintext', () => {
-	// FIXME: Those two tests currently fail as trailing whitespace seems to be stripped,
-	// if it occurs in the first line which is empty otherwise.
-	const skippedMarkdownTests = [97, 117]
-
 	spec.forEach((entry) => {
-		if (skippedMarkdownTests.indexOf(entry.example) !== -1) {
-			return
-		}
 		test('commonmark ' + entry.example, () => {
 			expect(plaintextThroughEditor(entry.markdown)).toBe(entry.markdown)
 		})


### PR DESCRIPTION
### 📝 Summary

* Resolves: N/A

This PR fixes an issue where the plain text editor stripped leading newlines and trailing whitespace on empty first lines of plain text documents.

When setting or updating the content of the plain text editor, the raw content is escaped and wrapped inside HTML `<pre>...</pre>` tags. By standard HTML rules, `DOMParser` strips a single leading newline character inside `<pre>` tags. Prepending a newline (`\n`) to `<pre>` content ensures that `DOMParser` strips only our prepended newline, leaving the document's original leading newlines and whitespace intact.

This change also re-enables the previously skipped CommonMark plain text tests `97` and `117`, which now pass successfully.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
N/A (No visual changes) | N/A (No visual changes)


### 🚧 TODO

- None

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI tools
- [ ] The AI-generated content was reviewed, comprehended and tested by a human