### PR TITLE
[stable30] fix(DirectEditing): check if user is enabled

### DIFF
--- a/composer/composer/autoload_classmap.php
+++ b/composer/composer/autoload_classmap.php
@@ -29,6 +29,7 @@ return array(
     'OCA\\Text\\DirectEditing\\TextDirectEditor' => $baseDir . '/../lib/DirectEditing/TextDirectEditor.php',
     'OCA\\Text\\DirectEditing\\TextDocumentCreator' => $baseDir . '/../lib/DirectEditing/TextDocumentCreator.php',
     'OCA\\Text\\Event\\LoadEditor' => $baseDir . '/../lib/Event/LoadEditor.php',
+    'OCA\\Text\\Exception\\AccountDisabledException' => $baseDir . '/../lib/Exception/AccountDisabledException.php',
     'OCA\\Text\\Exception\\DocumentHasUnsavedChangesException' => $baseDir . '/../lib/Exception/DocumentHasUnsavedChangesException.php',
     'OCA\\Text\\Exception\\DocumentSaveConflictException' => $baseDir . '/../lib/Exception/DocumentSaveConflictException.php',
     'OCA\\Text\\Exception\\InvalidDocumentBaseVersionEtagException' => $baseDir . '/../lib/Exception/InvalidDocumentBaseVersionEtagException.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -44,6 +44,7 @@ class ComposerStaticInitText
         'OCA\\Text\\DirectEditing\\TextDirectEditor' => __DIR__ . '/..' . '/../lib/DirectEditing/TextDirectEditor.php',
         'OCA\\Text\\DirectEditing\\TextDocumentCreator' => __DIR__ . '/..' . '/../lib/DirectEditing/TextDocumentCreator.php',
         'OCA\\Text\\Event\\LoadEditor' => __DIR__ . '/..' . '/../lib/Event/LoadEditor.php',
+        'OCA\\Text\\Exception\\AccountDisabledException' => __DIR__ . '/..' . '/../lib/Exception/AccountDisabledException.php',
         'OCA\\Text\\Exception\\DocumentHasUnsavedChangesException' => __DIR__ . '/..' . '/../lib/Exception/DocumentHasUnsavedChangesException.php',
         'OCA\\Text\\Exception\\DocumentSaveConflictException' => __DIR__ . '/..' . '/../lib/Exception/DocumentSaveConflictException.php',
         'OCA\\Text\\Exception\\InvalidDocumentBaseVersionEtagException' => __DIR__ . '/..' . '/../lib/Exception/InvalidDocumentBaseVersionEtagException.php',

--- a/lib/Exception/AccountDisabledException.php
+++ b/lib/Exception/AccountDisabledException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Text\Exception;
+
+class AccountDisabledException extends \Exception {
+
+}

--- a/lib/Middleware/SessionMiddleware.php
+++ b/lib/Middleware/SessionMiddleware.php
@@ -9,6 +9,7 @@ namespace OCA\Text\Middleware;
 
 use OC\User\NoUserException;
 use OCA\Text\Controller\ISessionAwareController;
+use OCA\Text\Exception\AccountDisabledException;
 use OCA\Text\Exception\InvalidDocumentBaseVersionEtagException;
 use OCA\Text\Exception\InvalidSessionException;
 use OCA\Text\Middleware\Attribute\RequireDocumentBaseVersionEtag;
@@ -27,6 +28,7 @@ use OCP\Files\NotPermittedException;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\ISession;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as ShareManager;
@@ -43,6 +45,7 @@ class SessionMiddleware extends Middleware {
 		private IRootFolder $rootFolder,
 		private ShareManager $shareManager,
 		private IL10N $l10n,
+		private IUserManager $userManager,
 	) {
 	}
 
@@ -50,6 +53,7 @@ class SessionMiddleware extends Middleware {
 	 * @throws ReflectionException
 	 * @throws InvalidDocumentBaseVersionEtagException
 	 * @throws InvalidSessionException
+	 * @throws AccountDisabledException
 	 */
 	public function beforeController(Controller $controller, string $methodName): void {
 		if (!$controller instanceof ISessionAwareController) {
@@ -90,6 +94,7 @@ class SessionMiddleware extends Middleware {
 
 	/**
 	 * @throws InvalidSessionException
+	 * @throws AccountDisabledException
 	 */
 	private function assertDocumentSession(ISessionAwareController $controller): void {
 		$documentId = (int)$this->request->getParam('documentId');
@@ -100,6 +105,13 @@ class SessionMiddleware extends Middleware {
 		$session = $this->sessionService->getValidSession($documentId, $sessionId, $token);
 		if (!$session) {
 			throw new InvalidSessionException();
+		}
+
+		if (!$session->isGuest()) {
+			$user = $this->userManager->get($session->getUserId());
+			if ($user === null || !$user->isEnabled()) {
+				throw new AccountDisabledException();
+			}
 		}
 
 		$document = $this->documentService->getDocument($documentId);
@@ -172,6 +184,10 @@ class SessionMiddleware extends Middleware {
 	public function afterException($controller, $methodName, \Exception $exception): JSONResponse|Response {
 		if ($exception instanceof InvalidDocumentBaseVersionEtagException) {
 			return new JSONResponse(['error' => $this->l10n->t('Editing session has expired. Please reload the page.')], Http::STATUS_PRECONDITION_FAILED);
+		}
+
+		if ($exception instanceof AccountDisabledException) {
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		if ($exception instanceof InvalidSessionException) {

--- a/tests/unit/Middleware/SessionMiddlewareTest.php
+++ b/tests/unit/Middleware/SessionMiddlewareTest.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace OCA\Text\Tests;
+
+use OCA\Text\Controller\ISessionAwareController;
+use OCA\Text\Db\Document;
+use OCA\Text\Db\Session;
+use OCA\Text\Exception\AccountDisabledException;
+use OCA\Text\Exception\InvalidSessionException;
+use OCA\Text\Middleware\SessionMiddleware;
+use OCA\Text\Service\DocumentService;
+use OCA\Text\Service\SessionService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\Constants;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use Test\TestCase;
+
+class SessionMiddlewareTest extends TestCase {
+	private SessionMiddleware $middleware;
+	private IRequest $request;
+	private ISession $session;
+	private IUserSession $userSession;
+	private IRootFolder $rootFolder;
+	private IManager $shareManager;
+	private SessionService $sessionService;
+	private DocumentService $documentService;
+	private IUserManager $userManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->session = $this->createMock(ISession::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->shareManager = $this->createMock(IManager::class);
+		$this->sessionService = $this->createMock(SessionService::class);
+		$this->documentService = $this->createMock(DocumentService::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+
+		$this->middleware = new SessionMiddleware(
+			$this->request,
+			$this->sessionService,
+			$this->documentService,
+			$this->session,
+			$this->userSession,
+			$this->rootFolder,
+			$this->shareManager,
+			$this->createMock(IL10N::class),
+			$this->userManager,
+		);
+	}
+
+	public function testUnauthenticatedAccessBlocked(): void {
+		$this->expectException(InvalidSessionException::class);
+
+		$share = $this->createPasswordProtectedShare('42');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(null);
+
+		$this->invokeMiddleware($share);
+	}
+
+	public function testAuthenticatedSingleIdAllowed(): void {
+		$share = $this->createPasswordProtectedShare('42');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn('42');
+
+		$this->invokeMiddleware($share);
+		$this->assertTrue(true);
+	}
+
+	public function testAuthenticatedArrayAllowed(): void {
+		$share = $this->createPasswordProtectedShare('42');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(['40', '42', '44']);
+
+		$this->invokeMiddleware($share);
+		$this->assertTrue(true);
+	}
+
+	public function testWrongSingleIdBlocked(): void {
+		$this->expectException(InvalidSessionException::class);
+
+		$share = $this->createPasswordProtectedShare('42');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn('99');
+
+		$this->invokeMiddleware($share);
+	}
+
+	public function testWrongArrayBlocked(): void {
+		$this->expectException(InvalidSessionException::class);
+
+		$share = $this->createPasswordProtectedShare('42');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(['10', '20', '30']);
+
+		$this->invokeMiddleware($share);
+	}
+
+	public function testLoggedInUserWithInvalidToken(): void {
+		$this->expectException(InvalidSessionException::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user1');
+
+		$share = $this->createPasswordProtectedShare('42');
+		$this->shareManager->method('getShareByToken')->willThrowException(new ShareNotFound());
+
+		$this->invokeMiddleware($share, $user);
+	}
+
+	public function testLoggedInUserWithValidToken(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user1');
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getId')->willReturn('user2-share');
+		$share->method('getPassword')->willReturn(null);
+		$share->method('getPermissions')->willReturn(Constants::PERMISSION_READ);
+		$share->method('getShareOwner')->willReturn('user2');
+		$share->method('getAttributes')->willReturn(null);
+
+		$this->shareManager->method('getShareByToken')->willReturn($share);
+
+		$controller = $this->createMock(ISessionAwareController::class);
+		$controller->expects($this->never())->method('setUserId');
+		$controller->expects($this->once())->method('setDocumentId');
+
+		$this->invokeMiddleware($share, $user, $controller);
+	}
+
+	public function testLoggedInUserWithValidTokenUnauthenticated(): void {
+		$this->expectException(InvalidSessionException::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user1');
+
+		$share = $this->createPasswordProtectedShare('user2-share');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(null);
+		$this->shareManager->method('getShareByToken')->willReturn($share);
+
+		$this->invokeMiddleware($share, $user);
+	}
+
+	public function testDocumentSessionWithEnabledUserAllowed(): void {
+		$session = new Session();
+		$session->setUserId('alice');
+
+		$user = $this->createMock(IUser::class);
+		$user->method('isEnabled')->willReturn(true);
+
+		$this->sessionService->method('getValidSession')->willReturn($session);
+		$this->userManager->method('get')->with('alice')->willReturn($user);
+		$this->documentService->method('getDocument')->willReturn($this->createMock(Document::class));
+
+		$controller = $this->createMock(ISessionAwareController::class);
+		$controller->expects($this->once())->method('setUserId')->with('alice');
+
+		$this->invokeAssertDocumentSession($controller);
+		$this->assertTrue(true);
+	}
+
+	public function testDocumentSessionWithDisabledUserBlocked(): void {
+		$this->expectException(AccountDisabledException::class);
+
+		$session = new Session();
+		$session->setUserId('alice');
+
+		$user = $this->createMock(IUser::class);
+		$user->method('isEnabled')->willReturn(false);
+
+		$this->sessionService->method('getValidSession')->willReturn($session);
+		$this->userManager->method('get')->with('alice')->willReturn($user);
+
+		$controller = $this->createMock(ISessionAwareController::class);
+		$controller->expects($this->never())->method('setUserId');
+
+		$this->invokeAssertDocumentSession($controller);
+	}
+
+	public function testDocumentSessionWithNonexistentUserBlocked(): void {
+		$this->expectException(AccountDisabledException::class);
+
+		$session = new Session();
+		$session->setUserId('alice');
+
+		$this->sessionService->method('getValidSession')->willReturn($session);
+		$this->userManager->method('get')->with('alice')->willReturn(null);
+
+		$controller = $this->createMock(ISessionAwareController::class);
+		$controller->expects($this->never())->method('setUserId');
+
+		$this->invokeAssertDocumentSession($controller);
+	}
+
+	public function testDocumentSessionGuestSessionSkipsUserCheck(): void {
+		$session = new Session();
+
+		$this->sessionService->method('getValidSession')->willReturn($session);
+		$this->userManager->expects($this->never())->method('get');
+		$this->documentService->method('getDocument')->willReturn($this->createMock(Document::class));
+
+		$controller = $this->createMock(ISessionAwareController::class);
+
+		$this->invokeAssertDocumentSession($controller, 'shareToken123');
+		$this->assertTrue(true);
+	}
+
+	public function testAfterExceptionMapsAccountDisabledToForbidden(): void {
+		$controller = $this->createMock(ISessionAwareController::class);
+
+		$response = $this->middleware->afterException($controller, 'push', new AccountDisabledException());
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}
+
+	private function invokeAssertDocumentSession(ISessionAwareController $controller, ?string $shareToken = null): void {
+		$this->request->method('getParam')->willReturnMap([
+			['documentId', null, 999],
+			['sessionId', null, 1],
+			['sessionToken', null, 'sessionToken'],
+			['token', null, $shareToken],
+		]);
+
+		self::invokePrivate($this->middleware, 'assertDocumentSession', [$controller]);
+	}
+
+	private function createPasswordProtectedShare(string $id): IShare {
+		$share = $this->createMock(IShare::class);
+		$share->method('getId')->willReturn($id);
+		$share->method('getPassword')->willReturn('password');
+		$share->method('getPermissions')->willReturn(Constants::PERMISSION_READ);
+		$share->method('getShareOwner')->willReturn('owner');
+		$share->method('getAttributes')->willReturn(null);
+		return $share;
+	}
+
+	private function invokeMiddleware(IShare $share, ?IUser $user = null, ?ISessionAwareController $controller = null): void {
+		$this->request->method('getParam')->willReturnMap([
+			['documentId', null, 999],
+			['shareToken', null, 'token'],
+		]);
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->shareManager->method('getShareByToken')->willReturn($share);
+
+		$folder = $this->createMock(Folder::class);
+		$folder->method('getFirstNodeById')->willReturn($this->createMock(File::class));
+		$this->rootFolder->method('getUserFolder')->willReturn($folder);
+
+		$controller ??= $this->createMock(ISessionAwareController::class);
+		self::invokePrivate($this->middleware, 'assertUserOrShareToken', [$controller]);
+	}
+}


### PR DESCRIPTION
### 📝 Summary

Manual backport of #8951 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required