### PR TITLE
Two small footnotes follow-up fixes

### DIFF
--- a/playwright/e2e/footnotes.spec.ts
+++ b/playwright/e2e/footnotes.spec.ts
@@ -33,9 +33,9 @@ test('inserts footnote via keyboard shortcut', async ({ editor, open }) => {
 	await expect(editor.getFootnote('1')).toContainText('footnote')
 })
 
-test('inserts footnote via [^label] input rule', async ({ editor, open }) => {
+test('inserts footnote via [^] input rule', async ({ editor, open }) => {
 	await open()
-	await editor.type('hello[^bar]')
-	await expect(editor.getFootnoteReference('bar')).toBeVisible()
-	await expect(editor.getFootnote('bar')).toBeVisible()
+	await editor.type('hello[^]')
+	await expect(editor.getFootnoteReference('1')).toBeVisible()
+	await expect(editor.getFootnote('1')).toBeVisible()
 })

--- a/src/components/HelpModal.vue
+++ b/src/components/HelpModal.vue
@@ -226,7 +226,7 @@
 				<tr>
 					<td>{{ t('text', 'Footnote') }}</td>
 					<td>
-						<code>[^{{ t('text', 'label') }}]</code>
+						<code>[^]</code>
 					</td>
 					<td v-if="!isMobileCached">
 						<kbd>{{ ctrlOrModKey }}</kbd>

--- a/src/nodes/FootnoteReference.ts
+++ b/src/nodes/FootnoteReference.ts
@@ -146,17 +146,15 @@ const FootnoteReference = Node.create({
 	addInputRules() {
 		return [
 			new InputRule({
-				find: /\[\^([^\]\s]+)\]$/,
-				handler: ({ state, range, match, chain }) => {
-					const referenceId = match[1] ?? ''
-
+				find: /\[\^\]$/,
+				handler: ({ state, range, chain }) => {
 					if (isInsideFootnote(state)) {
 						return null
 					}
 
 					chain()
 						.deleteRange({ from: range.from, to: range.to })
-						.insertFootnote({ referenceId })
+						.insertFootnote()
 						.run()
 				},
 			}),

--- a/src/nodes/Footnotes.ts
+++ b/src/nodes/Footnotes.ts
@@ -83,6 +83,17 @@ const Footnotes = Node.create({
 						return null
 					}
 
+					let hasFootnotes = false
+					for (let i = 0; i < newState.doc.childCount; i++) {
+						if (newState.doc.child(i).type.name === 'footnotes') {
+							hasFootnotes = true
+							break
+						}
+					}
+					if (!hasFootnotes) {
+						return null
+					}
+
 					const referencedLabels = new Set<string>()
 					newState.doc.descendants((node) => {
 						if (node.type.name === 'footnoteReference') {


### PR DESCRIPTION
### 📝 Summary

* fix(footnotes): return early in footnotesCleanup plugin without footnotes
* fix(footnotes): change input rule to `[^]`

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
