### PR TITLE
fix(sync): reset #sending flag when no active connection on sendStepsNow

### DIFF
--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -234,6 +234,7 @@ class SyncService {
 		this.#sendIntervalId = undefined
 		const hadUpdate = this.#outbox.hasUpdate
 		if (!this.hasActiveConnection()) {
+			this.#sending = false
 			return
 		}
 		const sendable = this.#outbox.getDataToSend()


### PR DESCRIPTION
Without this fix, a connection loss during step push setup leaves before calling sendStepsNow(), so all subsequent local changes are silently dropped — never sent to the server — even after the connection recovers.

This PR supersedes https://github.com/nextcloud/text/pull/8796, where the author didn't reply any longer and I lack permissions to push changes to the fork branch.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
