### PR TITLE
chore(playwright): use `list` reporter when run locally

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
 	// line (so we have a quick overview in the logs while the tests are running)
 	// github (to have annotations in the PR)
 	// locally we just want the html report with the traces
-	reporter: process.env.CI ? [['blob'], ['line'], ['github']] : 'html',
+	reporter: process.env.CI ? [['blob'], ['line'], ['github']] : 'list',
 	use: {
 		// Base URL to use in actions like `await page.goto('./')`.
 		baseURL: process.env.baseURL ?? 'http://localhost:8089/index.php/',


### PR DESCRIPTION
Spawning the browser to show HTML report after failed tests turned out to be rather annoying to me.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
