### PR TITLE
fix(BulletList): remove `preserveWhitespace: true` parseHTML override

### DIFF
--- a/src/nodes/BulletList.ts
+++ b/src/nodes/BulletList.ts
@@ -12,10 +12,6 @@ import { listInputRule, toggleListCommand } from '../commands/index.ts'
  * Only there we know the user is not trying to create a task list.
  */
 const BulletList = TiptapBulletList.extend({
-	parseHTML() {
-		return this.parent?.()?.map((rule) => Object.assign(rule, { preserveWhitespace: true }))
-	},
-
 	addAttributes() {
 		return {
 			...this.parent?.(),

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -44,6 +44,21 @@ describe('Markdown though editor', () => {
 		expect(markdownThroughEditor('- foo\n- bar')).toBe('- foo\n- bar')
 		expect(markdownThroughEditor('- foo\n\n- bar')).toBe('- foo\n- bar')
 		expect(markdownThroughEditor('- foo\n\n\n- bar')).toBe('- foo\n- bar')
+		expect(markdownThroughEditor('- foo\n  - bar')).toBe('- foo\n  - bar')
+		expect(markdownThroughEditor('- foo\n  - bar\n- baz')).toBe('- foo\n  - bar\n- baz')
+		expect(markdownThroughEditor('- foo  \n  bar  \n  baz')).toBe('- foo  \n  bar  \n  baz')
+	})
+	test('ul - no suprious linebreak in nested lists (#8775)', ({ editor }) => {
+		const source = '- foo\n   - bar\n- baz'
+		editor.commands.setContent(markdownit.render(source))
+		// Walk the doc: no hardBreak node should exist in outer list item's paragraph
+		let hasHardBreak = false
+		editor.state.doc.descendants((node) => {
+			if (node.type.name === 'hardBreak') {
+				hasHardBreak = true
+			}
+		})
+		expect(hasHardBreak).toBe(false)
 	})
 	test('ol', ({ markdownThroughEditor }) => {
 		expect(markdownThroughEditor('1. foo\n2. bar')).toBe('1. foo\n2. bar')


### PR DESCRIPTION
This fixes a regression with prosemirror-model 1.25.4 which changed DOM parsing so that newlines in whitespace-preserved text nodes are converted into a hard break instead of being collapsed to spaces.

The `preserveWhitespace: true` setting never really had an effect: The newline in `* first\n  second` already was converted to a space in a full Markdown - editor - Markdown round-trip before the regression.

Also add several regression tests.

Fixes: #8775

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
