### PR TITLE
test(playwright): don't set `webServer.url` parameter

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,7 +54,8 @@ export default defineConfig({
 	],
 
 	webServer: {
-		url: 'http://127.0.0.1:8089',
+		// Don't set `url` as it would take precedence over `wait.stdout` and tests start too early
+		// url: 'http://127.0.0.1:8089',
 		// Starts the Nextcloud docker container
 		command: 'npm run start:nextcloud',
 		// we use sigterm to notify the script to stop the container
@@ -63,7 +64,8 @@ export default defineConfig({
 			signal: 'SIGTERM',
 			timeout: 10000,
 		},
-		reuseExistingServer: !process.env.CI,
+		// `start-nextcloud-server.mjs` only starts the server if not reachable yet.
+		reuseExistingServer: false,
 		stderr: 'pipe',
 		stdout: 'pipe',
 		// max. 5 minutes for creating the container

--- a/playwright/start-nextcloud-server.mjs
+++ b/playwright/start-nextcloud-server.mjs
@@ -17,6 +17,18 @@ import { execSync } from 'node:child_process'
 /**
  *
  */
+async function isServerRunning() {
+	try {
+		const res = await fetch('http://127.0.0.1:8089/status.php')
+		return res.ok
+	} catch {
+		return false
+	}
+}
+
+/**
+ *
+ */
 async function start() {
 	const appinfo = readFileSync('appinfo/info.xml').toString()
 	const maxVersion = appinfo.match(/<nextcloud min-version="\d+" max-version="(\d\d+)" \/>/)?.[1]
@@ -47,9 +59,14 @@ process.on('SIGTERM', stop)
 process.on('SIGINT', stop)
 
 // Start the Nextcloud docker container
-const ip = await start()
-await waitOnNextcloud(ip)
-await configureNextcloud(['text', 'viewer'])
+if (await isServerRunning()) {
+	// eslint-disable-next-line no-console
+	console.log('└─ Nextcloud is now ready to use')
+} else {
+	const ip = await start()
+	await waitOnNextcloud(ip)
+	await configureNextcloud(['text', 'viewer'])
+}
 
 // Idle to wait for shutdown
 while (true) {


### PR DESCRIPTION
We want Playwright to wait for the `webServer.wait.stdout` condition. If `webServer.url` is set, it takes precedence.

Set `reuseExistingServer: false` and let `start-nextcloud-server.mjs` detect if the webserver is already running.

With these changes, Playwright waits for Nextcloud to be ready before running the tests, but at the same time can be started several times in a row with a running Docker container without running into conflicts.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
