### PR TITLE
Fix: Pasting from excel inserts an image instead of a formatted table

### DIFF
--- a/src/nodes/Image.ts
+++ b/src/nodes/Image.ts
@@ -89,22 +89,34 @@ const Image = TiptapImage.extend<ImageOptions>({
 						}
 					},
 					handlePaste: (view, event) => {
+						const data = event.clipboardData
+						if (!data) {
+							return false
+						}
+
+						// Check if the pasted content contains a table, either in HTML or TSV-like format. If so, let the regular paste pipeline handle it.
+						const html = data.getData('text/html') || ''
+						const text = data.getData('text/plain') || ''
+
+						const hasHtmlTable = /<table[\s>]/i.test(html)
+						const hasTsvLikeTable = text.includes('\t') && text.includes('\n')
+
+						if (hasHtmlTable || hasTsvLikeTable) {
+							// Let regular paste pipeline parse table content
+							return false
+						}
+
 						// only catch the paste if it contains files
-						if (
-							event.target
-							&& event.clipboardData?.files
-							&& event.clipboardData.files.length > 0
-						) {
-							// let the editor wrapper catch this custom event
+						if (event.target && data.files && data.files.length > 0) {
 							const customEvent = new CustomEvent('image-paste', {
 								bubbles: true,
-								detail: {
-									files: event.clipboardData.files,
-								},
+								detail: { files: data.files },
 							})
 							event.target.dispatchEvent(customEvent)
 							return true
 						}
+
+						return false
 					},
 				},
 			}),


### PR DESCRIPTION
### 📝 Summary

* Resolves: #8472

Added a check if the pasted content contains a table, either in HTML or TSV-like format. If so, let the regular paste pipeline handle it.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [x] ...

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
