### PR TITLE
[stable34] fix: update ShowImageModal to use fullUrl for show original image instead of preview

### DIFF
--- a/src/components/ImageView/ShowImageModal.vue
+++ b/src/components/ImageView/ShowImageModal.vue
@@ -17,7 +17,7 @@
 		@previous="showPreviousImage"
 		@close="$emit('close')">
 		<div class="modal__content">
-			<img :src="currentImage.previewUrl" />
+			<img :src="currentImage.fullUrl" />
 		</div>
 	</NcModal>
 </template>


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
