### PR TITLE
feat: add per-user raw Markdown editing (#3570)

### DIFF
--- a/cypress/e2e/RawEditing.spec.js
+++ b/cypress/e2e/RawEditing.spec.js
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { randUser } from '../utils/index.js'
+
+const user = randUser()
+
+describe('Raw Markdown editing', function() {
+	before(function() {
+		cy.createUser(user)
+	})
+
+	beforeEach(function() {
+		cy.login(user)
+		cy.uploadTestFile()
+		cy.visit('/apps/files')
+		cy.openTestFile()
+		// Seed some rich content to round-trip.
+		cy.getContent().type('# Hello{enter}World')
+		cy.getContent().find('h1').should('contain.text', 'Hello')
+	})
+
+	const openRawEditor = function() {
+		cy.getActionEntry('remain').click()
+		cy.contains('Edit Markdown source').click()
+		return cy.get('[data-text-el="raw-markdown-editor"]').should('exist')
+	}
+
+	const rawContent = function() {
+		return cy.get('[data-text-el="raw-markdown-editor"] .ProseMirror')
+	}
+
+	it('shows the Markdown source when toggled on', function() {
+		openRawEditor()
+		rawContent().should('contain.text', '# Hello')
+		// The rich formatting toolbar is hidden while editing raw.
+		cy.get('div[data-text-el="menubar"] .text-menubar__entries').should('not.exist')
+	})
+
+	it('applies raw edits back into the rich editor', function() {
+		openRawEditor()
+		rawContent().type('{selectall}{del}## Changed heading{enter}{enter}body text')
+		cy.get('[data-cy="exitRawEditing"]').click()
+		cy.get('[data-text-el="raw-markdown-editor"]').should('not.exist')
+		cy.getContent().find('h2').should('contain.text', 'Changed heading')
+		cy.getContent().should('contain.text', 'body text')
+		cy.getContent().find('h1').should('not.exist')
+	})
+
+	it('discards raw edits when requested', function() {
+		openRawEditor()
+		rawContent().type('{selectall}{del}throwaway content')
+		cy.get('[data-cy="discardRawEditing"]').click()
+		cy.get('[data-text-el="raw-markdown-editor"]').should('not.exist')
+		cy.getContent().find('h1').should('contain.text', 'Hello')
+		cy.getContent().should('not.contain.text', 'throwaway content')
+	})
+
+	describe('concurrent changes', function() {
+		// Mimic a remote collaborator editing the live document while we are
+		// detached in raw mode by mutating the still-connected rich editor
+		// directly — the same effect a remote yjs update would have.
+		const simulateConcurrentEdit = function(text) {
+			return cy.window().then((win) => {
+				const component = [...win.OCA.Text.editorComponents].find((c) => c.rawEditing)
+				expect(component, 'component in raw editing mode').to.exist
+				component.editor.commands.insertContentAt(1, text)
+			})
+		}
+
+		const forkAndDiverge = function() {
+			openRawEditor()
+			simulateConcurrentEdit('CONCURRENT ')
+			rawContent().type('{selectall}{del}mine rewrite')
+			cy.get('[data-cy="exitRawEditing"]').click()
+			// Drift detected: the collision resolver is shown instead of
+			// silently overwriting the concurrent change.
+			cy.get('#resolve-conflicts', { timeout: 10000 }).should('exist')
+		}
+
+		it('keeps the raw edits when choosing the local version', function() {
+			forkAndDiverge()
+			cy.get('[data-cy="useReaderVersion"]').click()
+			cy.get('#resolve-conflicts').should('not.exist')
+			cy.getContent().should('contain.text', 'mine rewrite')
+			cy.getContent().should('not.contain.text', 'CONCURRENT')
+		})
+
+		it('keeps the concurrent version when discarding the raw edits', function() {
+			forkAndDiverge()
+			cy.get('[data-cy="useEditorVersion"]').click()
+			cy.get('#resolve-conflicts').should('not.exist')
+			cy.getContent().should('contain.text', 'CONCURRENT')
+			cy.getContent().should('not.contain.text', 'mine rewrite')
+		})
+	})
+})

--- a/src/components/CollaborativeEditor.vue
+++ b/src/components/CollaborativeEditor.vue
@@ -15,7 +15,7 @@
 		<CollisionResolveDialog
 			v-if="isResolvingConflict"
 			:otherVersion="otherVersion"
-			:readerSource="indexedDbConflictContent ? 'local' : 'server'"
+			:readerSource="conflictReaderSource"
 			@resolved="resolved()" />
 		<EditorWrapper
 			v-if="displayed"
@@ -54,12 +54,16 @@
 					</MenuBar>
 					<div v-else class="menubar-placeholder" />
 				</template>
+				<RawMarkdownEditor
+					v-if="rawEditing"
+					:initialMarkdown="rawInitialMarkdown"
+					@change="rawMarkdown = $event" />
 				<ContentContainer
-					v-show="contentLoaded"
+					v-show="contentLoaded && !rawEditing"
 					ref="contentWrapper"
 					:readOnly="!editMode" />
 				<SuggestionsBar
-					v-if="isRichEditor && contentLoaded && !isRichWorkspace" />
+					v-if="isRichEditor && contentLoaded && !isRichWorkspace && !rawEditing" />
 			</MainContainer>
 			<Component
 				:is="isRichEditor ? 'RichTextReader' : 'PlainTextReader'"
@@ -85,7 +89,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { generateRemoteUrl } from '@nextcloud/router'
 import { Collaboration } from '@tiptap/extension-collaboration'
 import { useElementSize } from '@vueuse/core'
-import { defineAsyncComponent, defineComponent, inject, provide, ref, shallowRef, watch } from 'vue'
+import { computed, defineAsyncComponent, defineComponent, inject, provide, ref, shallowRef, watch } from 'vue'
 import { Awareness } from 'y-protocols/awareness.js'
 import { Doc, logUpdate } from 'yjs'
 import CollisionResolveDialog from './CollisionResolveDialog.vue'
@@ -93,6 +97,7 @@ import ContentContainer from './Editor/ContentContainer.vue'
 import DocumentStatus from './Editor/DocumentStatus.vue'
 import EditorWrapper from './Editor/EditorWrapper.vue'
 import MainContainer from './Editor/MainContainer.vue'
+import RawMarkdownEditor from './Editor/RawMarkdownEditor.vue'
 import SessionStatus from './Editor/SessionStatus.vue'
 import MenuBar from './Menu/MenuBar.vue'
 import ReadonlyBar from './Menu/ReadonlyBar.vue'
@@ -108,6 +113,7 @@ import { provideEditorWidth } from '../composables/useEditorWidth.ts'
 import { provideFileProps } from '../composables/useFileProps.ts'
 import { useIndexedDbProvider } from '../composables/useIndexedDbProvider.ts'
 import { useOpenLinkHandler } from '../composables/useOpenLinkHandler.ts'
+import { provideRawEditing } from '../composables/useRawEditing.ts'
 import { provideSaveService } from '../composables/useSaveService.ts'
 import { provideSyncService } from '../composables/useSyncService.ts'
 import { useSyntaxHighlighting } from '../composables/useSyntaxHighlighting.ts'
@@ -145,6 +151,7 @@ export default defineComponent({
 		MainContainer,
 		ReadonlyBar,
 		ContentContainer,
+		RawMarkdownEditor,
 		MenuBar,
 		RichTextReader: defineAsyncComponent(() => import('./RichTextReader.vue')),
 		PlainTextReader: defineAsyncComponent(() => import('./PlainTextReader.vue')),
@@ -312,7 +319,7 @@ export default defineComponent({
 
 		provideEditorHeadings(editor)
 
-		const { setEditable, updateUser } = useEditorMethods(editor)
+		const { setContent, setEditable, updateUser } = useEditorMethods(editor)
 
 		const serialize = isRichEditor
 			? () => createMarkdownSerializer(editor.schema).serialize(editor.state.doc)
@@ -324,6 +331,24 @@ export default defineComponent({
 			serialize,
 			ydoc,
 		)
+
+		// Per-user raw Markdown editing. Only meaningful when the rich editor is
+		// in use — when `rich_editing_enabled` is off the whole instance is
+		// already raw (isRichEditor === false), so the toggle stays hidden.
+		const canRawEdit = computed(() => isRichEditor && !isRichWorkspace && !isPublic)
+		const {
+			rawEditing,
+			rawInitialMarkdown,
+			rawMarkdown,
+			rawConflict,
+			resolveRawConflict,
+		} = provideRawEditing({
+			serialize,
+			setContent,
+			setEditable,
+			save: () => saveService.save(),
+			canRawEdit,
+		})
 
 		const syncProvider = shallowRef(null)
 
@@ -354,6 +379,11 @@ export default defineComponent({
 			language,
 			lowlightLoaded,
 			displayConnectionIssue,
+			rawEditing,
+			rawInitialMarkdown,
+			rawMarkdown,
+			rawConflict,
+			resolveRawConflict,
 			saveService,
 			serialize,
 			setDirty,
@@ -395,14 +425,32 @@ export default defineComponent({
 
 		hasSyncCollision() {
 			return (
-				Boolean(this.indexedDbConflictContent)
+				Boolean(this.rawConflict)
+				|| Boolean(this.indexedDbConflictContent)
 				|| (this.syncError
 					&& this.syncError.type === ERROR_TYPE.SAVE_COLLISION)
 			)
 		},
 
 		otherVersion() {
-			return this.indexedDbConflictContent || this.syncError.data.outsideChange
+			// For a raw-editing conflict the editor still holds the live
+			// (remote) document, and `rawConflict` holds the user's raw edits —
+			// so it maps to the "local" reader source in CollisionResolveDialog.
+			return (
+				this.rawConflict
+				|| this.indexedDbConflictContent
+				|| this.syncError.data.outsideChange
+			)
+		},
+
+		conflictReaderSource() {
+			return this.rawConflict || this.indexedDbConflictContent
+				? 'local'
+				: 'server'
+		},
+
+		rawUnsaved() {
+			return this.rawEditing && this.rawMarkdown !== this.rawInitialMarkdown
 		},
 
 		hasDocumentParameters() {
@@ -465,6 +513,14 @@ export default defineComponent({
 				window.addEventListener('beforeunload', this.saveBeforeUnload)
 			} else {
 				window.removeEventListener('beforeunload', this.saveBeforeUnload)
+			}
+		},
+
+		rawUnsaved(val) {
+			if (val) {
+				window.addEventListener('beforeunload', this.warnBeforeUnload)
+			} else {
+				window.removeEventListener('beforeunload', this.warnBeforeUnload)
 			}
 		},
 
@@ -547,6 +603,7 @@ export default defineComponent({
 			window.removeEventListener('afterprint', this.preparePrinting)
 		}
 		unsubscribe('text:keyboard:save', this.onKeyboardSave)
+		window.removeEventListener('beforeunload', this.warnBeforeUnload)
 		const timeout = new Promise((resolve) => setTimeout(resolve, 2000))
 		await Promise.any([timeout, this.saveWhenDirty()])
 		await this.close()
@@ -763,7 +820,11 @@ export default defineComponent({
 					// ignore initial loading and other automated changes before first user change
 					if (this.editor.can().undo() || this.editor.can().redo()) {
 						this.setDirty(state.dirty)
-						this.saveService.autosave()
+						// While raw editing, the rich editor is detached and only
+						// absorbs remote changes — never autosave/push from it.
+						if (!this.rawEditing) {
+							this.saveService.autosave()
+						}
 					}
 				} else {
 					this.setDirty(state.dirty)
@@ -923,6 +984,13 @@ export default defineComponent({
 			this.saveService.saveViaSendBeacon()
 		},
 
+		warnBeforeUnload(event) {
+			// Raw edits live in a detached buffer that cannot be flushed safely
+			// on unload, so prompt the user instead of losing them silently.
+			event.preventDefault()
+			event.returnValue = ''
+		},
+
 		checkIndexedDbConflict() {
 			// Only check if we're not already showing a conflict (e.g. when server API reported one)
 			if (this.hasSyncCollision) {
@@ -947,6 +1015,7 @@ export default defineComponent({
 		resolved() {
 			localStorage.removeItem(this.indexedDbConflictKey)
 			this.indexedDbConflictContent = ''
+			this.resolveRawConflict()
 		},
 	},
 })

--- a/src/components/Editor/RawMarkdownEditor.vue
+++ b/src/components/Editor/RawMarkdownEditor.vue
@@ -1,0 +1,144 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="raw-markdown-editor" data-text-el="raw-markdown-editor">
+		<div class="raw-markdown-editor__bar">
+			<span class="raw-markdown-editor__label">
+				<CodeTags :size="20" />
+				{{ t('text', 'Editing Markdown source') }}
+			</span>
+			<div class="raw-markdown-editor__actions">
+				<NcButton
+					v-if="changed"
+					variant="tertiary"
+					data-cy="discardRawEditing"
+					@click="exitRawEditing({ discard: true })">
+					{{ t('text', 'Discard changes') }}
+				</NcButton>
+				<NcButton
+					variant="primary"
+					data-cy="exitRawEditing"
+					@click="exitRawEditing()">
+					{{ t('text', 'Rich text') }}
+				</NcButton>
+			</div>
+		</div>
+		<div class="editor__content-wrapper">
+			<EditorContent
+				class="editor__content text-editor__content"
+				:editor="editor" />
+		</div>
+	</div>
+</template>
+
+<script>
+import { t } from '@nextcloud/l10n'
+import { EditorContent } from '@tiptap/vue-3'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import { useEditorMethods } from '../../composables/useEditorMethods.ts'
+import { useRawEditing } from '../../composables/useRawEditing.ts'
+import { createPlainEditor, serializePlainText } from '../../EditorFactory.ts'
+import { CodeTags } from '../icons.js'
+
+export default {
+	name: 'RawMarkdownEditor',
+
+	components: {
+		CodeTags,
+		EditorContent,
+		NcButton,
+	},
+
+	props: {
+		/**
+		 * Markdown source to seed the raw editor with.
+		 */
+		initialMarkdown: {
+			type: String,
+			required: true,
+		},
+	},
+
+	emits: ['change'],
+
+	setup() {
+		const { exitRawEditing } = useRawEditing()
+		// A detached plain editor: no Collaboration extension, so it never
+		// touches the shared document while the user edits raw Markdown.
+		const editor = createPlainEditor()
+		const { setContent } = useEditorMethods(editor)
+		return { editor, exitRawEditing, setContent, t }
+	},
+
+	data() {
+		return {
+			changed: false,
+		}
+	},
+
+	mounted() {
+		this.setContent(this.initialMarkdown, { addToHistory: false })
+		this.editor.on('update', this.onUpdate)
+		this.editor.commands.focus('start')
+	},
+
+	beforeUnmount() {
+		this.editor?.off('update', this.onUpdate)
+		this.editor?.destroy()
+	},
+
+	methods: {
+		onUpdate() {
+			const markdown = serializePlainText(this.editor.state.doc)
+			this.changed = markdown !== this.initialMarkdown
+			this.$emit('change', markdown)
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.raw-markdown-editor {
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1;
+	width: 100%;
+}
+
+.raw-markdown-editor__bar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--default-grid-baseline);
+	padding: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
+	border-bottom: 1px solid var(--color-border);
+}
+
+.raw-markdown-editor__label {
+	display: flex;
+	align-items: center;
+	gap: var(--default-grid-baseline);
+	color: var(--color-text-maxcontrast);
+}
+
+.raw-markdown-editor__actions {
+	display: flex;
+	align-items: center;
+	gap: var(--default-grid-baseline);
+}
+
+.editor__content-wrapper {
+	display: flex;
+	flex-grow: 1;
+}
+
+.editor__content {
+	flex-grow: 1;
+	max-width: var(--text-editor-max-width);
+	margin: 0 auto;
+	position: relative;
+}
+</style>

--- a/src/components/Menu/MenuBar.vue
+++ b/src/components/Menu/MenuBar.vue
@@ -19,7 +19,7 @@
 		<HelpModal v-if="displayHelp" @close="hideHelp" />
 
 		<div
-			v-if="isRichEditor"
+			v-if="isRichEditor && !rawEditing"
 			ref="menubar"
 			role="toolbar"
 			class="text-menubar__entries"
@@ -53,6 +53,7 @@
 				forceEnabled
 				@click="activeMenuEntry = 'remain'">
 				<template #lastAction="{ visible }">
+					<RawEditingToggle />
 					<WidthToggle />
 					<ActionFormattingHelp @click="showHelp" />
 					<NcActionSeparator />
@@ -77,10 +78,12 @@ import ActionFormattingHelp from './ActionFormattingHelp.vue'
 import ActionList from './ActionList.vue'
 import ActionSingle from './ActionSingle.vue'
 import CharacterCount from './CharacterCount.vue'
+import RawEditingToggle from './RawEditingToggle.vue'
 import WidthToggle from './WidthToggle.vue'
 import { useEditor } from '../../composables/useEditor.ts'
 import { useEditorFlags } from '../../composables/useEditorFlags.ts'
 import { useMenuEntries } from '../../composables/useMenuEntries.ts'
+import { useRawEditing } from '../../composables/useRawEditing.ts'
 import { useIsMobileMixin } from '../Editor.provider.ts'
 import { DotsHorizontal } from '../icons.js'
 import { MENU_ID } from './MenuBar.provider.js'
@@ -95,6 +98,7 @@ export default {
 		HelpModal,
 		NcActionSeparator,
 		CharacterCount,
+		RawEditingToggle,
 		WidthToggle,
 	},
 
@@ -129,6 +133,7 @@ export default {
 	setup() {
 		const editor = useEditor()
 		const { isPublic, isRichEditor, isRichWorkspace } = useEditorFlags()
+		const { rawEditing } = useRawEditing()
 		const { assistantMenuEntries, menuEntries, readOnlyDoneEntries }
 			= useMenuEntries()
 		const menubar = ref()
@@ -139,6 +144,7 @@ export default {
 			isPublic,
 			isRichEditor,
 			isRichWorkspace,
+			rawEditing,
 			menubar,
 			menuEntries,
 			readOnlyDoneEntries,

--- a/src/components/Menu/RawEditingToggle.vue
+++ b/src/components/Menu/RawEditingToggle.vue
@@ -1,0 +1,32 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NextcloudVueNcActionButton
+		v-if="canRawEdit && !rawEditing"
+		:closeAfterClick="true"
+		data-cy="enterRawEditing"
+		@click="enterRawEditing">
+		<template #icon>
+			<CodeTags :size="20" />
+		</template>
+		{{ t('text', 'Edit Markdown source') }}
+	</NextcloudVueNcActionButton>
+</template>
+
+<script setup>
+import { t } from '@nextcloud/l10n'
+import NextcloudVueNcActionButton from '@nextcloud/vue/components/NcActionButton'
+import { useRawEditing } from '../../composables/useRawEditing.ts'
+import { CodeTags } from '../icons.js'
+
+// This component is used as a direct child of NcActions.
+// Even if it actually renders NcActionButton, NcActions cannot see it due to
+// rendering limitations in Vue. Rename it to NcActionButton so NcActions treats
+// it correctly. See NcActions docs and WidthToggle.vue for details.
+defineOptions({ name: 'NcActionButton' })
+
+const { canRawEdit, rawEditing, enterRawEditing } = useRawEditing()
+</script>

--- a/src/composables/useRawEditing.ts
+++ b/src/composables/useRawEditing.ts
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { InjectionKey, Ref } from 'vue'
+
+import { inject, provide, ref } from 'vue'
+import { logger } from '../helpers/logger.ts'
+
+export interface RawEditingApi {
+	/** Whether the current user is editing the raw Markdown source. */
+	rawEditing: Ref<boolean>
+	/** Whether the raw editing toggle is available in this context. */
+	canRawEdit: Ref<boolean>
+	/** Markdown handed to the raw editor when it is opened. */
+	rawInitialMarkdown: Ref<string>
+	/** Current content of the raw editor, kept in sync via its `change` event. */
+	rawMarkdown: Ref<string>
+	/**
+	 * Raw Markdown that could not be applied automatically because the live
+	 * document drifted while it was being edited. Empty unless a conflict is
+	 * pending resolution via CollisionResolveDialog.
+	 */
+	rawConflict: Ref<string>
+	enterRawEditing: () => void
+	exitRawEditing: (options?: { discard?: boolean }) => Promise<void>
+	/** Clear a pending raw conflict (once resolved). */
+	resolveRawConflict: () => void
+	toggle: () => void
+}
+
+interface Dependencies {
+	/** Serialize the live (rich) document to Markdown. */
+	serialize: () => string
+	/** Replace the live document content from a Markdown string. */
+	setContent: (content: string) => void
+	/** Toggle whether the live (rich) editor accepts input. */
+	setEditable: (editable: boolean) => void
+	/** Persist the document. */
+	save: () => Promise<unknown>
+	/** Whether raw editing is allowed at all (markdown, not a workspace, …). */
+	canRawEdit: Ref<boolean>
+}
+
+export const rawEditingKey = Symbol('editor:raw-editing') as InjectionKey<RawEditingApi>
+
+/**
+ * Create the raw Markdown editing state machine and provide it to descendants.
+ *
+ * Raw editing runs the current user on a *detached* plain-text editor while the
+ * collaborative rich editor stays mounted and connected in the background. This
+ * keeps other collaborators unaffected (they never see the plain schema) at the
+ * cost of reconciling the raw buffer against the live document on return.
+ *
+ * @param deps dependencies from the collaborative editor
+ */
+export function provideRawEditing(deps: Dependencies): RawEditingApi {
+	const rawEditing = ref(false)
+	const rawInitialMarkdown = ref('')
+	const rawMarkdown = ref('')
+	const rawConflict = ref('')
+	// Markdown at the moment raw editing started, used to detect whether the
+	// live document drifted (concurrent edits) while it was being edited raw.
+	const forkSnapshot = ref('')
+
+	const enterRawEditing = () => {
+		if (!deps.canRawEdit.value || rawEditing.value) {
+			return
+		}
+		const markdown = deps.serialize()
+		forkSnapshot.value = markdown
+		rawInitialMarkdown.value = markdown
+		rawMarkdown.value = markdown
+		// Freeze the background rich editor so it only absorbs remote changes.
+		deps.setEditable(false)
+		rawEditing.value = true
+		logger.debug('Entered raw Markdown editing')
+	}
+
+	const exitRawEditing = async ({ discard = false } = {}) => {
+		if (!rawEditing.value) {
+			return
+		}
+		const mine = rawMarkdown.value
+		const base = forkSnapshot.value
+		// Re-enable and reveal the live rich editor before reconciling.
+		deps.setEditable(true)
+		rawEditing.value = false
+
+		if (discard || mine === base) {
+			// Nothing to apply: the user either cancelled or never changed the
+			// source. Keep whatever the live document currently holds.
+			logger.debug('Left raw Markdown editing without changes', { discard })
+			return
+		}
+
+		const live = deps.serialize()
+		if (live === base) {
+			// No concurrent edits arrived while editing raw: apply directly.
+			deps.setContent(mine)
+			try {
+				await deps.save()
+			} catch (error) {
+				logger.error('Failed to save raw Markdown changes', { error })
+			}
+			logger.debug('Applied raw Markdown changes')
+		} else {
+			// The live document drifted (other collaborators edited it) while we
+			// were detached. Hand both versions to CollisionResolveDialog and let
+			// the user pick, instead of silently clobbering their work.
+			rawConflict.value = mine
+			logger.debug('Raw Markdown editing conflicts with concurrent changes')
+		}
+	}
+
+	const resolveRawConflict = () => {
+		rawConflict.value = ''
+	}
+
+	const toggle = () => {
+		if (rawEditing.value) {
+			exitRawEditing()
+		} else {
+			enterRawEditing()
+		}
+	}
+
+	const api: RawEditingApi = {
+		rawEditing,
+		canRawEdit: deps.canRawEdit,
+		rawInitialMarkdown,
+		rawMarkdown,
+		rawConflict,
+		enterRawEditing,
+		exitRawEditing,
+		resolveRawConflict,
+		toggle,
+	}
+	provide(rawEditingKey, api)
+	return api
+}
+
+/**
+ *
+ */
+function noopApi(): RawEditingApi {
+	return {
+		rawEditing: ref(false),
+		canRawEdit: ref(false),
+		rawInitialMarkdown: ref(''),
+		rawMarkdown: ref(''),
+		rawConflict: ref(''),
+		enterRawEditing: () => {},
+		exitRawEditing: async () => {},
+		resolveRawConflict: () => {},
+		toggle: () => {},
+	}
+}
+
+/**
+ * Inject the raw editing API.
+ *
+ * Falls back to an inert API when used outside of a collaborative editor (e.g.
+ * the plain editor or standalone readers) so consumers can be rendered anywhere.
+ */
+export function useRawEditing(): RawEditingApi {
+	return inject(rawEditingKey, undefined) ?? noopApi()
+}

--- a/src/tests/composables/useRawEditing.spec.ts
+++ b/src/tests/composables/useRawEditing.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { RawEditingApi } from '../../composables/useRawEditing.ts'
+
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+import { provideRawEditing } from '../../composables/useRawEditing.ts'
+
+/**
+ * Mount a host component that provides the raw editing API and expose it along
+ * with the mocked dependencies so tests can drive the state machine directly.
+ *
+ * @param live markdown returned by `serialize()` when raw editing is left
+ */
+function setup(live: string) {
+	const deps = {
+		serialize: vi.fn(() => live),
+		setContent: vi.fn(),
+		setEditable: vi.fn(),
+		save: vi.fn(async () => {}),
+		canRawEdit: ref(true),
+	}
+	let api: RawEditingApi | undefined
+	const Host = defineComponent({
+		template: '<div />',
+		setup() {
+			api = provideRawEditing(deps)
+			return {}
+		},
+	})
+	mount(Host)
+	return { api: api as RawEditingApi, deps }
+}
+
+describe('useRawEditing', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('freezes the rich editor when entering raw mode', () => {
+		const { api, deps } = setup('# Base')
+		deps.serialize.mockReturnValueOnce('# Base')
+		api.enterRawEditing()
+		expect(api.rawEditing.value).toBe(true)
+		expect(api.rawInitialMarkdown.value).toBe('# Base')
+		expect(deps.setEditable).toHaveBeenCalledWith(false)
+	})
+
+	it('does not enter raw mode when disabled', () => {
+		const { api, deps } = setup('# Base')
+		deps.canRawEdit.value = false
+		api.enterRawEditing()
+		expect(api.rawEditing.value).toBe(false)
+		expect(deps.setEditable).not.toHaveBeenCalled()
+	})
+
+	it('applies raw edits directly when the document did not drift', async () => {
+		const { api, deps } = setup('# Base')
+		deps.serialize.mockReturnValueOnce('# Base') // fork snapshot on enter
+		api.enterRawEditing()
+		api.rawMarkdown.value = '# Edited'
+		deps.serialize.mockReturnValueOnce('# Base') // live doc unchanged on exit
+		await api.exitRawEditing()
+		expect(deps.setContent).toHaveBeenCalledWith('# Edited')
+		expect(deps.save).toHaveBeenCalled()
+		expect(api.rawConflict.value).toBe('')
+		expect(api.rawEditing.value).toBe(false)
+		expect(deps.setEditable).toHaveBeenLastCalledWith(true)
+	})
+
+	it('raises a conflict instead of clobbering concurrent edits', async () => {
+		const { api, deps } = setup('# Base')
+		deps.serialize.mockReturnValueOnce('# Base') // fork snapshot on enter
+		api.enterRawEditing()
+		api.rawMarkdown.value = '# Edited'
+		deps.serialize.mockReturnValueOnce('# Base\n\nremote change') // drifted
+		await api.exitRawEditing()
+		expect(deps.setContent).not.toHaveBeenCalled()
+		expect(deps.save).not.toHaveBeenCalled()
+		expect(api.rawConflict.value).toBe('# Edited')
+		expect(api.rawEditing.value).toBe(false)
+	})
+
+	it('does nothing when the source was not changed', async () => {
+		const { api, deps } = setup('# Base')
+		deps.serialize.mockReturnValueOnce('# Base')
+		api.enterRawEditing()
+		// rawMarkdown left equal to the initial snapshot
+		await api.exitRawEditing()
+		expect(deps.setContent).not.toHaveBeenCalled()
+		expect(deps.save).not.toHaveBeenCalled()
+		expect(api.rawConflict.value).toBe('')
+	})
+
+	it('discards raw edits without applying them', async () => {
+		const { api, deps } = setup('# Base')
+		deps.serialize.mockReturnValueOnce('# Base')
+		api.enterRawEditing()
+		api.rawMarkdown.value = '# Edited'
+		await api.exitRawEditing({ discard: true })
+		expect(deps.setContent).not.toHaveBeenCalled()
+		expect(deps.save).not.toHaveBeenCalled()
+		expect(api.rawConflict.value).toBe('')
+	})
+
+	it('clears a pending conflict once resolved', async () => {
+		const { api, deps } = setup('# Base')
+		deps.serialize.mockReturnValueOnce('# Base')
+		api.enterRawEditing()
+		api.rawMarkdown.value = '# Edited'
+		deps.serialize.mockReturnValueOnce('# Drifted')
+		await api.exitRawEditing()
+		expect(api.rawConflict.value).toBe('# Edited')
+		api.resolveRawConflict()
+		expect(api.rawConflict.value).toBe('')
+	})
+})


### PR DESCRIPTION
### 📝 Summary

* Resolves: #3570

Adds a per-user **"Edit Markdown source"** toggle that lets a user switch the current document into a raw Markdown editor on the fly, without disrupting other collaborators.

**Why the per-user, detached approach.** The rich editor and the plain editor bind to the same shared yjs document but use incompatible ProseMirror schemas (rich node tree vs. a single plain-text document). Two users on different schemas against one shared document would corrupt each other — which is exactly the concern raised in the issue discussion. So raw editing runs on a **detached** plain-text editor (no `Collaboration` extension): the collaborative rich editor stays mounted and connected in the background, so the shared document never sees the plain-text schema and other participants are unaffected.

**Round-trip and conflicts.** On leaving raw mode the edited source is applied back to the live document. If the document drifted in the meantime (concurrent edits from other users), the existing `CollisionResolveDialog` is reused so the user can keep their raw version or the remote one, instead of silently clobbering either. If the user made no changes, or the document did not drift, the edits are applied directly with no prompt.

**Interplay with `rich_editing_enabled`.** The toggle is gated on rich Markdown editing being active, so when an admin has set `rich_editing_enabled=0` (the whole instance already edits raw) the toggle simply does not appear — no "raw within raw", no schema mixing. The mode is ephemeral per-user view state and is not persisted, which deliberately sidesteps the open "user vs. file vs. instance setting" question from the issue.

#### What's included

* `useRawEditing` composable — enter/exit state machine with drift detection
* `RawMarkdownEditor` — detached plain-text editor seeded with the serialized Markdown
* `RawEditingToggle` — overflow-menu entry, gated to rich Markdown editing
* Autosave suppression while detached; unload warning when raw edits are unsaved
* A "Discard changes" affordance to leave raw mode without applying edits

#### 🖼️ Screenshots

**1. Toggle in the ⋯ overflow menu**

<img width="897" height="321" alt="Edit Markdown source entry in the editor overflow menu" src="https://github.com/user-attachments/assets/35171053-bb2e-4374-8fda-40ee030a5ce6" />

**2. Editing the raw Markdown source**

The current user is switched to a detached plain-text editor showing the document's raw Markdown. **Rich text** returns to the WYSIWYG view.

<img width="857" height="352" alt="Detached raw Markdown source editor" src="https://github.com/user-attachments/assets/20a8c275-358c-4872-bfed-38e4a7ad28e8" />

**3. Conflict resolution when the document changed concurrently**

If another collaborator changed the document while it was being edited raw, the existing collision dialog is reused to keep either the local (raw) version or the remote one.

<img width="1911" height="362" alt="Collision dialog offering to keep local raw edits or the remote version" src="https://github.com/user-attachments/assets/adc5e918-6dda-4a0d-bcff-ac1a57c23e7d" />

### 🚧 TODO

- [ ] Confirm desired wording for the menu entry / buttons with maintainers

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` passes; `tsc` clean under TypeScript 6)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

#### Testing notes

* **Unit** (`src/tests/composables/useRawEditing.spec.ts`, 7 cases): enter/gating, direct apply when there is no drift, conflict raised on drift, no-op when unchanged, discard, and conflict clearing.
* **End-to-end** (`cypress/e2e/RawEditing.spec.js`, 5 cases): toggling into the source view, applying raw edits back to the rich editor, discarding, and both branches of the conflict dialog when the document changed concurrently. All passing against a local Nextcloud instance.

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
