### PR TITLE
fix(editor): fix viewer header overlaying page content on mobile

### DIFF
--- a/src/components/CollaborativeEditor.vue
+++ b/src/components/CollaborativeEditor.vue
@@ -9,7 +9,6 @@
 		ref="el"
 		data-text-el="editor-container"
 		class="text-editor"
-		:class="{ 'is-mobile': isMobile }"
 		tabindex="-1">
 		<SkeletonLoading v-if="showLoadingSkeleton" />
 		<CollisionResolveDialog
@@ -940,13 +939,6 @@ export default defineComponent({
 .modal-container .text-editor {
 	top: 0;
 	height: calc(100vh - var(--header-height));
-
-	&.is-mobile {
-		// TODO: Why is this required to prevent small scrolling container on mobile with short content?
-		height: calc(
-			100vh - var(--header-height) - 2 * var(--default-grid-baseline)
-		);
-	}
 }
 
 .text-editor {


### PR DESCRIPTION
The rule resulted in the editor content being covered partially by the viewer header when opening a shared document on real mobile browsers (e.g. Firefox on Android).

I was not able to reproduce the issue with mobile view in Firefox on desktop. Via remote debugging on Android I was able to pin the issue to this rule though.

Fixes: #8709

Reverts 87f2ddf25b074f2c451416bf7874c828732de5dc. The issue that this commit originally aimed to fix (superfluous scrollbar with short content on mobile) is also no longer reproducible on mobile browsers.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
