### PR TITLE
chore(test): direct editing permissions

### DIFF
--- a/cypress/e2e/directediting.spec.js
+++ b/cypress/e2e/directediting.spec.js
@@ -28,6 +28,12 @@ describe('direct editing', function() {
 		initUserAndFiles(user, 'test.md', 'empty.md', 'empty.txt')
 	})
 
+	beforeEach(function() {
+		// ensure user is enabled if it was disabled before
+		cy.clearCookies()
+		cy.enableUser(user, true)
+	})
+
 	it('Open an existing file, edit it', () => {
 		cy.login(user)
 		cy.createDirectEditingLink('empty.md').then((token) => {
@@ -68,5 +74,27 @@ describe('direct editing', function() {
 			'equal',
 			'# This is a headline\nSome text\n',
 		)
+	})
+
+	it('Cannot open as disabled user', () => {
+		cy.login(user)
+		cy.createDirectEditingLink('empty.md').as('token')
+		cy.clearCookies()
+		cy.enableUser(user, false)
+		cy.get('@token')
+			.then((token) => { cy.request({ url: token, failOnStatusCode: false }) })
+			.its('status')
+			.should('equal', 404)
+	})
+
+	it('Cannot open as deleted user', () => {
+		cy.login(user)
+		cy.createDirectEditingLink('empty.md').as('token')
+		cy.clearCookies()
+		cy.deleteUser(user)
+		cy.get('@token')
+			.then((token) => { cy.request({ url: token, failOnStatusCode: false }) })
+			.its('status')
+			.should('equal', 404)
 	})
 })


### PR DESCRIPTION
### 📝 Summary

Add a cypress test for https://github.com/nextcloud/text/pull/8951 to test that disabled/deleted users can not open directEditing links.

The test was written by @max-nextcloud 


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required