### PR TITLE
fix(table): replace alert() with showWarning() for nested table paste

### DIFF
--- a/src/nodes/Table/TableCell.js
+++ b/src/nodes/Table/TableCell.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { showWarning } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import { mergeAttributes } from '@tiptap/core'
 import { TableCell } from '@tiptap/extension-table'
@@ -113,7 +114,7 @@ export default TableCell.extend({
 						}
 
 						console.warn('Nested tables are not supported')
-						alert(
+						showWarning(
 							t(
 								'text',
 								'A table was pasted into a table. Nested tables are not supported.',


### PR DESCRIPTION
### 📝 *Summary*

* Resolves: 

Replaces the blocking `window.alert()` dialog with a non-blocking `showWarning()` toast notification when a user pastes a table into a table cell (nested tables are not supported in this editor).

**Before:** A browser-native `alert()` dialog would pop up, blocking all UI interaction until dismissed. It was unstyled and confusing.
**After:** A styled Nextcloud toast notification using `showWarning()` from `@nextcloud/dialogs`, consistent with other warnings throughout the app (e.g., permission changes in `Editor.vue`).


### 🖼️ *Screenshots*

| 🏚️ *Before* | 🏡 *After* |
| :--- | :--- |
| N/A | N/A |

> Not applicable.


### 🚧 *TODO*

- [ ] ...

### 🏁 *Checklist*

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests — *all 14 table unit tests pass*
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

---

### 🤖 *AI (if applicable)*

- [ ] The content of this PR was partly or fully generated using AI tools
- [ ] The AI-generated content was reviewed, comprehended and tested by a human