### PR TITLE
fix(editor): set `translate=yes` for read-only editor

### DIFF
--- a/src/extensions/RichText.ts
+++ b/src/extensions/RichText.ts
@@ -54,6 +54,7 @@ import Markdown from './Markdown.js'
 import Mention from './Mention.js'
 import Search from './Search.ts'
 import TextDirection from './TextDirection.ts'
+import TranslateAttribute from './TranslateAttribute.ts'
 import Typography from './Typography.ts'
 
 const lowlight = createLowlight(common)
@@ -169,6 +170,7 @@ export default Extension.create<RichTextOptions>({
 					'taskItem',
 				],
 			}),
+			TranslateAttribute,
 			Typography,
 			MathInline,
 			MathBlock,

--- a/src/extensions/TranslateAttribute.ts
+++ b/src/extensions/TranslateAttribute.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+
+const translateAttributeKey = new PluginKey('translateAttribute')
+
+export default Extension.create({
+	name: 'TranslateAttribute',
+
+	addProseMirrorPlugins() {
+		return [
+			new Plugin({
+				key: translateAttributeKey,
+				props: {
+					attributes: () => ({
+						translate: this.editor.isEditable ? 'no' : 'yes',
+					}),
+				},
+			}),
+		]
+	},
+})


### PR DESCRIPTION
Tells browsers to translate the editor content despite it being a `contenteditable` element.

Fixes: nextcloud/collectives#2666

Assisted-by: OpenCode:claude-fable-5

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
