### PR TITLE
fix(image): auto-scale embedded images to fit their container

### DIFF
--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -516,7 +516,11 @@ export default {
 }
 
 .image__main {
+	max-width: 100%;
 	max-height: calc(100vh - 50px - 50px);
+	width: auto;
+	height: auto;
+	object-fit: contain;
 	margin: auto;
 }
 
@@ -536,6 +540,7 @@ export default {
 
 	img {
 		max-width: 100%;
+		height: auto;
 	}
 
 	&:hover {


### PR DESCRIPTION
Embedded images were not reliably scaled to fit the available width, and tall images could overflow the surrounding frame instead of being shrunk to be fully visible.

Constrain the rendered image with max-width: 100% and object-fit: contain while letting width and height stay auto, so the whole image is always visible and the frame adjusts to the image's real aspect ratio without reserving fixed empty space.

### 📝 Summary

* Resolves:  The PR resolves issue [Auto-scale embedded images and adjust frame #8774
](https://github.com/nextcloud/text/issues/8774)

Specifically, it addresses the first two of the three points in that issue:

1. Auto-scale embedded images so the whole image is visible images now get max-width: 100% + object-fit: contain with auto width/height.
3. Auto-adjust the frame around the image — height: auto lets the frame collapse to the image's real aspect ratio instead of reserving fixed empty space.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI tools
- [ ] The AI-generated content was reviewed, comprehended and tested by a human
