### PR TITLE
fix(FloatingButtons): in headings, leave space for the anchor icon

### DIFF
--- a/src/components/Editor/FloatingButtons.vue
+++ b/src/components/Editor/FloatingButtons.vue
@@ -64,7 +64,7 @@ export default {
 
 	computed: {
 		isHeadingNode() {
-			return this.node?.type === this.editor.schema.nodes.heading
+			return this.node?.type.name === 'heading'
 		},
 	},
 
@@ -101,7 +101,7 @@ export default {
 	display: flex;
 
 	&.heading {
-		margin-right: 16px;
+		left: calc(-34px - 14px) !important;
 	}
 }
 


### PR DESCRIPTION
This is a pure regression fix to be backportable. It's still ugly as floating buttons and anchor icon still overlap, but we don't have more space available on narrow screens in Collectives.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="558" height="142" alt="image" src="https://github.com/user-attachments/assets/45c7eebf-2479-4f00-8ff8-3898dc6c8f77" /> | <img width="553" height="143" alt="image" src="https://github.com/user-attachments/assets/a8e0ffba-0ec0-4786-8d2a-c222c2e54008" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
