### PR TITLE
fix: update ShowImageModal to use fullUrl for show original image ins…

### DIFF
--- a/src/components/ImageView/ShowImageModal.vue
+++ b/src/components/ImageView/ShowImageModal.vue
@@ -17,7 +17,7 @@
 		@previous="showPreviousImage"
 		@close="$emit('close')">
 		<div class="modal__content">
-			<img :src="currentImage.previewUrl">
+			<img :src="currentImage.fullUrl">
 		</div>
 	</NcModal>
 </template>


### PR DESCRIPTION
### 📝 Summary

Clicking an embedded image opened the modal on `currentImage.previewUrl` — the
1024x1024 preview, upscaled to an 80vh modal and visibly soft. `fullUrl` (the
original, same route + `&preferRawImage=1`) was already on the attachment object
and unused, so this just points the modal's `<img>` at it.

Inline rendering is untouched — documents still load previews, the original is
fetched only on an explicit click. Also matches `handleAttachmentClick()`, which
already uses `fullUrl` / the Viewer; the image modal was the only click-through
still showing a preview.


#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] [Documentation](https://github.com/nextcloud/text/blob/main/README.md) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human