### PR TITLE
[stable32] fix(links): scroll to anchor links directly

### DIFF
--- a/src/plugins/links.js
+++ b/src/plugins/links.js
@@ -177,8 +177,17 @@ export function linkClicking() {
 						event.preventDefault()
 
 						if (isLinkToSelfWithHash(linkEl.attributes.href?.value)) {
-							// Open anchor links directly
-							location.href = linkEl.attributes.href.value
+							// Directly scroll to anchor links
+							const url = new URL(linkEl.href, window.location.href)
+							const hash = url.hash
+							if (hash) {
+								const target = view.dom.querySelector(hash)
+								target?.scrollIntoView({
+									block: 'start',
+									behavior: 'smooth',
+								})
+							}
+							window.history.replaceState({}, '', url.href)
 						} else if (event.ctrlKey || event.metaKey) {
 							// Open link in new tab on Ctrl/Cmd + left click
 							window.open(linkEl.href, '_blank')


### PR DESCRIPTION
Setting location.href doesn't work reliably as the window may hold several editors with conflicting IDs (e.g. reader and editor in Collectives). Instead, scroll to the heading in `view.dom`.

Fixes: #8804

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
