### PR TITLE
fix(lists): no margin-bottom for nested lists to prevent ugly gap

### DIFF
--- a/src/css/prosemirror.scss
+++ b/src/css/prosemirror.scss
@@ -311,6 +311,10 @@ div.ProseMirror {
 		padding-inline-start: 10px;
 		margin-inline-start: 10px;
 		margin-bottom: 1em;
+
+		ul, ol {
+			margin-bottom: 0;
+		}
 	}
 
 	ul > li {


### PR DESCRIPTION
We want the margin-bottom for top-level lists so they have the same bottom spacing as paragraphs, but we don't want it in nested lists.

Fixes: #9002

Assisted-by: OpenCode:claude-fable-5

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
