### PR TITLE
[stable31] fix(ReadonlyBar): add missing useIsRichWorkspaceMixin

### DIFF
--- a/src/components/Menu/ReadonlyBar.vue
+++ b/src/components/Menu/ReadonlyBar.vue
@@ -34,7 +34,7 @@
 import { defineComponent } from 'vue'
 import { ReadOnlyEditEntries, OutlineEntries } from './entries.js'
 
-import { useIsMobileMixin } from '../Editor.provider.js'
+import { useIsMobileMixin, useIsRichWorkspaceMixin } from '../Editor.provider.js'
 import ActionList from './ActionList.vue'
 import ActionSingle from './ActionSingle.vue'
 import ToolBarLogic from './ToolBarLogic.js'
@@ -49,7 +49,7 @@ export default defineComponent({
 
 	extends: ToolBarLogic,
 
-	mixins: [useIsMobileMixin],
+	mixins: [useIsMobileMixin, useIsRichWorkspaceMixin],
 
 	props: {
 		isHidden: {


### PR DESCRIPTION
### 📝 Summary

The browser console was showing the following error due to a missing `useRichWorkspaceMixin`:
<img width="1212" height="292" alt="Screenshot from 2026-07-02 09-13-17" src="https://github.com/user-attachments/assets/3f57342f-839c-4167-8f18-dad3906677b1" />

So in `ReadonlyBar.vue` `$isRichWorkspace` was being referenced but the according mixin not added.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required
