### PR TITLE
fix(collaboration): ellipsise user caret labels

### DIFF
--- a/src/components/CollaborativeEditor.vue
+++ b/src/components/CollaborativeEditor.vue
@@ -1086,6 +1086,7 @@ export default defineComponent({
 	position: absolute;
 	top: -1.4em;
 	left: -1px;
+	max-width: 80px;
 	font-size: 12px;
 	font-style: normal;
 	font-weight: 600;
@@ -1094,6 +1095,8 @@ export default defineComponent({
 	color: #0d0d0d;
 	padding: 0.1rem 0.3rem;
 	border-radius: 3px 3px 3px 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	white-space: nowrap;
 	opacity: 0;
 


### PR DESCRIPTION
Very long user caret labels can be annoying in editing sessions.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="525" height="106" alt="image" src="https://github.com/user-attachments/assets/4440ddb7-b8fc-4a1a-844d-572487bb1f2d" /> | <img width="480" height="105" alt="image" src="https://github.com/user-attachments/assets/24f303d3-cd6d-40ec-b5da-e5fdf2dd2833" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
