### PR TITLE
fix: handle Viewer preloading race condition for spinner

### DIFF
--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -97,6 +97,7 @@ export default defineComponent({
 	data() {
 		return {
 			hasToggledInteractiveEmbedding: false,
+			isLoaded: false,
 		}
 	},
 
@@ -117,6 +118,29 @@ export default defineComponent({
 		},
 	},
 
+	watch: {
+		/**
+		 * Watch for active prop changes to handle the preloading race condition.
+		 *
+		 * The Viewer preloads adjacent files (next/prev) for faster navigation.
+		 * When a component finishes loading while in "preloaded" state (not yet active),
+		 * it emits 'update:loaded', but the Viewer isn't listening yet because the
+		 * component isn't active. When the user navigates to that file and it becomes
+		 * active, the Viewer is still showing the spinner waiting for the event.
+		 *
+		 * This watcher re-emits 'update:loaded' when transitioning from inactive to active
+		 * if the content has already loaded.
+		 */
+		active: {
+			handler(newVal, oldVal) {
+				if (newVal === true && oldVal === false && this.isLoaded) {
+					this.onLoaded()
+				}
+			},
+			immediate: false,
+		},
+	},
+
 	mounted() {
 		if (!this.useSourceView) {
 			this.onLoaded()
@@ -125,7 +149,12 @@ export default defineComponent({
 
 	methods: {
 		async onLoaded() {
-			this.onLoadedHandler()
+			this.isLoaded = true
+			// Only emit if already active to handle preloading race condition.
+			// If not active yet, the active watcher will call this when it becomes active.
+			if (this.active) {
+				this.onLoadedHandler()
+			}
 		},
 
 		toggleEdit() {


### PR DESCRIPTION
When using arrow keys to navigate between files in the Nextcloud Viewer, the loading spinner keeps spinning indefinitely even after the file content is already visible. This affects all file types handled by the text app (txt, md, etc.).

 ## Root Cause

The Viewer preloads adjacent files (next/prev) in the background for faster navigation. This creates a race condition:

   1. User is viewing File A
   2. Viewer preloads File B (next file) in the background
   3. File B's \`ViewerComponent\` mounts and calls \`onLoaded()\`, which emits \`update:loaded\`
   4. But File B is not yet \`active\` -- it is still in preloaded state
   5. The Viewer only listens for \`update:loaded\` from the active component
   6. The \`update:loaded\` event from File B is lost
   7. User navigates to File B (presses arrow key)
   8. File B becomes active
   9. Viewer is still showing the spinner, waiting for an \`update:loaded\` event that was already emitted

## Fix

Add an \`active\` prop watcher to \`ViewerComponent.vue\` that re-emits \`update:loaded\` when transitioning from inactive to active, if the content has already loaded.

Changes to \`src/components/ViewerComponent.vue\`:
   - Added \`isLoaded: false\` data property to track whether content has finished loading
   - Added \`active\` watcher that calls \`onLoaded()\` when becoming active (false -> true transition) and content is already loaded
   - Modified \`onLoaded()\` to set \`isLoaded = true\` and only emit when the component is already active

If the component is already active when \`onLoaded()\` is called (the normal non-preloaded case), behavior is unchanged -- it emits immediately.

## Server Details (where bug was reproduced)

   | Component | Version |
   |-----------|---------|
   | Nextcloud | 33.0.6 |
   | PHP | 8.4.23 |
   | Database | PostgreSQL 16.14 |
   | Text app | 7.0.1 |
   | Viewer app | 6.0.0 |

## Steps to Reproduce

   1. Open any text file (e.g. \`.txt\`, \`.md\`) in the Nextcloud Viewer
   2. Use the right arrow key to navigate to the next file
   3. Use the left arrow key to navigate back to the original file
   4. The loading spinner continues spinning indefinitely, even though the file content is visible
