### PR TITLE
Fix(LinkPicker): improve suggestions order and rename 'Files'

### DIFF
--- a/playwright/e2e/smart-picker.spec.ts
+++ b/playwright/e2e/smart-picker.spec.ts
@@ -34,3 +34,27 @@ test('Insert Link', async ({ editor }) => {
 	await editor.referencePicker.press('Enter')
 	await expect(editor.content.getByRole('link')).toContainText('github.com')
 })
+
+test('Files provider is renamed to "Link a file"', async ({ editor }) => {
+	await editor.type('/')
+	await expect(editor.getSuggestion('Link a file')).toBeVisible()
+})
+
+test('Important items appear before remaining items', async ({ editor }) => {
+	await editor.type('/')
+	await expect(editor.getSuggestion('To-Do list')).toBeVisible()
+	const allTexts = await editor.suggestions
+		.locator('.suggestion-list__item')
+		.allTextContents()
+
+	const todoIdx = allTexts.findIndex((t) => t.includes('To-Do list'))
+	const tableIdx = allTexts.findIndex((t) => t.includes('Table'))
+	const filesIdx = allTexts.findIndex((t) => t.includes('Link a file'))
+	const heading1Idx = allTexts.findIndex((t) => t.includes('Heading 1'))
+
+	expect(todoIdx).toBeLessThan(filesIdx)
+	expect(todoIdx).toBeLessThan(heading1Idx)
+	expect(tableIdx).toBeLessThan(filesIdx)
+	expect(tableIdx).toBeLessThan(heading1Idx)
+	expect(filesIdx).toBeLessThan(heading1Idx)
+})

--- a/src/components/Suggestion/LinkPicker/suggestions.js
+++ b/src/components/Suggestion/LinkPicker/suggestions.js
@@ -16,11 +16,14 @@ import { getIsActive } from '../../Menu/utils.js'
 import createSuggestions from '../suggestions.js'
 import { getMenuEntries } from './../../Menu/entries.ts'
 
+const suggestGroupImportant = t('text', 'Suggestions')
 const suggestGroupFormat = t('text', 'Formatting')
 const suggestGroupPicker = t('text', 'Smart picker')
 
-const important = ['task-list', 'table']
-const excluded = ['undo', 'redo', 'outline', 'emoji-picker']
+const important = ['task-list', 'table', 'callout-info']
+const excludedFormatting = ['undo', 'redo', 'outline', 'emoji-picker']
+
+const isImportant = (item) => important.includes(item.key) || important.includes(item.providerId)
 
 /**
  *
@@ -36,25 +39,15 @@ function isValidUrl(url) {
 
 /**
  *
- * @param {Array} list of menu entries
- */
-function sortImportantFirst(list) {
-	return [
-		...list.filter((e) => important.indexOf(e.key) > -1),
-		...list.filter((e) => important.indexOf(e.key) === -1),
-	]
-}
-
-/**
- *
  * @param {string} query to filter by
+ * @param {object} editor the editor instance
  */
-function formattingSuggestions(query) {
+function formattingItems(query, editor) {
 	const menuEntries = getMenuEntries(false, false)
-	return sortImportantFirst([
+	return [
 		...menuEntries.find((e) => e.key === 'headings').children,
 		...menuEntries.find((e) => e.key === 'lists').children,
-		...menuEntries.filter((e) => e.action && !excluded.includes(e.key)),
+		...menuEntries.filter((e) => e.action && !excludedFormatting.includes(e.key)),
 		...menuEntries.find((e) => e.key === 'blocks').children,
 		{
 			...menuEntries.find((e) => e.key === 'emoji-picker'),
@@ -62,7 +55,28 @@ function formattingSuggestions(query) {
 		},
 	]
 		.filter((e) => e?.label?.toLowerCase?.()?.includes(query.toLowerCase()))
-		.map((e) => ({ ...e, suggestGroup: suggestGroupFormat })))
+		.filter(({ action, isActive }) => {
+			const canRunState = action(editor?.can())
+			const isActiveState
+				= isActive && getIsActive({ isActive }, editor)
+			return canRunState && !isActiveState
+		})
+}
+
+/**
+ * @param {string} query to filter by
+ */
+function pickerItems(query) {
+	return searchProvider(query)
+		.map((p) => {
+			return {
+				label: p.title,
+				icon: p.icon_url,
+				providerId: p.id,
+				order: p.order,
+			}
+		})
+		.filter((e) => e?.label?.toLowerCase?.()?.includes(query.toLowerCase()))
 }
 
 export default () => createSuggestions({
@@ -101,23 +115,25 @@ export default () => createSuggestions({
 			})
 	},
 	items: ({ editor, query }) => {
+		const pickers = pickerItems(query)
+		const formatting = formattingItems(query, editor)
 		return [
-			...searchProvider(query)
-				.map((p) => {
-					return {
-						suggestGroup: suggestGroupPicker,
-						label: p.title,
-						icon: p.icon_url,
-						providerId: p.id,
-					}
-				})
-				.filter((e) => e?.label?.toLowerCase?.()?.includes(query.toLowerCase())),
-			...formattingSuggestions(query).filter(({ action, isActive }) => {
-				const canRunState = action(editor?.can())
-				const isActiveState
-					= isActive && getIsActive({ isActive }, editor)
-				return canRunState && !isActiveState
-			}),
+			// pickers with order -1, then important pickers, then important formatting
+			...[
+				...pickers.filter((e) => e.order === -1),
+				...pickers.filter((e) => e.order !== -1 && isImportant(e)),
+				...formatting.filter(isImportant),
+			].map((e) => ({ ...e, suggestGroup: suggestGroupImportant })),
+
+			// Smart picker: remaining (non-important) pickers
+			...pickers
+				.filter((e) => e.order !== -1 && !isImportant(e))
+				.map((e) => ({ ...e, suggestGroup: suggestGroupPicker })),
+
+			// Formatting: remaining (non-important) formatting entries
+			...formatting
+				.filter((e) => !isImportant(e))
+				.map((e) => ({ ...e, suggestGroup: suggestGroupFormat })),
 		]
 	},
 })

--- a/src/components/Suggestion/LinkPicker/suggestions.js
+++ b/src/components/Suggestion/LinkPicker/suggestions.js
@@ -69,8 +69,13 @@ function formattingItems(query, editor) {
 function pickerItems(query) {
 	return searchProvider(query)
 		.map((p) => {
+			let label = p.title
+			if (p.id === 'files') {
+				// Rename "Files" to "Link a file", less ambiguous
+				label = t('text', 'Link a file')
+			}
 			return {
-				label: p.title,
+				label,
 				icon: p.icon_url,
 				providerId: p.id,
 				order: p.order,


### PR DESCRIPTION
### 📝 Summary

* List smart picker items with `order === -1` first (e.g. "Link to page in collective" inside Collectives).
* List some items declared as "important" second.
* List remaining smart picker items third.
* List remaining formatting items last.
* Rename 'Files' to 'Link a file'. The generic 'Files' is too ambiguous in document editing context.
* Resolves: #8802 

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1056" height="600" alt="image" src="https://github.com/user-attachments/assets/92b92190-c37f-4fc0-aaf1-0df485eeda17" /> | <img width="1056" height="600" alt="image" src="https://github.com/user-attachments/assets/7622aeb6-5aad-4ee8-b5ce-755da61c6cea" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
