### PR TITLE
fix(links): scroll to anchor links directly

### DIFF
--- a/src/plugins/links.ts
+++ b/src/plugins/links.ts
@@ -188,8 +188,14 @@ export function linkClicking(openLink: (href: string) => void = (href) => {
 						event.preventDefault()
 
 						if (isLinkToSelfWithHash(linkEl.href)) {
-							// Open anchor links directly
-							location.href = linkEl.href
+							// Directly scroll to anchor links
+							const url = new URL(linkEl.href, window.location.href)
+							const hash = url.hash
+							if (hash) {
+								const target = view.dom.querySelector(hash)
+								target?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+							}
+							window.history.replaceState({}, '', url.href)
 						} else if (event.ctrlKey || event.metaKey) {
 							// Open link directly on Ctrl/Cmd + left click
 							openLink(linkEl.href)


### PR DESCRIPTION
Setting location.href doesn't work reliably as the window may hold several editors with conflicting IDs (e.g. reader and editor in Collectives). Instead, scroll to the heading in `view.dom`.

Fixes: #8804

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
