### PR TITLE
[stable34] fix: guard access to unavailable extensions when rich editing is off

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -113,17 +113,23 @@ class TextEditorEmbed {
 
 	setSearchQuery(query, matchAll) {
 		const editor = this.#getEditorComponent()?.editor
-		editor?.commands.setSearchQuery(query, matchAll)
+		if (typeof editor?.commands.setSearchQuery === 'function') {
+			editor?.commands.setSearchQuery(query, matchAll)
+		}
 	}
 
 	searchNext() {
 		const editor = this.#getEditorComponent()?.editor
-		editor?.commands.nextMatch()
+		if (typeof editor?.commands.nextMatch === 'function') {
+			editor?.commands.nextMatch()
+		}
 	}
 
 	searchPrevious() {
 		const editor = this.#getEditorComponent()?.editor
-		editor?.commands.previousMatch()
+		if (typeof editor?.commands.previousMatch === 'function') {
+			editor?.commands.previousMatch()
+		}
 	}
 
 	async save() {


### PR DESCRIPTION
Manual backport of #8970

Assisted-by: Copilot:gpt-5.6-luna

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
