### PR TITLE
chore(npm): allow scripts of known NPM dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,5 +149,14 @@
       "email": "jus@bitgrid.net",
       "role": "Developer"
     }
-  ]
+  ],
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "core-js": true,
+    "cypress": true,
+    "esbuild": true,
+    "protobufjs": true,
+    "ssh2": true,
+    "cpu-features": true
+  }
 }


### PR DESCRIPTION
Starting with NPM v12, scripts defined by dependencies need to be allowed explicitely to protect against supply-chain attacks.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
