### PR TITLE
fix(viewer): align content of old version in viewer version comparison

### DIFF
--- a/playwright/e2e/versions.spec.ts
+++ b/playwright/e2e/versions.spec.ts
@@ -64,6 +64,11 @@ test.describe('Versions with distant timestamps', () => {
 		const current = page.locator('.ProseMirror[contenteditable="true"]')
 		await expect(oldVersion.getByRole('heading', { name: 'V1' })).toBeVisible()
 		await expect(current.getByRole('heading', { name: 'V3' })).toBeVisible()
+
+		// Test that version contents are vertically aligned
+		const oldBox = await oldVersion.getByRole('heading', { name: 'V1' }).boundingBox()
+		const currentBox = await oldVersion.getByRole('heading', { name: 'V3' }).boundingBox()
+		expect(Math.abs(oldBox!.y - currentBox!.y)).toBeLessThan(5)
 	})
 })
 

--- a/src/components/ViewerComponent.vue
+++ b/src/components/ViewerComponent.vue
@@ -167,7 +167,12 @@ body .toastify.dialogs {
 	margin-top: calc(45px + var(--default-clickable-area));
 }
 
-.viewer[data-handler='text'] .modal-wrapper .modal-container {
+.viewer--split .source-viewer .editor__content-wrapper {
+	// Account for missing menubar for old version in version comparison
+	margin-top: calc(var(--default-clickable-area) + 2 * var(--default-grid-baseline));
+}
+
+.viewer[data-handler="text"] .modal-wrapper .modal-container {
 	bottom: 0;
 }
 </style>


### PR DESCRIPTION
The source viewer in the "compare side by side" view in Viewer app doesn't have a menubar, so it needs a margin-top to align both versions vertically.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1134" height="232" alt="image" src="https://github.com/user-attachments/assets/a3cd6fee-36c4-400a-94a9-b1c26395a04c" /> | <img width="1134" height="232" alt="image" src="https://github.com/user-attachments/assets/c6ffd372-dc97-4ad2-b4e2-10cfd7583538" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
