### PR TITLE
fix(filepicker): hide menu

### DIFF
--- a/src/helpers/filePicker.js
+++ b/src/helpers/filePicker.js
@@ -17,6 +17,7 @@ export function buildFilePicker(startPath, allowDirectories = true) {
 		.startAt(startPath)
 		.allowDirectories(allowDirectories)
 		.setMultiSelect(false)
+		.setNoMenu(true)
 		.setButtonFactory((nodes) => {
 			const node = nodes?.[0]
 			const nodeName = node?.attributes?.displayName || node?.basename


### PR DESCRIPTION
We use the file picker in two scenarios:
* Linking to a file.
* Adding a file as an attachment.

In both cases creating new folders does not make sense.
