### PR TITLE
fix(embed): guard unavailable search commands

### DIFF
--- a/src/TextEditorEmbed.ts
+++ b/src/TextEditorEmbed.ts
@@ -65,17 +65,23 @@ export class TextEditorEmbed {
 
 	setSearchQuery(query: string, matchAll: boolean) {
 		const editor = this.#editorComponent.editor
-		editor?.commands.setSearchQuery(query, matchAll)
+		if (typeof editor?.commands.setSearchQuery === 'function') {
+			editor.commands.setSearchQuery(query, matchAll)
+		}
 	}
 
 	searchNext() {
 		const editor = this.#editorComponent.editor
-		editor?.commands.nextMatch()
+		if (typeof editor?.commands.nextMatch === 'function') {
+			editor.commands.nextMatch()
+		}
 	}
 
 	searchPrevious() {
 		const editor = this.#editorComponent.editor
-		editor?.commands.previousMatch()
+		if (typeof editor?.commands.previousMatch === 'function') {
+			editor.commands.previousMatch()
+		}
 	}
 
 	async save() {


### PR DESCRIPTION
### 📝 Summary

* Resolves: nextcloud/collectives#2434 <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

When `rich_editing_enabled = 0`, the collaborative editor created through Text’s integration (embed) API uses the plain-text editor. This editor does not include the `Search` extension, so the related commands are unavailable.

Guard the embedded editor API calls to:

- `setSearchQuery`
- `searchNext`
- `searchPrevious`

When these commands are unavailable, the methods now safely behave as no-ops instead of throwing an exception.

This allows integrations such as Collectives to finish loading when rich editing is disabled.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
