### PR TITLE
Derive semantic Markdown changes

### DIFF
--- a/src/comparison/comparisonDocumentIndex.ts
+++ b/src/comparison/comparisonDocumentIndex.ts
@@ -1,0 +1,242 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonRange } from './markdownComparisonTypes.ts'
+
+export interface LocatedComparisonNode {
+	node: Node
+	path: readonly number[]
+	index: number
+	from: number
+	to: number
+	parent: LocatedComparisonNode | null
+	children: readonly LocatedComparisonNode[]
+}
+
+export interface ComparisonDocumentIndex {
+	children: readonly LocatedComparisonNode[]
+	nodes: readonly LocatedComparisonNode[]
+	nodeAtPath: (path: readonly number[]) => LocatedComparisonNode
+}
+
+export interface ComparisonNodeSearchAudit {
+	examinedNodes: number
+}
+
+interface MutableLocatedComparisonNode extends Omit<LocatedComparisonNode, 'children'> {
+	children: MutableLocatedComparisonNode[]
+}
+
+/**
+ * Build one reusable position and path index for an immutable document.
+ *
+ * @param doc Immutable ProseMirror document
+ * @param audit Optional operation counter for structural regression tests
+ */
+export function createComparisonDocumentIndex(
+	doc: Node,
+	audit?: ComparisonNodeSearchAudit,
+): ComparisonDocumentIndex {
+	const nodes: MutableLocatedComparisonNode[] = []
+	const byPath = new Map<string, MutableLocatedComparisonNode>()
+	const locateChildren = (
+		parentNode: Node,
+		parentLocation: MutableLocatedComparisonNode | null,
+		parentPath: readonly number[],
+		contentFrom: number,
+	) => {
+		const children: MutableLocatedComparisonNode[] = []
+		parentNode.forEach((node, offset, index) => {
+			if (audit) {
+				audit.examinedNodes++
+			}
+			const from = contentFrom + offset
+			const path = [...parentPath, index]
+			const location: MutableLocatedComparisonNode = {
+				node,
+				path,
+				index,
+				from,
+				to: from + node.nodeSize,
+				parent: parentLocation,
+				children: [],
+			}
+			children.push(location)
+			nodes.push(location)
+			byPath.set(pathKey(path), location)
+			if (!node.isLeaf) {
+				location.children = locateChildren(node, location, path, from + 1)
+			}
+		})
+		return children
+	}
+	const children = locateChildren(doc, null, [], 0)
+	return {
+		children,
+		nodes,
+		nodeAtPath(path) {
+			const location = byPath.get(pathKey(path))
+			if (!location) {
+				throw new Error(`Comparison document path does not exist: ${path.join('.')}`)
+			}
+			return location
+		},
+	}
+}
+
+/**
+ * Find touched nodes without scanning unrelated siblings.
+ *
+ * @param range Absolute document range
+ * @param roots Smallest known roots for the range
+ * @param audit Optional operation counter for structural regression tests
+ */
+export function findComparisonNodes(
+	range: ComparisonRange,
+	roots: readonly LocatedComparisonNode[],
+	audit?: ComparisonNodeSearchAudit,
+) {
+	const found = new Map<string, LocatedComparisonNode>()
+	const add = (location: LocatedComparisonNode) => found.set(pathKey(location.path), location)
+	const visit = (location: LocatedComparisonNode) => {
+		if (audit) {
+			audit.examinedNodes++
+		}
+		if (!touches(location, range)) {
+			return
+		}
+		add(location)
+		visitChildren(location.children, range, visit, audit)
+	}
+	for (const root of minimalRoots(roots)) {
+		for (let ancestor = root.parent; ancestor; ancestor = ancestor.parent) {
+			add(ancestor)
+		}
+		visit(root)
+	}
+	return [...found.values()].toSorted((a, b) => a.from - b.from || a.path.length - b.path.length)
+}
+
+/**
+ * Read text from the known roots instead of resolving the range from the document root.
+ *
+ * @param range Absolute document range
+ * @param roots Known range roots
+ */
+export function comparisonRangeText(range: ComparisonRange, roots: readonly LocatedComparisonNode[]) {
+	if (range.from === range.to) {
+		return ''
+	}
+	return minimalRoots(roots)
+		.filter((root) => touches(root, range))
+		.map((root) => textFromRoot(root, range))
+		.join('\n')
+}
+
+/**
+ * Visit child nodes that can intersect the requested range.
+ *
+ * @param children Candidate child nodes
+ * @param range Absolute document range
+ * @param visit Callback for each matching node
+ * @param audit Optional operation counter for structural regression tests
+ */
+function visitChildren(
+	children: readonly LocatedComparisonNode[],
+	range: ComparisonRange,
+	visit: (location: LocatedComparisonNode) => void,
+	audit?: ComparisonNodeSearchAudit,
+) {
+	let lower = 0
+	let upper = children.length
+	while (lower < upper) {
+		const middle = (lower + upper) >>> 1
+		if (audit) {
+			audit.examinedNodes++
+		}
+		const beforeRange = range.from === range.to
+			? children[middle]!.to < range.from
+			: children[middle]!.to <= range.from
+		if (beforeRange) {
+			lower = middle + 1
+		} else {
+			upper = middle
+		}
+	}
+	for (let index = lower; index < children.length; index++) {
+		const child = children[index]!
+		if (audit) {
+			audit.examinedNodes++
+		}
+		if (range.from === range.to ? child.from > range.from : child.from >= range.to) {
+			break
+		}
+		visit(child)
+	}
+}
+
+/**
+ * Check whether a located node intersects a document range.
+ *
+ * @param location Located document node
+ * @param range Absolute document range
+ */
+function touches(location: LocatedComparisonNode, range: ComparisonRange) {
+	return range.from === range.to
+		? range.from >= location.from && range.from <= location.to
+		: range.from < location.to && range.to > location.from
+}
+
+/**
+ * Remove roots whose ancestor is already present.
+ *
+ * @param roots Known range roots
+ */
+function minimalRoots(roots: readonly LocatedComparisonNode[]) {
+	const rootPaths = new Set(roots.map(({ path }) => pathKey(path)))
+	return roots.filter((root) => {
+		for (let ancestor = root.parent; ancestor; ancestor = ancestor.parent) {
+			if (rootPaths.has(pathKey(ancestor.path))) {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+/**
+ * Read the requested text from one known root.
+ *
+ * @param root Known range root
+ * @param range Absolute document range
+ */
+function textFromRoot(root: LocatedComparisonNode, range: ComparisonRange) {
+	if (root.node.isText) {
+		return root.node.text?.slice(
+			Math.max(0, range.from - root.from),
+			Math.min(root.node.nodeSize, range.to - root.from),
+		) ?? ''
+	}
+	if (root.node.isLeaf) {
+		return '\ufffc'
+	}
+	const contentFrom = root.from + 1
+	return root.node.textBetween(
+		Math.max(0, range.from - contentFrom),
+		Math.min(root.node.content.size, range.to - contentFrom),
+		'\n',
+		'\ufffc',
+	)
+}
+
+/**
+ * Encode a document path for map lookup.
+ *
+ * @param path Document child-index path
+ */
+function pathKey(path: readonly number[]) {
+	return path.join('.')
+}

--- a/src/comparison/comparisonEditorLifecycle.ts
+++ b/src/comparison/comparisonEditorLifecycle.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { EditorState, Plugin } from '@tiptap/pm/state'
+import type { Editor } from '@tiptap/vue-3'
+
+const INITIALIZATION_ERROR = 'Comparison editor plugin initialization failed'
+const stateOnlyEditors = new WeakSet<Editor>()
+
+/**
+ * Register one comparison editor created without a view.
+ *
+ * @param editor State-only comparison editor
+ */
+export function registerStateOnlyComparisonEditor(editor: Editor) {
+	if (editor.options.element !== null || editor.contentComponent !== null || editor.appContext !== null) {
+		throw new Error(INITIALIZATION_ERROR)
+	}
+	stateOnlyEditors.add(editor)
+}
+
+/**
+ * Register one comparison plugin against the live mounted state.
+ *
+ * @param editor Mounted comparison editor
+ * @param plugin Comparison plugin
+ */
+export function registerMountedPlugin(editor: Editor, plugin: Plugin): EditorState {
+	const previousPlugins = new Set(editor.view.state.plugins)
+	let nextState: EditorState
+	try {
+		nextState = editor.registerPlugin(plugin, (newPlugin) => [
+			...editor.view.state.plugins.filter((item) => item.spec.key !== newPlugin.spec.key),
+			newPlugin,
+		])
+	} catch (error) {
+		throw new Error(INITIALIZATION_ERROR, { cause: error })
+	}
+	if ([...previousPlugins].some((item) => !nextState.plugins.includes(item))
+		|| nextState.plugins.filter((item) => item === plugin).length !== 1
+		|| nextState !== editor.view.state
+		|| editor.state !== nextState) {
+		throw new Error(INITIALIZATION_ERROR)
+	}
+	return nextState
+}
+
+/**
+ * Consume the one-shot state-only registration before the visible mount.
+ *
+ * @param editor State-only comparison editor
+ */
+export function consumeStateOnlyComparisonEditor(editor: Editor) {
+	if (!stateOnlyEditors.delete(editor)) {
+		throw new Error(INITIALIZATION_ERROR)
+	}
+}

--- a/src/comparison/createComparisonEditor.ts
+++ b/src/comparison/createComparisonEditor.ts
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Schema } from '@tiptap/pm/model'
+
+import { Editor } from '@tiptap/vue-3'
+import { renderEditorContent } from '../composables/useEditorMethods.ts'
+import RichText from '../extensions/RichText.ts'
+import { registerStateOnlyComparisonEditor } from './comparisonEditorLifecycle.ts'
+
+interface ComparisonEditorOptions {
+	filePath?: string
+	noLazyImages?: boolean
+	openLink?: (href: string) => void
+	schema?: Schema
+}
+
+/**
+ * Create one normalized, immutable Text editor for comparison rendering.
+ *
+ * @param content Markdown content
+ * @param options Rendering options
+ */
+export function createComparisonEditor(content: string, options: ComparisonEditorOptions = {}) {
+	if (typeof content !== 'string') {
+		throw new TypeError('Comparison content must be a string')
+	}
+
+	const editor = new Editor({
+		content: renderEditorContent(content, true),
+		editable: false,
+		element: null,
+		extensions: [
+			RichText.configure({
+				editing: false,
+				emitAttachmentEvents: false,
+				extensions: [],
+				inferTextDirectionOnParse: true,
+				isEmbedded: true,
+				keymap: false,
+				noLazyImages: options.noLazyImages ?? false,
+				openLink: options.openLink,
+				relativePath: options.filePath,
+				search: false,
+			}),
+		],
+		onBeforeCreate: ({ editor }) => {
+			if (options.schema) {
+				editor.schema = options.schema
+				editor.extensionManager.schema = options.schema
+			}
+		},
+	})
+	registerStateOnlyComparisonEditor(editor)
+	return editor
+}

--- a/src/comparison/hierarchicalMarkdownComparisonModel.ts
+++ b/src/comparison/hierarchicalMarkdownComparisonModel.ts
@@ -1,0 +1,955 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type {
+	ComparisonDocumentIndex,
+	ComparisonNodeSearchAudit,
+	LocatedComparisonNode,
+} from './comparisonDocumentIndex.ts'
+import type { ReservedExactMovePair } from './markdownComparisonMoves.ts'
+import type {
+	ComparisonDescriptor,
+	ComparisonRange,
+	MarkdownComparisonModel,
+} from './markdownComparisonTypes.ts'
+
+import { ChangeSet, simplifyChanges } from '@tiptap/pm/changeset'
+import { StepMap } from '@tiptap/pm/transform'
+import {
+	comparisonRangeText,
+	createComparisonDocumentIndex,
+} from './comparisonDocumentIndex.ts'
+import {
+	classifyComparisonDescriptor,
+	classifyNodeMarkupDescriptor,
+	compareCodeUnits,
+	deepFreeze,
+	semanticTokenEncoder,
+	stableSerialize,
+} from './markdownComparisonClassification.ts'
+import { confirmReservedExactMoves } from './markdownComparisonMoves.ts'
+
+export const MAX_INLINE_ENVELOPE_SIZE = 4500
+export const MAX_ALIGNMENT_PRODUCT = 40_000
+export const MAX_RENDERED_COMPARISON_DESCRIPTORS = 10_000
+
+export interface ComparisonModelAudit extends ComparisonNodeSearchAudit {
+	fingerprintGroupAllocations: number
+}
+
+interface ComparisonModelOptions {
+	audit?: ComparisonModelAudit
+	maximumDescriptors?: number
+}
+
+export class ComparisonModelLimitError extends Error {
+	constructor() {
+		super('Rendered comparison change limit reached')
+		this.name = 'ComparisonModelLimitError'
+	}
+}
+
+const MAX_LINEAR_ALIGNMENT_LOOKAHEAD = 8
+
+const fingerprintCache = new WeakMap<Node, string>()
+
+type ExactPair = ReservedExactMovePair
+
+interface AlignmentStep {
+	before: LocatedComparisonNode | null
+	after: LocatedComparisonNode | null
+}
+
+interface AlignmentWindow {
+	before: readonly LocatedComparisonNode[]
+	after: readonly LocatedComparisonNode[]
+	beforeStart: number
+	beforeEnd: number
+	afterStart: number
+	afterEnd: number
+}
+
+interface InlineChangeRange {
+	fromA: number
+	toA: number
+	fromB: number
+	toB: number
+}
+
+interface ComparisonBuilder {
+	originalBefore: Node
+	originalAfter: Node
+	originalBeforeIndex: ComparisonDocumentIndex
+	originalAfterIndex: ComparisonDocumentIndex
+	comparisonBefore: Node
+	comparisonAfter: Node
+	comparisonBeforeIndex: ComparisonDocumentIndex
+	comparisonAfterIndex: ComparisonDocumentIndex
+	descriptors: ComparisonDescriptor[]
+	reservedMoves: ExactPair[]
+	audit?: ComparisonModelAudit
+	maximumDescriptors: number
+}
+
+/**
+ * Compare original documents by aligning bounded sibling windows recursively.
+ *
+ * @param originalBefore Earlier complete document and coordinate owner
+ * @param originalAfter Later complete document and coordinate owner
+ * @param options Comparison limits and optional structural-test counter
+ */
+export function createHierarchicalMarkdownComparisonModel(
+	originalBefore: Node,
+	originalAfter: Node,
+	options: ComparisonModelOptions = {},
+): MarkdownComparisonModel {
+	const { audit } = options
+	const normalized = normalizeSchemas(originalBefore, originalAfter)
+	const originalBeforeIndex = createComparisonDocumentIndex(originalBefore, audit)
+	const originalAfterIndex = createComparisonDocumentIndex(originalAfter, audit)
+	const comparisonBeforeIndex = normalized.before === originalBefore
+		? originalBeforeIndex
+		: createComparisonDocumentIndex(normalized.before, audit)
+	const comparisonAfterIndex = normalized.after === originalAfter
+		? originalAfterIndex
+		: createComparisonDocumentIndex(normalized.after, audit)
+	const builder: ComparisonBuilder = {
+		originalBefore,
+		originalAfter,
+		originalBeforeIndex,
+		originalAfterIndex,
+		comparisonBefore: normalized.before,
+		comparisonAfter: normalized.after,
+		comparisonBeforeIndex,
+		comparisonAfterIndex,
+		descriptors: [],
+		reservedMoves: [],
+		audit,
+		maximumDescriptors: options.maximumDescriptors ?? MAX_RENDERED_COMPARISON_DESCRIPTORS,
+	}
+
+	compareSiblingNodes(
+		builder,
+		comparisonBeforeIndex.children,
+		comparisonAfterIndex.children,
+		0,
+		normalized.before.content.size,
+		0,
+		normalized.after.content.size,
+		true,
+	)
+	emitReservedMoves(builder)
+
+	return deepFreeze({
+		descriptors: finalizeDescriptors(builder.descriptors),
+	})
+}
+
+/**
+ * Rebuild the earlier document with the later schema while preserving positions.
+ *
+ * @param before Earlier document
+ * @param after Later document
+ */
+function normalizeSchemas(before: Node, after: Node) {
+	if (before.type.schema === after.type.schema) {
+		return { before, after }
+	}
+	const rebuilt = after.type.schema.nodeFromJSON(before.toJSON())
+	if (rebuilt.nodeSize !== before.nodeSize) {
+		throw new Error('Markdown comparison schema normalization changed document positions')
+	}
+	if (rebuilt.textBetween(0, rebuilt.content.size, '\n', '\ufffc')
+		!== before.textBetween(0, before.content.size, '\n', '\ufffc')) {
+		throw new Error('Markdown comparison schema normalization changed document content')
+	}
+	return { before: rebuilt, after }
+}
+
+/**
+ * Align direct siblings around ordered exact anchors and recurse into pairs.
+ *
+ * @param builder Comparison state
+ * @param before Earlier direct children
+ * @param after Later direct children
+ * @param beforeStart Earlier parent content start
+ * @param beforeEnd Earlier parent content end
+ * @param afterStart Later parent content start
+ * @param afterEnd Later parent content end
+ * @param topLevel Whether these are root children
+ */
+function compareSiblingNodes(
+	builder: ComparisonBuilder,
+	before: readonly LocatedComparisonNode[],
+	after: readonly LocatedComparisonNode[],
+	beforeStart: number,
+	beforeEnd: number,
+	afterStart: number,
+	afterEnd: number,
+	topLevel: boolean,
+) {
+	const exactPairs = findUniqueExactPairs(before, after, builder.audit)
+	const anchors = longestIncreasingPairs(exactPairs)
+	const anchorKeys = new Set(anchors.map(pairKey))
+	const reserved = topLevel ? exactPairs.filter((pair) => !anchorKeys.has(pairKey(pair))) : []
+	const reservedBefore = new Set(reserved.map(({ before: node }) => node.index))
+	const reservedAfter = new Set(reserved.map(({ after: node }) => node.index))
+	builder.reservedMoves.push(...reserved)
+
+	let previousBeforeIndex = -1
+	let previousAfterIndex = -1
+	for (const anchor of [...anchors, null]) {
+		const nextBeforeIndex = anchor?.before.index ?? before.length
+		const nextAfterIndex = anchor?.after.index ?? after.length
+		const window: AlignmentWindow = {
+			before: before
+				.slice(previousBeforeIndex + 1, nextBeforeIndex)
+				.filter(({ index }) => !reservedBefore.has(index)),
+			after: after
+				.slice(previousAfterIndex + 1, nextAfterIndex)
+				.filter(({ index }) => !reservedAfter.has(index)),
+			beforeStart: positionAt(before, previousBeforeIndex + 1, beforeStart, beforeEnd),
+			beforeEnd: positionAt(before, nextBeforeIndex, beforeStart, beforeEnd),
+			afterStart: positionAt(after, previousAfterIndex + 1, afterStart, afterEnd),
+			afterEnd: positionAt(after, nextAfterIndex, afterStart, afterEnd),
+		}
+		compareAlignmentWindow(builder, window)
+		if (anchor) {
+			previousBeforeIndex = anchor.before.index
+			previousAfterIndex = anchor.after.index
+		}
+	}
+}
+
+/**
+ * Find exact sibling pairs whose canonical fingerprints are unique on both sides.
+ *
+ * @param before Earlier siblings
+ * @param after Later siblings
+ * @param audit Optional operation counter for structural regression tests
+ */
+function findUniqueExactPairs(
+	before: readonly LocatedComparisonNode[],
+	after: readonly LocatedComparisonNode[],
+	audit?: ComparisonModelAudit,
+) {
+	const beforeByFingerprint = groupByFingerprint(before, audit)
+	const afterByFingerprint = groupByFingerprint(after, audit)
+	const pairs: ExactPair[] = []
+	for (const afterNode of after) {
+		const fingerprint = fingerprintNode(afterNode.node)
+		const beforeMatches = beforeByFingerprint.get(fingerprint)
+		const afterMatches = afterByFingerprint.get(fingerprint)
+		if (beforeMatches?.length !== 1 || afterMatches?.length !== 1) {
+			continue
+		}
+		const beforeNode = beforeMatches[0]!
+		if (beforeNode.node.eq(afterNode.node)) {
+			pairs.push({ before: beforeNode, after: afterNode, fingerprint })
+		}
+	}
+	return pairs
+}
+
+/**
+ * @param nodes Siblings to index
+ * @param audit Optional operation counter for structural regression tests
+ */
+function groupByFingerprint(nodes: readonly LocatedComparisonNode[], audit?: ComparisonModelAudit) {
+	const grouped = new Map<string, LocatedComparisonNode[]>()
+	for (const node of nodes) {
+		const fingerprint = fingerprintNode(node.node)
+		const group = grouped.get(fingerprint)
+		if (group) {
+			group.push(node)
+		} else {
+			if (audit) {
+				audit.fingerprintGroupAllocations++
+			}
+			grouped.set(fingerprint, [node])
+		}
+	}
+	return grouped
+}
+
+/**
+ * Select deterministic order-preserving exact anchors in O(n log n).
+ *
+ * @param pairs Exact pairs in later-document order
+ */
+function longestIncreasingPairs(pairs: ExactPair[]) {
+	if (pairs.length === 0) {
+		return []
+	}
+	const tails: number[] = []
+	const previous = new Int32Array(pairs.length).fill(-1)
+	for (let candidateIndex = 0; candidateIndex < pairs.length; candidateIndex++) {
+		const beforeIndex = pairs[candidateIndex]!.before.index
+		let low = 0
+		let high = tails.length
+		while (low < high) {
+			const middle = (low + high) >>> 1
+			if (pairs[tails[middle]!]!.before.index < beforeIndex) {
+				low = middle + 1
+			} else {
+				high = middle
+			}
+		}
+		if (low > 0) {
+			previous[candidateIndex] = tails[low - 1]!
+		}
+		tails[low] = candidateIndex
+	}
+
+	const selected: ExactPair[] = []
+	let candidateIndex = tails.at(-1)!
+	while (candidateIndex >= 0) {
+		selected.push(pairs[candidateIndex]!)
+		candidateIndex = previous[candidateIndex]!
+	}
+	return selected.reverse()
+}
+
+/**
+ * @param pair Exact pair
+ */
+function pairKey(pair: ExactPair) {
+	return `${pair.before.index}:${pair.after.index}`
+}
+
+/**
+ * @param nodes Siblings
+ * @param index Child slot
+ * @param start Parent content start
+ * @param end Parent content end
+ */
+function positionAt(nodes: readonly LocatedComparisonNode[], index: number, start: number, end: number) {
+	return index < 0 ? start : nodes[index]?.from ?? end
+}
+
+/**
+ * Align one bounded window and compare every resulting pair or unmatched node.
+ *
+ * @param builder Comparison state
+ * @param window Unanchored sibling window
+ */
+function compareAlignmentWindow(builder: ComparisonBuilder, window: AlignmentWindow) {
+	const steps = alignWindow(window.before, window.after)
+	for (let index = 0; index < steps.length; index++) {
+		const step = steps[index]!
+		if (step.before && step.after) {
+			comparePairedNodes(builder, step.before, step.after)
+		} else if (step.before) {
+			const missing = missingLocation(steps, index, 'after', window.afterStart, window.afterEnd)
+			emitBlockChange(
+				builder,
+				step.before,
+				null,
+				missing.position,
+				missing.neighbors,
+			)
+		} else if (step.after) {
+			const missing = missingLocation(steps, index, 'before', window.beforeStart, window.beforeEnd)
+			emitBlockChange(
+				builder,
+				null,
+				step.after,
+				missing.position,
+				missing.neighbors,
+			)
+		}
+	}
+}
+
+/**
+ * Align a sibling window with bounded dynamic programming or a conservative fallback.
+ *
+ * @param before Earlier siblings
+ * @param after Later siblings
+ */
+function alignWindow(before: readonly LocatedComparisonNode[], after: readonly LocatedComparisonNode[]) {
+	if (before.length * after.length > MAX_ALIGNMENT_PRODUCT) {
+		return alignLargeWindow(before, after)
+	}
+
+	const columns = after.length + 1
+	const scores = new Float64Array((before.length + 1) * columns)
+	const pairScores = new Float64Array(before.length * after.length).fill(-1)
+	const scoreAt = (beforeIndex: number, afterIndex: number) => scores[beforeIndex * columns + afterIndex]!
+	for (let beforeIndex = 1; beforeIndex <= before.length; beforeIndex++) {
+		for (let afterIndex = 1; afterIndex <= after.length; afterIndex++) {
+			const pairScore = scoreCompatibleNodes(before[beforeIndex - 1]!.node, after[afterIndex - 1]!.node)
+			pairScores[(beforeIndex - 1) * after.length + afterIndex - 1] = pairScore
+			const pair = pairScore < 0 ? -1 : scoreAt(beforeIndex - 1, afterIndex - 1) + pairScore
+			scores[beforeIndex * columns + afterIndex] = Math.max(
+				pair,
+				scoreAt(beforeIndex - 1, afterIndex),
+				scoreAt(beforeIndex, afterIndex - 1),
+			)
+		}
+	}
+
+	const reversed: AlignmentStep[] = []
+	let beforeIndex = before.length
+	let afterIndex = after.length
+	while (beforeIndex > 0 || afterIndex > 0) {
+		const current = scoreAt(beforeIndex, afterIndex)
+		const pairScore = beforeIndex > 0 && afterIndex > 0
+			? pairScores[(beforeIndex - 1) * after.length + afterIndex - 1]!
+			: -1
+		if (pairScore >= 0 && current === scoreAt(beforeIndex - 1, afterIndex - 1) + pairScore) {
+			reversed.push({ before: before[--beforeIndex]!, after: after[--afterIndex]! })
+		} else if (beforeIndex > 0 && current === scoreAt(beforeIndex - 1, afterIndex)) {
+			reversed.push({ before: before[--beforeIndex]!, after: null })
+		} else {
+			reversed.push({ before: null, after: after[--afterIndex]! })
+		}
+	}
+	return reversed.reverse()
+}
+
+/**
+ * Preserve positional precision beyond the dynamic-programming ceiling.
+ * A bounded lookahead consumes small insert/delete runs without allowing
+ * alignment work to grow with the sibling product.
+ *
+ * @param before Earlier siblings
+ * @param after Later siblings
+ */
+function alignLargeWindow(before: readonly LocatedComparisonNode[], after: readonly LocatedComparisonNode[]) {
+	const steps: AlignmentStep[] = []
+	let beforeIndex = 0
+	let afterIndex = 0
+	while (beforeIndex < before.length || afterIndex < after.length) {
+		if (beforeIndex >= before.length) {
+			steps.push({ before: null, after: after[afterIndex++]! })
+			continue
+		}
+		if (afterIndex >= after.length) {
+			steps.push({ before: before[beforeIndex++]!, after: null })
+			continue
+		}
+
+		const beforeNode = before[beforeIndex]!
+		const afterNode = after[afterIndex]!
+		const directScore = scoreCompatibleNodes(beforeNode.node, afterNode.node)
+		const remainingBefore = before.length - beforeIndex
+		const remainingAfter = after.length - afterIndex
+		if (remainingAfter > remainingBefore) {
+			const skip = bestFollowingMatch(
+				beforeNode.node,
+				after,
+				afterIndex,
+				Math.min(remainingAfter - remainingBefore, MAX_LINEAR_ALIGNMENT_LOOKAHEAD),
+				directScore,
+			)
+			if (skip > 0) {
+				for (let offset = 0; offset < skip; offset++) {
+					steps.push({ before: null, after: after[afterIndex++]! })
+				}
+				continue
+			}
+		} else if (remainingBefore > remainingAfter) {
+			const skip = bestFollowingMatch(
+				afterNode.node,
+				before,
+				beforeIndex,
+				Math.min(remainingBefore - remainingAfter, MAX_LINEAR_ALIGNMENT_LOOKAHEAD),
+				directScore,
+			)
+			if (skip > 0) {
+				for (let offset = 0; offset < skip; offset++) {
+					steps.push({ before: before[beforeIndex++]!, after: null })
+				}
+				continue
+			}
+		}
+
+		if (directScore >= 0) {
+			steps.push({ before: beforeNode, after: afterNode })
+		} else {
+			steps.push({ before: beforeNode, after: null })
+			steps.push({ before: null, after: afterNode })
+		}
+		beforeIndex++
+		afterIndex++
+	}
+	return steps
+}
+
+/**
+ * Find a strictly better compatible node after a short unmatched run.
+ *
+ * @param target Node on the shorter side
+ * @param candidates Nodes on the longer side
+ * @param start Current longer-side index
+ * @param maximumSkip Maximum unmatched prefix to inspect
+ * @param directScore Current positional score
+ */
+function bestFollowingMatch(
+	target: Node,
+	candidates: readonly LocatedComparisonNode[],
+	start: number,
+	maximumSkip: number,
+	directScore: number,
+) {
+	let bestOffset = 0
+	let bestScore = directScore
+	for (let offset = 1; offset <= maximumSkip && start + offset < candidates.length; offset++) {
+		const score = scoreCompatibleNodes(target, candidates[start + offset]!.node)
+		if (score > bestScore) {
+			bestOffset = offset
+			bestScore = score
+		}
+	}
+	return bestOffset
+}
+
+/**
+ * @param before Earlier node
+ * @param after Later node
+ */
+function scoreCompatibleNodes(before: Node, after: Node) {
+	if (!compatibleNodes(before, after)) {
+		return -1
+	}
+	return before.eq(after) ? 3 : 1 + textSimilarity(before.textContent, after.textContent)
+}
+
+/**
+ * @param before Earlier node
+ * @param after Later node
+ */
+function compatibleNodes(before: Node, after: Node) {
+	return before.type === after.type
+}
+
+/**
+ * Compute the required prefix/non-overlapping-suffix Unicode similarity.
+ *
+ * @param before Earlier text
+ * @param after Later text
+ */
+function textSimilarity(before: string, after: string) {
+	const previous = [...normalizeAlignmentText(before)]
+	const next = [...normalizeAlignmentText(after)]
+	let prefix = 0
+	while (prefix < previous.length && prefix < next.length && previous[prefix] === next[prefix]) {
+		prefix++
+	}
+	let suffix = 0
+	const maximumSuffix = Math.min(previous.length, next.length) - prefix
+	while (suffix < maximumSuffix
+		&& previous[previous.length - suffix - 1] === next[next.length - suffix - 1]) {
+		suffix++
+	}
+	return (prefix + suffix) / Math.max(previous.length, next.length, 1)
+}
+
+/**
+ * @param value Text used only as an alignment hint
+ */
+function normalizeAlignmentText(value: string) {
+	return value.normalize('NFC').replace(/\s+/gu, ' ').trim()
+}
+
+/**
+ * Find the closest coordinate on an absent side of one alignment operation.
+ *
+ * @param steps Ordered alignment operations
+ * @param index Current operation
+ * @param side Missing side
+ * @param start Window start
+ * @param end Window end
+ */
+function missingLocation(
+	steps: AlignmentStep[],
+	index: number,
+	side: 'before' | 'after',
+	start: number,
+	end: number,
+) {
+	let previous: LocatedComparisonNode | null = null
+	for (let next = index + 1; next < steps.length; next++) {
+		const node = steps[next]![side]
+		if (node) {
+			for (let previousIndex = index - 1; previousIndex >= 0; previousIndex--) {
+				previous = steps[previousIndex]![side]
+				if (previous) {
+					break
+				}
+			}
+			return {
+				position: node.from,
+				neighbors: previous ? [previous, node] : [node],
+			}
+		}
+	}
+	for (let previousIndex = index - 1; previousIndex >= 0; previousIndex--) {
+		const node = steps[previousIndex]![side]
+		if (node) {
+			return { position: node.to, neighbors: [node] }
+		}
+	}
+	return { position: Math.min(Math.max(start, 0), end), neighbors: [] }
+}
+
+/**
+ * Compare one structurally compatible pair by category.
+ *
+ * @param builder Comparison state
+ * @param before Earlier node
+ * @param after Later node
+ */
+function comparePairedNodes(
+	builder: ComparisonBuilder,
+	before: LocatedComparisonNode,
+	after: LocatedComparisonNode,
+) {
+	if (before.node.eq(after.node)) {
+		return
+	}
+	if (before.node.isTextblock && after.node.isTextblock) {
+		compareTextblocks(builder, before, after)
+		return
+	}
+	if (before.node.isLeaf || after.node.isLeaf || before.node.isAtom || after.node.isAtom) {
+		emitBlockChange(builder, before, after)
+		return
+	}
+	if (!before.node.sameMarkup(after.node)) {
+		emitMarkupChange(builder, before, after)
+	}
+	compareSiblingNodes(
+		builder,
+		before.children,
+		after.children,
+		before.from + 1,
+		before.to - 1,
+		after.from + 1,
+		after.to - 1,
+		false,
+	)
+}
+
+/**
+ * Compare one textblock through a bounded bare-block ChangeSet.
+ *
+ * @param builder Comparison state
+ * @param before Earlier textblock
+ * @param after Later textblock
+ */
+function compareTextblocks(
+	builder: ComparisonBuilder,
+	before: LocatedComparisonNode,
+	after: LocatedComparisonNode,
+) {
+	const start = before.node.content.findDiffStart(after.node.content)
+	if (start === null) {
+		if (!before.node.sameMarkup(after.node)) {
+			emitMarkupChange(builder, before, after)
+		}
+		return
+	}
+	const diffEnd = before.node.content.findDiffEnd(after.node.content)
+	if (!diffEnd) {
+		emitBlockChange(builder, before, after)
+		return
+	}
+	let { a: endA, b: endB } = diffEnd
+	if (endA < start) {
+		endB += start - endA
+		endA = start
+	}
+	if (endB < start) {
+		endA += start - endB
+		endB = start
+	}
+	if ((endA - start) + (endB - start) > MAX_INLINE_ENVELOPE_SIZE) {
+		emitBlockChange(builder, before, after)
+		return
+	}
+
+	const map = new StepMap([0, before.node.content.size, after.node.content.size])
+	const changes = simplifyChanges(
+		ChangeSet.create(before.node, undefined, semanticTokenEncoder)
+			.addSteps(after.node, [map], null)
+			.changes,
+		after.node,
+	)
+	if (changes.length === 0 || !changes.every((change) => validInlineChange(builder, before, after, change))) {
+		emitBlockChange(builder, before, after)
+		return
+	}
+	if (!before.node.sameMarkup(after.node)) {
+		emitMarkupChange(builder, before, after)
+	}
+	const beforeRoots = originalLocations(builder, 'before', [before])
+	const afterRoots = originalLocations(builder, 'after', [after])
+	for (const change of changes) {
+		pushDescriptor(builder, (sourceOrder) => classifyComparisonDescriptor(
+			builder.originalBefore,
+			builder.originalAfter,
+			{
+				from: before.from + 1 + change.fromA,
+				to: before.from + 1 + change.toA,
+			},
+			{
+				from: after.from + 1 + change.fromB,
+				to: after.from + 1 + change.toB,
+			},
+			beforeRoots,
+			afterRoots,
+			sourceOrder,
+			'inline',
+			{ before: before.path, after: after.path },
+			builder.audit,
+		))
+	}
+}
+
+/**
+ * Validate a local ChangeSet range and its original-document round trip.
+ *
+ * @param builder Comparison state
+ * @param before Earlier textblock
+ * @param after Later textblock
+ * @param change Local ChangeSet range
+ */
+function validInlineChange(
+	builder: ComparisonBuilder,
+	before: LocatedComparisonNode,
+	after: LocatedComparisonNode,
+	change: InlineChangeRange,
+) {
+	if (!validLocalRange(change.fromA, change.toA, before.node.content.size)
+		|| !validLocalRange(change.fromB, change.toB, after.node.content.size)) {
+		return false
+	}
+	const beforeLocal = before.node.textBetween(change.fromA, change.toA, '\n', '\ufffc')
+	const afterLocal = after.node.textBetween(change.fromB, change.toB, '\n', '\ufffc')
+	const beforeAbsolute = comparisonRangeText({
+		from: before.from + 1 + change.fromA,
+		to: before.from + 1 + change.toA,
+	}, [originalLocation(builder, 'before', before)])
+	const afterAbsolute = comparisonRangeText({
+		from: after.from + 1 + change.fromB,
+		to: after.from + 1 + change.toB,
+	}, [originalLocation(builder, 'after', after)])
+	return beforeLocal === beforeAbsolute && afterLocal === afterAbsolute
+}
+
+/**
+ * @param from Range start
+ * @param to Range end
+ * @param maximum Content size
+ */
+function validLocalRange(from: number, to: number, maximum: number) {
+	return Number.isInteger(from) && Number.isInteger(to) && from >= 0 && to >= from && to <= maximum
+}
+
+/**
+ * Emit a direct node-markup descriptor.
+ *
+ * @param builder Comparison state
+ * @param before Earlier node
+ * @param after Later node
+ */
+function emitMarkupChange(
+	builder: ComparisonBuilder,
+	before: LocatedComparisonNode,
+	after: LocatedComparisonNode,
+) {
+	const beforeRoot = originalLocation(builder, 'before', before)
+	const afterRoot = originalLocation(builder, 'after', after)
+	pushDescriptor(builder, (sourceOrder) => classifyNodeMarkupDescriptor(
+		builder.originalBefore,
+		builder.originalAfter,
+		rangeFor(before),
+		rangeFor(after),
+		beforeRoot.node,
+		afterRoot.node,
+		[beforeRoot],
+		[afterRoot],
+		sourceOrder,
+		builder.audit,
+	))
+}
+
+/**
+ * Emit one conservative whole-node insert, delete, or replacement.
+ *
+ * @param builder Comparison state
+ * @param before Earlier node, if present
+ * @param after Later node, if present
+ * @param absentPosition Coordinate on the absent side
+ * @param absentNeighbors Adjacent nodes on the absent side
+ */
+function emitBlockChange(
+	builder: ComparisonBuilder,
+	before: LocatedComparisonNode | null,
+	after: LocatedComparisonNode | null,
+	absentPosition = 0,
+	absentNeighbors: readonly LocatedComparisonNode[] = [],
+) {
+	const beforeRange = before ? rangeFor(before) : emptyRange(absentPosition)
+	const afterRange = after ? rangeFor(after) : emptyRange(absentPosition)
+	const beforeRoots = originalLocations(builder, 'before', before ? [before] : absentNeighbors)
+	const afterRoots = originalLocations(builder, 'after', after ? [after] : absentNeighbors)
+	pushDescriptor(builder, (sourceOrder) => classifyComparisonDescriptor(
+		builder.originalBefore,
+		builder.originalAfter,
+		beforeRange,
+		afterRange,
+		beforeRoots,
+		afterRoots,
+		sourceOrder,
+		'block',
+		undefined,
+		builder.audit,
+	))
+}
+
+/**
+ * Convert reserved unique exact pairs into conservative grouped move descriptors.
+ *
+ * @param builder Comparison state
+ */
+function emitReservedMoves(builder: ComparisonBuilder) {
+	const { groups, rejected } = confirmReservedExactMoves(
+		builder.comparisonBefore,
+		builder.comparisonAfter,
+		builder.reservedMoves,
+	)
+	for (const pair of rejected) {
+		emitBlockChange(builder, pair.before, null, pair.after.from, [pair.after])
+		emitBlockChange(builder, null, pair.after, pair.before.from, [pair.before])
+	}
+
+	for (const group of groups) {
+		const first = group[0]!
+		const last = group.at(-1)!
+		const beforeRoots = originalLocations(builder, 'before', group.map(({ before }) => before))
+		const afterRoots = originalLocations(builder, 'after', group.map(({ after }) => after))
+		pushDescriptor(builder, (sourceOrder) => {
+			const descriptor = classifyComparisonDescriptor(
+				builder.originalBefore,
+				builder.originalAfter,
+				{ from: first.before.from, to: last.before.to },
+				{ from: first.after.from, to: last.after.to },
+				beforeRoots,
+				afterRoots,
+				sourceOrder,
+				'block',
+				undefined,
+				builder.audit,
+			)
+			return {
+				...descriptor,
+				operation: 'move',
+				detail: 'block',
+				facets: ['structure'],
+				signals: [{ type: 'node' }],
+			}
+		})
+	}
+}
+
+/**
+ * Emit one descriptor through the shared model limit.
+ *
+ * @param builder Mutable comparison state
+ * @param create Descriptor factory
+ */
+function pushDescriptor(
+	builder: ComparisonBuilder,
+	create: (sourceOrder: number) => ComparisonDescriptor | null,
+) {
+	if (builder.descriptors.length >= builder.maximumDescriptors) {
+		throw new ComparisonModelLimitError()
+	}
+	const descriptor = create(builder.descriptors.length)
+	if (descriptor) {
+		builder.descriptors.push(descriptor)
+	}
+}
+
+/**
+ * Assign stable source order and IDs after moves join recursively emitted changes.
+ *
+ * @param descriptors Provisional descriptors
+ */
+function finalizeDescriptors(descriptors: ComparisonDescriptor[]) {
+	return descriptors
+		.toSorted((a, b) => a.after.from - b.after.from
+			|| a.before.from - b.before.from
+			|| a.after.to - b.after.to
+			|| a.before.to - b.before.to
+			|| compareCodeUnits(a.operation, b.operation))
+		.map((descriptor, sourceOrder) => ({
+			...descriptor,
+			id: `${descriptor.operation === 'move' ? 'move' : 'change'}-${sourceOrder.toString(36)}`,
+			sourceOrder,
+		}))
+}
+
+/**
+ * Resolve located nodes against an original document.
+ *
+ * @param builder Mutable comparison state
+ * @param side Document side
+ * @param locations Located document nodes
+ */
+function originalLocations(
+	builder: ComparisonBuilder,
+	side: 'before' | 'after',
+	locations: readonly LocatedComparisonNode[],
+) {
+	return locations.map((location) => originalLocation(builder, side, location))
+}
+
+/**
+ * Resolve one located node against an original document.
+ *
+ * @param builder Mutable comparison state
+ * @param side Document side
+ * @param location Located document node
+ */
+function originalLocation(
+	builder: ComparisonBuilder,
+	side: 'before' | 'after',
+	location: LocatedComparisonNode,
+) {
+	return (side === 'before' ? builder.originalBeforeIndex : builder.originalAfterIndex)
+		.nodeAtPath(location.path)
+}
+
+/**
+ * @param node Located node
+ */
+function rangeFor(node: LocatedComparisonNode): ComparisonRange {
+	return { from: node.from, to: node.to }
+}
+
+/**
+ * @param position Empty-side coordinate
+ */
+function emptyRange(position: number): ComparisonRange {
+	return { from: position, to: position }
+}
+
+/**
+ * @param node Node to fingerprint
+ */
+function fingerprintNode(node: Node) {
+	const cached = fingerprintCache.get(node)
+	if (cached !== undefined) {
+		return cached
+	}
+	const fingerprint = stableSerialize(node.toJSON())
+	fingerprintCache.set(node, fingerprint)
+	return fingerprint
+}

--- a/src/comparison/markdownComparison.ts
+++ b/src/comparison/markdownComparison.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+
+import { createHierarchicalMarkdownComparisonModel } from './hierarchicalMarkdownComparisonModel.ts'
+
+export { ComparisonModelLimitError } from './hierarchicalMarkdownComparisonModel.ts'
+export type * from './markdownComparisonTypes.ts'
+
+/**
+ * Compare complete documents through the bounded hierarchical implementation.
+ *
+ * @param before Earlier document
+ * @param after Later document
+ */
+export function createMarkdownComparisonModel(before: Node, after: Node) {
+	return createHierarchicalMarkdownComparisonModel(before, after)
+}

--- a/src/comparison/markdownComparisonClassification.ts
+++ b/src/comparison/markdownComparisonClassification.ts
@@ -1,0 +1,866 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Mark, Node } from '@tiptap/pm/model'
+import type {
+	ComparisonNodeSearchAudit,
+	LocatedComparisonNode,
+} from './comparisonDocumentIndex.ts'
+import type {
+	ComparisonAttributeCode,
+	ComparisonContext,
+	ComparisonContextCode,
+	ComparisonContextLocation,
+	ComparisonDescriptor,
+	ComparisonFacet,
+	ComparisonMarkCode,
+	ComparisonOperation,
+	ComparisonPreviewAtom,
+	ComparisonRange,
+	ComparisonSignal,
+} from './markdownComparisonTypes.ts'
+
+import { getTextDirection } from '../extensions/TextDirection.ts'
+import {
+	comparisonRangeText,
+	findComparisonNodes,
+} from './comparisonDocumentIndex.ts'
+
+interface AttributeRecord {
+	key: string
+	nodeName: string
+	attribute: string
+	value: unknown
+	textContent: string
+}
+
+interface ExcludedAttributePaths {
+	before: readonly number[]
+	after: readonly number[]
+}
+
+const marksCache = new WeakMap<readonly Mark[], string>()
+const nodeShapeCache = new WeakMap<Node, string>()
+const graphemeSegmenter = typeof Intl.Segmenter === 'function'
+	? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+	: null
+
+const contextCodes: Record<string, ComparisonContextCode> = {
+	frontMatter: 'front-matter',
+	paragraph: 'paragraph',
+	heading: 'heading',
+	bulletList: 'list-item',
+	orderedList: 'list-item',
+	taskList: 'list-item',
+	listItem: 'list-item',
+	taskItem: 'task',
+	tableCell: 'table-cell',
+	tableHeader: 'table-cell',
+	codeBlock: 'code-block',
+	blockquote: 'quote',
+	callout: 'callout',
+	details: 'details',
+	detailsContent: 'details',
+	detailsSummary: 'details',
+	footnotes: 'footnote',
+	footnote: 'footnote',
+	footnoteReference: 'footnote-reference',
+	image: 'image',
+	imageInline: 'image',
+	mention: 'mention',
+	inlineMath: 'mathematics',
+	blockMath: 'mathematics',
+	preview: 'preview',
+}
+
+const contextPriority: Record<ComparisonContextCode, number> = {
+	'footnote-reference': 100,
+	image: 95,
+	mention: 95,
+	mathematics: 95,
+	preview: 95,
+	footnote: 90,
+	'table-cell': 85,
+	task: 80,
+	'list-item': 75,
+	'front-matter': 70,
+	'code-block': 70,
+	callout: 65,
+	details: 65,
+	quote: 60,
+	heading: 50,
+	paragraph: 40,
+	unknown: 0,
+}
+
+const markCodes: Record<string, ComparisonMarkCode> = {
+	strong: 'bold',
+	em: 'italic',
+	strike: 'strike',
+	highlight: 'highlight',
+	underline: 'underline',
+	code: 'inline-code',
+}
+
+const meaningfulAttributes: Record<string, Record<string, ComparisonAttributeCode>> = {
+	heading: { level: 'heading-level' },
+	orderedList: { start: 'list-start' },
+	taskItem: { checked: 'task-state' },
+	codeBlock: { language: 'code-language' },
+	image: { src: 'image-target', alt: 'image-alt' },
+	imageInline: { src: 'image-target', alt: 'image-alt' },
+	mention: { id: 'mention-identity', label: 'mention-identity' },
+	inlineMath: { latex: 'mathematics' },
+	blockMath: { latex: 'mathematics' },
+	preview: { href: 'preview-target' },
+	footnoteReference: { referenceId: 'footnote-reference' },
+	footnote: { referenceId: 'footnote-reference' },
+	callout: { type: 'callout-type' },
+	details: { openDetails: 'details-state' },
+	tableCell: { align: 'table-alignment', colspan: 'table-span', rowspan: 'table-span' },
+	tableHeader: { align: 'table-alignment', colspan: 'table-span', rowspan: 'table-span' },
+}
+
+/**
+ * Deterministically encode values found in ProseMirror attributes.
+ *
+ * @param value Attribute value
+ */
+export function stableSerialize(value: unknown): string {
+	if (value === null || typeof value !== 'object') {
+		return JSON.stringify(value) ?? String(value)
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map(stableSerialize).join(',')}]`
+	}
+	return `{${Object.entries(value)
+		.toSorted(([a], [b]) => compareCodeUnits(a, b))
+		.map(([key, child]) => `${JSON.stringify(key)}:${stableSerialize(child)}`)
+		.join(',')}}`
+}
+
+/**
+ * Compare strings by UTF-16 code units without locale-dependent collation.
+ *
+ * @param a Left value
+ * @param b Right value
+ */
+export function compareCodeUnits(a: string, b: string) {
+	return a < b ? -1 : a > b ? 1 : 0
+}
+
+/**
+ * Encode a mark set independent of mark order.
+ *
+ * @param marks ProseMirror marks
+ */
+function encodeMarks(marks: readonly Mark[]) {
+	const cached = marksCache.get(marks)
+	if (cached !== undefined) {
+		return cached
+	}
+	const encoded = marks
+		.map((mark) => `${mark.type.name}:${stableSerialize(mark.attrs)}`)
+		.toSorted()
+		.join('|')
+	marksCache.set(marks, encoded)
+	return encoded
+}
+
+/** Token encoder that treats formatting and all schema attributes as semantics. */
+export const semanticTokenEncoder = {
+	encodeCharacter(character: number, marks: readonly Mark[]) {
+		return `character:${character}:${encodeMarks(marks)}`
+	},
+	encodeNodeStart(node: Node) {
+		return `node-start:${node.type.name}:${stableSerialize(node.attrs)}:${encodeMarks(node.marks)}`
+	},
+	encodeNodeEnd(node: Node) {
+		return `node-end:${node.type.name}`
+	},
+	compareTokens(a: string, b: string) {
+		return a === b
+	},
+}
+
+/**
+ * Classify one existing ChangeSet range without recomputing it.
+ *
+ * @param beforeDoc Earlier complete document
+ * @param afterDoc Later complete document
+ * @param before Earlier range
+ * @param after Later range
+ * @param beforeRoots Known earlier range roots
+ * @param afterRoots Known later range roots
+ * @param sourceOrder Stable provisional order
+ * @param detail Inline or whole-block detail
+ * @param excludedAttributePaths Root paths whose attributes were classified separately
+ * @param audit Optional operation counter for structural regression tests
+ */
+export function classifyComparisonDescriptor(
+	beforeDoc: Node,
+	afterDoc: Node,
+	before: ComparisonRange,
+	after: ComparisonRange,
+	beforeRoots: readonly LocatedComparisonNode[],
+	afterRoots: readonly LocatedComparisonNode[],
+	sourceOrder: number,
+	detail: ComparisonDescriptor['detail'] = 'inline',
+	excludedAttributePaths?: ExcludedAttributePaths,
+	audit?: ComparisonNodeSearchAudit,
+): ComparisonDescriptor {
+	const boundedBefore = boundedRange(before, beforeDoc.content.size)
+	const boundedAfter = boundedRange(after, afterDoc.content.size)
+	const beforeNodes = findComparisonNodes(boundedBefore, beforeRoots, audit)
+	const afterNodes = findComparisonNodes(boundedAfter, afterRoots, audit)
+	const context: ComparisonContext = {
+		before: resolveContext(beforeNodes),
+		after: resolveContext(afterNodes),
+	}
+	const facets = new Set<ComparisonFacet>()
+	const signals: ComparisonSignal[] = []
+	const beforeText = comparisonRangeText(boundedBefore, beforeRoots)
+	const afterText = comparisonRangeText(boundedAfter, afterRoots)
+
+	if (beforeText !== afterText) {
+		facets.add('text')
+	}
+
+	classifyMarks(beforeDoc, afterDoc, boundedBefore, boundedAfter, beforeNodes, afterNodes, facets, signals)
+	classifyNodes(beforeNodes, afterNodes, boundedBefore, boundedAfter, facets, signals, audit)
+	classifyAttributes(
+		excludePath(beforeNodes, excludedAttributePaths?.before),
+		excludePath(afterNodes, excludedAttributePaths?.after),
+		facets,
+		signals,
+	)
+
+	if (facets.size === 0) {
+		facets.add('unknown')
+	}
+
+	return {
+		id: `change-${sourceOrder.toString(36)}`,
+		sourceOrder,
+		operation: operationFor(before, after),
+		detail,
+		facets: orderedFacets(facets),
+		before: boundedBefore,
+		after: boundedAfter,
+		context,
+		preview: {
+			before: previewAtom(boundedBefore, beforeText, beforeNodes),
+			after: previewAtom(boundedAfter, afterText, afterNodes),
+		},
+		signals: deduplicateSignals(signals),
+	}
+}
+
+/**
+ * Classify direct node markup without reclassifying changed descendant content.
+ *
+ * @param beforeDoc Earlier complete document
+ * @param afterDoc Later complete document
+ * @param before Earlier node range
+ * @param after Later node range
+ * @param beforeNode Earlier paired node
+ * @param afterNode Later paired node
+ * @param beforeRoots Known earlier range roots
+ * @param afterRoots Known later range roots
+ * @param sourceOrder Stable provisional order
+ * @param audit Optional operation counter for structural regression tests
+ */
+export function classifyNodeMarkupDescriptor(
+	beforeDoc: Node,
+	afterDoc: Node,
+	before: ComparisonRange,
+	after: ComparisonRange,
+	beforeNode: Node,
+	afterNode: Node,
+	beforeRoots: readonly LocatedComparisonNode[],
+	afterRoots: readonly LocatedComparisonNode[],
+	sourceOrder: number,
+	audit?: ComparisonNodeSearchAudit,
+): ComparisonDescriptor | null {
+	const boundedBefore = boundedRange(before, beforeDoc.content.size)
+	const boundedAfter = boundedRange(after, afterDoc.content.size)
+	const beforeNodes = findComparisonNodes(boundedBefore, beforeRoots, audit)
+	const afterNodes = findComparisonNodes(boundedAfter, afterRoots, audit)
+	const facets = new Set<ComparisonFacet>()
+	const signals: ComparisonSignal[] = []
+	classifyDirectAttributes(beforeNode, afterNode, facets, signals)
+	classifyDirectMarks(beforeNode, afterNode, facets, signals)
+	if (beforeNode.type.name !== afterNode.type.name) {
+		facets.add('structure')
+		signals.push({ type: 'node' })
+	}
+	if (facets.size === 0) {
+		return null
+	}
+	return {
+		id: `change-${sourceOrder.toString(36)}`,
+		sourceOrder,
+		operation: 'replace',
+		detail: 'block',
+		facets: orderedFacets(facets),
+		before: boundedBefore,
+		after: boundedAfter,
+		context: {
+			before: resolveContext(beforeNodes),
+			after: resolveContext(afterNodes),
+		},
+		preview: {
+			before: previewAtom(boundedBefore, comparisonRangeText(boundedBefore, beforeRoots), beforeNodes),
+			after: previewAtom(boundedAfter, comparisonRangeText(boundedAfter, afterRoots), afterNodes),
+		},
+		signals: deduplicateSignals(signals),
+	}
+}
+
+/**
+ * Resolve the comparison operation from both ranges.
+ *
+ * @param before Earlier comparison range
+ * @param after Later comparison range
+ */
+function operationFor(before: ComparisonRange, after: ComparisonRange): ComparisonOperation {
+	if (before.from === before.to && after.from !== after.to) {
+		return 'insert'
+	}
+	if (after.from === after.to && before.from !== before.to) {
+		return 'delete'
+	}
+	return 'replace'
+}
+
+/**
+ * Classify mark differences across touched nodes.
+ *
+ * @param beforeDoc Earlier complete document
+ * @param afterDoc Later complete document
+ * @param before Earlier range
+ * @param after Later range
+ * @param beforeNodes Earlier touched nodes
+ * @param afterNodes Later touched nodes
+ * @param facets Mutable descriptor facets
+ * @param signals Mutable descriptor signals
+ */
+function classifyMarks(
+	beforeDoc: Node,
+	afterDoc: Node,
+	before: ComparisonRange,
+	after: ComparisonRange,
+	beforeNodes: readonly LocatedComparisonNode[],
+	afterNodes: readonly LocatedComparisonNode[],
+	facets: Set<ComparisonFacet>,
+	signals: ComparisonSignal[],
+) {
+	const beforeMarks = collectMarks(beforeDoc, before, beforeNodes)
+	const afterMarks = collectMarks(afterDoc, after, afterNodes)
+	const names = new Set([...beforeMarks.keys(), ...afterMarks.keys()])
+	for (const name of [...names].toSorted()) {
+		const previous = beforeMarks.get(name)
+		const next = afterMarks.get(name)
+		if (stableSerialize(previous) === stableSerialize(next)) {
+			continue
+		}
+		const change = previous === undefined ? 'added' : next === undefined ? 'removed' : 'changed'
+		if (name === 'link') {
+			facets.add('attribute')
+			signals.push({
+				type: 'attribute',
+				attribute: previous === undefined || next === undefined ? 'link' : 'link-target',
+				change,
+			})
+		} else if (markCodes[name]) {
+			facets.add('formatting')
+			signals.push({ type: 'mark', mark: markCodes[name], change })
+		} else {
+			facets.add('unknown')
+		}
+	}
+}
+
+/**
+ * Classify structural differences across touched nodes.
+ *
+ * @param beforeNodes Earlier touched nodes
+ * @param afterNodes Later touched nodes
+ * @param before Earlier changed range
+ * @param after Later changed range
+ * @param facets Mutable descriptor facets
+ * @param signals Mutable descriptor signals
+ * @param audit Optional operation counter for structural regression tests
+ */
+function classifyNodes(
+	beforeNodes: readonly LocatedComparisonNode[],
+	afterNodes: readonly LocatedComparisonNode[],
+	before: ComparisonRange,
+	after: ComparisonRange,
+	facets: Set<ComparisonFacet>,
+	signals: ComparisonSignal[],
+	audit?: ComparisonNodeSearchAudit,
+) {
+	const beforeShape = structuralShape(beforeNodes, before, audit)
+	const afterShape = structuralShape(afterNodes, after, audit)
+	if (beforeShape === afterShape) {
+		return
+	}
+	// A text split caused only by marks is intentionally absent from structuralShape.
+	facets.add('structure')
+	signals.push({ type: 'node' })
+}
+
+/**
+ * Classify attribute differences across touched nodes.
+ *
+ * @param beforeNodes Earlier touched nodes
+ * @param afterNodes Later touched nodes
+ * @param facets Mutable descriptor facets
+ * @param signals Mutable descriptor signals
+ */
+function classifyAttributes(
+	beforeNodes: readonly LocatedComparisonNode[],
+	afterNodes: readonly LocatedComparisonNode[],
+	facets: Set<ComparisonFacet>,
+	signals: ComparisonSignal[],
+) {
+	const previous = collectAttributes(beforeNodes)
+	const next = collectAttributes(afterNodes)
+	const keys = new Set([...previous.keys()].filter((key) => next.has(key)))
+	for (const key of [...keys].toSorted()) {
+		const before = previous.get(key)!
+		const after = next.get(key)!
+		if (stableSerialize(before?.value) === stableSerialize(after?.value)) {
+			continue
+		}
+		// Do not turn a node replacement into an arbitrary attribute comparison.
+		if (before.nodeName !== after.nodeName) {
+			continue
+		}
+		const record = after
+		// Ignore a neutral transition when both values match content inference.
+		if (record.attribute === 'dir' && isInferredDirectionTransition(
+			before.value,
+			after.value,
+			before.textContent,
+			after.textContent,
+		)) {
+			continue
+		}
+		const code = record.attribute === 'dir'
+			? 'text-direction'
+			: meaningfulAttributes[record.nodeName]?.[record.attribute]
+		facets.add('attribute')
+		if (!code) {
+			facets.add('unknown')
+		}
+		signals.push({
+			type: 'attribute',
+			attribute: code ?? 'unknown-attribute',
+			change: 'changed',
+		})
+	}
+}
+
+/**
+ * @param before Earlier paired node
+ * @param after Later paired node
+ * @param facets Descriptor facets
+ * @param signals Descriptor signals
+ */
+function classifyDirectAttributes(
+	before: Node,
+	after: Node,
+	facets: Set<ComparisonFacet>,
+	signals: ComparisonSignal[],
+) {
+	const names = new Set([...Object.keys(before.attrs), ...Object.keys(after.attrs)])
+	for (const attribute of [...names].toSorted()) {
+		const previous = before.attrs[attribute]
+		const next = after.attrs[attribute]
+		if (stableSerialize(previous) === stableSerialize(next)) {
+			continue
+		}
+		if (attribute === 'dir' && isInferredDirectionTransition(
+			previous,
+			next,
+			before.textContent,
+			after.textContent,
+		)) {
+			continue
+		}
+		const code = attribute === 'dir'
+			? 'text-direction'
+			: meaningfulAttributes[after.type.name]?.[attribute]
+		facets.add('attribute')
+		if (!code) {
+			facets.add('unknown')
+		}
+		signals.push({
+			type: 'attribute',
+			attribute: code ?? 'unknown-attribute',
+			change: previous === undefined ? 'added' : next === undefined ? 'removed' : 'changed',
+		})
+	}
+}
+
+/**
+ * @param before Earlier paired node
+ * @param after Later paired node
+ * @param facets Descriptor facets
+ * @param signals Descriptor signals
+ */
+function classifyDirectMarks(
+	before: Node,
+	after: Node,
+	facets: Set<ComparisonFacet>,
+	signals: ComparisonSignal[],
+) {
+	const previous = new Map(before.marks.map((mark) => [mark.type.name, stableSerialize(mark.attrs)]))
+	const next = new Map(after.marks.map((mark) => [mark.type.name, stableSerialize(mark.attrs)]))
+	const names = new Set([...previous.keys(), ...next.keys()])
+	for (const name of [...names].toSorted()) {
+		if (previous.get(name) === next.get(name)) {
+			continue
+		}
+		const change = !previous.has(name) ? 'added' : !next.has(name) ? 'removed' : 'changed'
+		if (name === 'link') {
+			facets.add('attribute')
+			signals.push({ type: 'attribute', attribute: 'link-target', change })
+		} else if (markCodes[name]) {
+			facets.add('formatting')
+			signals.push({ type: 'mark', mark: markCodes[name], change })
+		} else {
+			facets.add('unknown')
+		}
+	}
+}
+
+/**
+ * Collect marks that intersect a changed range.
+ *
+ * @param doc Complete document
+ * @param range Changed range
+ * @param nodes Touched nodes
+ */
+function collectMarks(
+	doc: Node,
+	range: ComparisonRange,
+	nodes: readonly LocatedComparisonNode[],
+) {
+	const marks = new Map<string, string[]>()
+	const add = (mark: Mark) => {
+		const values = marks.get(mark.type.name) ?? []
+		const encoded = stableSerialize(mark.attrs)
+		if (!values.includes(encoded)) {
+			values.push(encoded)
+			values.sort()
+		}
+		marks.set(mark.type.name, values)
+	}
+	if (range.from === range.to) {
+		for (const mark of doc.resolve(range.from).marks()) {
+			add(mark)
+		}
+	} else {
+		for (const { node } of nodes) {
+			for (const mark of node.marks) {
+				add(mark)
+			}
+		}
+	}
+	return marks
+}
+
+/**
+ * @param nodes Located nodes
+ * @param path Exact path to exclude
+ */
+function excludePath(nodes: readonly LocatedComparisonNode[], path: readonly number[] | undefined) {
+	if (!path) {
+		return nodes
+	}
+	return nodes.filter((node) => node.path.length !== path.length
+		|| node.path.some((index, depth) => index !== path[depth]))
+}
+
+/**
+ * Resolve the strongest semantic context for touched nodes.
+ *
+ * @param nodes Located document nodes
+ */
+function resolveContext(nodes: readonly LocatedComparisonNode[]): ComparisonContextLocation | null {
+	const candidate = nodes
+		.filter(({ node }) => contextCodes[node.type.name] !== undefined)
+		.toSorted(compareContextCandidates)[0]
+	if (!candidate) {
+		return nodes[0]
+			? {
+					code: 'unknown',
+					path: nodes[0].path,
+					from: nodes[0].from,
+					to: nodes[0].to,
+				}
+			: null
+	}
+	return {
+		code: contextCodes[candidate.node.type.name],
+		path: candidate.path,
+		from: candidate.from,
+		to: candidate.to,
+	}
+}
+
+/**
+ * Encode the top-level structural shape of touched nodes.
+ *
+ * @param nodes Located document nodes
+ * @param range Changed range
+ * @param audit Optional operation counter for structural regression tests
+ */
+function structuralShape(
+	nodes: readonly LocatedComparisonNode[],
+	range: ComparisonRange,
+	audit?: ComparisonNodeSearchAudit,
+) {
+	const contained = nodes.filter(({ node, from, to }) => !node.isText
+		&& range.from <= from
+		&& range.to >= to)
+	const containedNodes = new Set(contained)
+	const roots = contained.filter(({ parent }) => !parent || !containedNodes.has(parent))
+	return roots.map(({ node }) => nodeShape(node, audit)).join('|')
+}
+
+/**
+ * Identify a direction transition consistent with parsed-content inference.
+ *
+ * @param before Earlier direction
+ * @param after Later direction
+ * @param beforeText Earlier node text
+ * @param afterText Later node text
+ */
+function isInferredDirectionTransition(
+	before: unknown,
+	after: unknown,
+	beforeText: string,
+	afterText: string,
+) {
+	return (!before || !after)
+		&& beforeText !== afterText
+		&& before === getTextDirection(beforeText)
+		&& after === getTextDirection(afterText)
+}
+
+/**
+ * Encode and cache one immutable node shape.
+ *
+ * @param node Immutable ProseMirror node
+ * @param audit Optional operation counter for structural regression tests
+ */
+function nodeShape(node: Node, audit?: ComparisonNodeSearchAudit): string {
+	const cached = nodeShapeCache.get(node)
+	if (cached !== undefined) {
+		return cached
+	}
+	if (node.isText) {
+		return ''
+	}
+	if (audit) {
+		audit.examinedNodes++
+	}
+	const children: string[] = []
+	node.forEach((child) => {
+		const shape = nodeShape(child, audit)
+		if (shape && children.at(-1) !== shape) {
+			children.push(shape)
+		}
+	})
+	const shape = `${node.type.name}(${children.join(',')})`
+	nodeShapeCache.set(node, shape)
+	return shape
+}
+
+/**
+ * Collect stable attribute records from touched nodes.
+ *
+ * @param nodes Located document nodes
+ */
+function collectAttributes(nodes: readonly LocatedComparisonNode[]) {
+	const records = new Map<string, AttributeRecord>()
+	const topLevelIndices = [...new Set(nodes.map(({ path }) => path[0]).filter((index): index is number => index !== undefined))]
+		.toSorted((a, b) => a - b)
+	const topLevelOrder = new Map(topLevelIndices.map((index, order) => [index, order]))
+	for (const { node, path } of nodes) {
+		if (node.isText) {
+			continue
+		}
+		const relativePath = path.length
+			? [topLevelOrder.get(path[0]!) ?? 0, ...path.slice(1)]
+			: []
+		for (const [attribute, value] of Object.entries(node.attrs)) {
+			const key = `${relativePath.join('.')}:${node.type.name}:${attribute}`
+			records.set(key, {
+				key,
+				nodeName: node.type.name,
+				attribute,
+				value,
+				textContent: node.textContent,
+			})
+		}
+	}
+	return records
+}
+
+/**
+ * Build a short preview for a changed range.
+ *
+ * @param range Changed document range
+ * @param rangeText Changed range text
+ * @param nodes Located document nodes
+ */
+function previewAtom(
+	range: ComparisonRange,
+	rangeText: string,
+	nodes: readonly LocatedComparisonNode[],
+): ComparisonPreviewAtom | null {
+	if (range.from === range.to) {
+		return null
+	}
+	const text = normalizePreview(rangeText.replaceAll('\ufffc', ''))
+	if (text) {
+		return { kind: 'text', text: truncateGraphemes(text, 96) }
+	}
+	const contextText = normalizePreview(resolveContextNode(nodes)?.node.textContent ?? '')
+	if (contextText) {
+		return { kind: 'text', text: truncateGraphemes(contextText, 96) }
+	}
+	const nodeName = resolveContextNode(nodes)?.node.type.name
+	const node = nodeName === 'frontMatter'
+		? 'front-matter'
+		: nodeName === 'image' || nodeName === 'imageInline'
+			? 'image'
+			: nodeName === 'mention'
+				? 'mention'
+				: nodeName === 'inlineMath' || nodeName === 'blockMath'
+					? 'mathematics'
+					: nodeName === 'footnoteReference'
+						? 'footnote-reference'
+						: nodeName === 'horizontalRule'
+							? 'horizontal-rule'
+							: 'changed-content'
+	return { kind: 'node', node }
+}
+
+/**
+ * Resolve the strongest context node.
+ *
+ * @param nodes Located document nodes
+ */
+function resolveContextNode(nodes: readonly LocatedComparisonNode[]) {
+	return nodes
+		.filter(({ node }) => contextCodes[node.type.name] !== undefined)
+		.toSorted(compareContextCandidates)[0]
+		?? nodes[0]
+}
+
+/**
+ * Order context nodes by semantic priority.
+ *
+ * @param a First context candidate
+ * @param b Second context candidate
+ */
+function compareContextCandidates(a: LocatedComparisonNode, b: LocatedComparisonNode) {
+	const aCode = contextCodes[a.node.type.name]
+	const bCode = contextCodes[b.node.type.name]
+	return contextPriority[bCode] - contextPriority[aCode]
+		|| b.path.length - a.path.length
+		|| a.from - b.from
+}
+
+/**
+ * Normalize whitespace in preview text.
+ *
+ * @param value Preview text
+ */
+function normalizePreview(value: string) {
+	return value.replace(/\s+/gu, ' ').trim()
+}
+
+/**
+ * Truncate text without splitting grapheme clusters.
+ *
+ * @param value Text to truncate
+ * @param maximum Maximum grapheme count
+ */
+export function truncateGraphemes(value: string, maximum: number) {
+	let count = 0
+	let truncated = ''
+	const segments = graphemeSegmenter?.segment(value) ?? value
+	for (const item of segments) {
+		if (count++ === maximum) {
+			return `${truncated}…`
+		}
+		truncated += typeof item === 'string' ? item : item.segment
+	}
+	return value
+}
+
+/**
+ * Return descriptor facets in presentation order.
+ *
+ * @param facets Mutable descriptor facets
+ */
+function orderedFacets(facets: Set<ComparisonFacet>) {
+	const order: ComparisonFacet[] = ['text', 'formatting', 'attribute', 'structure', 'unknown']
+	return order.filter((facet) => facets.has(facet))
+}
+
+/**
+ * Deduplicate and deterministically order signals.
+ *
+ * @param signals Mutable descriptor signals
+ */
+function deduplicateSignals(signals: ComparisonSignal[]) {
+	const byValue = new Map(signals.map((signal) => [stableSerialize(signal), signal]))
+	return [...byValue.values()].toSorted((a, b) => compareCodeUnits(stableSerialize(a), stableSerialize(b)))
+}
+
+/**
+ * Clamp a comparison range to a document size.
+ *
+ * @param range Changed document range
+ * @param maximum Document content size
+ */
+function boundedRange(range: ComparisonRange, maximum: number) {
+	const from = clamp(range.from, 0, maximum)
+	return { from, to: clamp(range.to, from, maximum) }
+}
+
+/**
+ * Constrain a number to an inclusive range.
+ *
+ * @param value Input number
+ * @param minimum Inclusive lower bound
+ * @param maximum Inclusive upper bound
+ */
+function clamp(value: number, minimum: number, maximum: number) {
+	return Math.min(Math.max(value, minimum), maximum)
+}
+
+/**
+ * Recursively freeze a comparison value.
+ *
+ * @param value Comparison value
+ */
+export function deepFreeze<T>(value: T): T {
+	if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+		Object.freeze(value)
+		for (const child of Object.values(value)) {
+			deepFreeze(child)
+		}
+	}
+	return value
+}

--- a/src/comparison/markdownComparisonMoves.ts
+++ b/src/comparison/markdownComparisonMoves.ts
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { LocatedComparisonNode } from './comparisonDocumentIndex.ts'
+
+import { stableSerialize } from './markdownComparisonClassification.ts'
+
+export type ReservedExactMoveNode = LocatedComparisonNode
+
+export interface ReservedExactMovePair {
+	before: ReservedExactMoveNode
+	after: ReservedExactMoveNode
+	fingerprint: string
+}
+
+interface TopLevelBlock {
+	index: number
+	node: Node
+	fingerprint: string
+}
+
+/**
+ * Reconfirm and group top-level exact pairs reserved by hierarchical alignment.
+ *
+ * @param before Earlier normalized document
+ * @param after Later normalized document
+ * @param candidates Reserved exact pairs
+ */
+export function confirmReservedExactMoves(
+	before: Node,
+	after: Node,
+	candidates: readonly ReservedExactMovePair[],
+) {
+	if (candidates.length === 0) {
+		return { groups: [], rejected: [] }
+	}
+	const beforeBlocks = topLevelBlocks(before)
+	const afterBlocks = topLevelBlocks(after)
+	const beforeCounts = documentFingerprintCounts(before)
+	const afterCounts = documentFingerprintCounts(after)
+	const confirmed: ReservedExactMovePair[] = []
+	const rejected: ReservedExactMovePair[] = []
+
+	for (const candidate of candidates) {
+		const beforeBlock = beforeBlocks[candidate.before.index]
+		const afterBlock = afterBlocks[candidate.after.index]
+		const valid = beforeBlock?.fingerprint === candidate.fingerprint
+			&& afterBlock?.fingerprint === candidate.fingerprint
+			&& beforeCounts.get(candidate.fingerprint) === 1
+			&& afterCounts.get(candidate.fingerprint) === 1
+			&& beforeBlock.node.eq(afterBlock.node)
+		if (valid) {
+			confirmed.push(candidate)
+		} else {
+			rejected.push(candidate)
+		}
+	}
+
+	const groups: ReservedExactMovePair[][] = []
+	for (const pair of confirmed.toSorted((a, b) => (
+		a.before.index - b.before.index || a.after.index - b.after.index
+	))) {
+		const group = groups.at(-1)
+		const previous = group?.at(-1)
+		if (group && previous
+			&& pair.before.index === previous.before.index + 1
+			&& pair.after.index === previous.after.index + 1) {
+			group.push(pair)
+		} else {
+			groups.push([pair])
+		}
+	}
+	return { groups, rejected }
+}
+
+/** @param doc Complete document */
+function topLevelBlocks(doc: Node) {
+	const blocks: TopLevelBlock[] = []
+	doc.forEach((node, _from, index) => {
+		blocks.push({
+			index,
+			node,
+			fingerprint: canonicalFingerprint(node),
+		})
+	})
+	return blocks
+}
+
+/** @param doc Complete document */
+function documentFingerprintCounts(doc: Node) {
+	const counts = new Map<string, number>()
+	doc.descendants((node) => {
+		const fingerprint = canonicalFingerprint(node)
+		counts.set(fingerprint, (counts.get(fingerprint) ?? 0) + 1)
+	})
+	return counts
+}
+
+/** @param node ProseMirror node */
+function canonicalFingerprint(node: Node) {
+	return stableSerialize(node.toJSON())
+}

--- a/src/comparison/markdownComparisonTypes.ts
+++ b/src/comparison/markdownComparisonTypes.ts
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export type ComparisonOperation = 'insert' | 'delete' | 'replace' | 'move'
+
+export type ComparisonDetail = 'inline' | 'block'
+
+export type ComparisonFacet
+	= | 'text'
+		| 'formatting'
+		| 'attribute'
+		| 'structure'
+		| 'unknown'
+
+export interface ComparisonRange {
+	from: number
+	to: number
+}
+
+export type ComparisonContextCode
+	= | 'front-matter'
+		| 'paragraph'
+		| 'heading'
+		| 'list-item'
+		| 'task'
+		| 'table-cell'
+		| 'code-block'
+		| 'quote'
+		| 'callout'
+		| 'details'
+		| 'footnote'
+		| 'footnote-reference'
+		| 'image'
+		| 'mention'
+		| 'mathematics'
+		| 'preview'
+		| 'unknown'
+
+export interface ComparisonContextLocation {
+	code: ComparisonContextCode
+	path: readonly number[]
+	from: number
+	to: number
+}
+
+export interface ComparisonContext {
+	before: ComparisonContextLocation | null
+	after: ComparisonContextLocation | null
+}
+
+export type ComparisonPreviewNode
+	= | 'front-matter'
+		| 'image'
+		| 'mention'
+		| 'mathematics'
+		| 'footnote-reference'
+		| 'horizontal-rule'
+		| 'changed-content'
+
+export type ComparisonPreviewAtom
+	= | { kind: 'text', text: string }
+		| { kind: 'node', node: ComparisonPreviewNode }
+
+export interface ComparisonPreview {
+	before: ComparisonPreviewAtom | null
+	after: ComparisonPreviewAtom | null
+}
+
+export type ComparisonMarkCode
+	= | 'bold'
+		| 'italic'
+		| 'strike'
+		| 'highlight'
+		| 'underline'
+		| 'inline-code'
+
+export type ComparisonAttributeCode
+	= | 'link'
+		| 'link-target'
+		| 'heading-level'
+		| 'list-start'
+		| 'task-state'
+		| 'code-language'
+		| 'text-direction'
+		| 'image-target'
+		| 'image-alt'
+		| 'mention-identity'
+		| 'mathematics'
+		| 'preview-target'
+		| 'footnote-reference'
+		| 'callout-type'
+		| 'details-state'
+		| 'table-alignment'
+		| 'table-span'
+		| 'unknown-attribute'
+
+export type ComparisonSignal
+	= | {
+		type: 'mark'
+		mark: ComparisonMarkCode
+		change: 'added' | 'removed' | 'changed'
+	}
+	| {
+		type: 'attribute'
+		attribute: ComparisonAttributeCode
+		change: 'added' | 'removed' | 'changed'
+	}
+	| {
+		type: 'node'
+	}
+
+export interface ComparisonDescriptor {
+	id: string
+	sourceOrder: number
+	operation: ComparisonOperation
+	detail: ComparisonDetail
+	facets: readonly ComparisonFacet[]
+	before: ComparisonRange
+	after: ComparisonRange
+	context: ComparisonContext
+	preview: ComparisonPreview
+	signals: readonly ComparisonSignal[]
+}
+
+export interface MarkdownComparisonModel {
+	descriptors: readonly ComparisonDescriptor[]
+}
+
+export type ComparisonSide = 'before' | 'after'

--- a/src/comparison/renderedComparisonLimit.ts
+++ b/src/comparison/renderedComparisonLimit.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * The first failing browser fixture measured 264,599/267,666 characters and
+ * 8,163/8,259 lines. These ceilings remain over 20% below the smaller failing
+ * dimension; recalibrate only with the same production-build browser gate.
+ */
+export const RENDERED_COMPARISON_LIMITS = Object.freeze({
+	maximumCharactersPerSnapshot: 210_000,
+	maximumLinesPerSnapshot: 6_500,
+})
+
+/**
+ * Determine whether rendered semantic comparison must be skipped before parsing.
+ *
+ * @param before Earlier raw Markdown
+ * @param after Later raw Markdown
+ */
+export function exceedsRenderedComparisonLimit(before: string, after: string): boolean {
+	return [before, after].some((content) => content.length > RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot
+		|| exceedsLineLimit(content))
+}
+
+/** @param content Raw Markdown */
+function exceedsLineLimit(content: string): boolean {
+	if (!content) {
+		return false
+	}
+	let lines = 1
+	for (let index = 0; index < content.length; index++) {
+		const character = content[index]
+		if (character === '\n' || (character === '\r' && content[index + 1] !== '\n')) {
+			lines++
+			if (lines > RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/src/composables/useEditorMethods.ts
+++ b/src/composables/useEditorMethods.ts
@@ -13,6 +13,18 @@ import markdownit from '../markdownit/index.js'
 import { isUser } from '../services/SyncService.ts'
 
 /**
+ * Convert editor source content to the HTML consumed by Tiptap's parser.
+ *
+ * @param content Editor source content
+ * @param markdown Whether the editor supports Markdown content
+ */
+export function renderEditorContent(content: string, markdown: boolean) {
+	return markdown
+		? markdownit.render(content) + '<p/>'
+		: `<pre>\n${escapeHtml(content)}</pre>`
+}
+
+/**
  *
  * @param editor to apply methods to
  */
@@ -29,12 +41,9 @@ export function useEditorMethods(editor: Editor) {
 	) => void = (content, { addToHistory = true } = {}) => {
 		const hasMarkdownContent
 			= editor.extensionManager.extensions.includes(Markdown)
-		const html = hasMarkdownContent
-			? markdownit.render(content) + '<p/>'
-			: `<pre>\n${escapeHtml(content)}</pre>`
 		editor
 			.chain()
-			.setContent(html, { emitUpdate: addToHistory })
+			.setContent(renderEditorContent(content, hasMarkdownContent), { emitUpdate: addToHistory })
 			.command(({ tr }) => {
 				tr.setMeta('addToHistory', addToHistory)
 				return true

--- a/src/extensions/RichText.ts
+++ b/src/extensions/RichText.ts
@@ -66,12 +66,16 @@ lowlight.registerAlias('plaintext', 'mermaid')
 interface RichTextOptions {
 	connection?: Connection
 	editing: boolean
+	emitAttachmentEvents: boolean
 	extensions: Extensions
+	inferTextDirectionOnParse: boolean
+	keymap: boolean
 	relativePath?: string
 	isEmbedded: boolean
 	mentionSearch?: (query: string) => Promise<Record<string, string>>
 	openLink?: (href: string) => void
 	noLazyImages: boolean
+	search: boolean
 }
 
 export default Extension.create<RichTextOptions>({
@@ -80,9 +84,13 @@ export default Extension.create<RichTextOptions>({
 	addOptions() {
 		return {
 			editing: true,
+			emitAttachmentEvents: true,
 			extensions: [],
+			inferTextDirectionOnParse: false,
 			isEmbedded: false,
+			keymap: true,
 			noLazyImages: false,
+			search: true,
 		}
 	},
 
@@ -123,7 +131,10 @@ export default Extension.create<RichTextOptions>({
 				isEmbedded: this.options.isEmbedded,
 			}),
 			Underline,
-			Image.configure({ noLazyImages: this.options.noLazyImages }),
+			Image.configure({
+				emitAttachmentEvents: this.options.emitAttachmentEvents,
+				noLazyImages: this.options.noLazyImages,
+			}),
 			ImageInline.configure({ noLazyImages: this.options.noLazyImages }),
 			Dropcursor.configure({
 				color: 'var(--color-primary-element)',
@@ -131,7 +142,7 @@ export default Extension.create<RichTextOptions>({
 			}),
 			Gapcursor,
 			KeepSyntax,
-			Keymap,
+			...(this.options.keymap ? [Keymap] : []),
 			FrontMatter,
 			Mention.configure({
 				suggestion: MentionSuggestion({
@@ -141,7 +152,9 @@ export default Extension.create<RichTextOptions>({
 					},
 				}),
 			}),
-			Search,
+			...(this.options.search
+				? [Search]
+				: []),
 			Emoji.configure({
 				suggestion: EmojiSuggestion(),
 			}),
@@ -163,6 +176,7 @@ export default Extension.create<RichTextOptions>({
 				notAfter: ['paragraph', 'comments', 'footnotes'],
 			}),
 			TextDirection.configure({
+				inferTextDirectionOnParse: this.options.inferTextDirectionOnParse,
 				types: [
 					'blockquote',
 					'callout',

--- a/src/extensions/TextDirection.ts
+++ b/src/extensions/TextDirection.ts
@@ -119,6 +119,7 @@ declare module '@tiptap/core' {
 export interface TextDirectionOptions {
 	types: string[]
 	defaultDirection: Direction | null
+	inferTextDirectionOnParse: boolean
 }
 
 export const TextDirection = Extension.create<TextDirectionOptions>({
@@ -128,6 +129,7 @@ export const TextDirection = Extension.create<TextDirectionOptions>({
 		return {
 			types: [],
 			defaultDirection: null,
+			inferTextDirectionOnParse: false,
 		}
 	},
 
@@ -138,7 +140,15 @@ export const TextDirection = Extension.create<TextDirectionOptions>({
 				attributes: {
 					dir: {
 						default: null,
-						parseHTML: (element) => element.dir || this.options.defaultDirection,
+						parseHTML: (element) => {
+							if (!this.options.inferTextDirectionOnParse) {
+								return element.dir || this.options.defaultDirection
+							}
+							const explicitDirection = element.dir as Direction
+							return validDirections.includes(explicitDirection)
+								? explicitDirection
+								: getTextDirection(element.textContent ?? '') ?? this.options.defaultDirection
+						},
 						renderHTML: (attributes) => {
 							if (attributes.dir === this.options.defaultDirection) {
 								return {}

--- a/src/nodes/Image.ts
+++ b/src/nodes/Image.ts
@@ -17,6 +17,7 @@ const imageFileDropPluginKey = new PluginKey('imageFileDrop')
 const imageExtractAttachmentsKey = new PluginKey('imageExtractAttachments')
 
 interface ImageOptions extends TiptapImageOptions {
+	emitAttachmentEvents: boolean
 	noLazyImages: boolean
 }
 
@@ -53,6 +54,7 @@ const Image = TiptapImage.extend<ImageOptions>({
 	addOptions() {
 		return {
 			...this.parent?.() as ImageOptions,
+			emitAttachmentEvents: true,
 			noLazyImages: false,
 		}
 	},
@@ -62,6 +64,7 @@ const Image = TiptapImage.extend<ImageOptions>({
 	},
 
 	addProseMirrorPlugins() {
+		const emitAttachmentEvents = this.options.emitAttachmentEvents
 		return [
 			new Plugin({
 				key: imageFileDropPluginKey,
@@ -125,7 +128,9 @@ const Image = TiptapImage.extend<ImageOptions>({
 				state: {
 					init(_, { doc }) {
 						const attachmentSrcs = extractAttachmentSrcs(doc)
-						emit('text:editor:attachments:updated', { attachmentSrcs })
+						if (emitAttachmentEvents) {
+							emit('text:editor:attachments:updated', { attachmentSrcs })
+						}
 						return { attachmentSrcs }
 					},
 					apply(tr, value, _oldState, newState) {
@@ -140,7 +145,9 @@ const Image = TiptapImage.extend<ImageOptions>({
 							return value
 						}
 
-						emit('text:editor:attachments:updated', { attachmentSrcs })
+						if (emitAttachmentEvents) {
+							emit('text:editor:attachments:updated', { attachmentSrcs })
+						}
 						return { attachmentSrcs }
 					},
 				},

--- a/src/tests/comparison/comparisonEditorLifecycle.spec.ts
+++ b/src/tests/comparison/comparisonEditorLifecycle.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Editor } from '@tiptap/vue-3'
+import { describe, expect, it, vi } from 'vitest'
+import { consumeStateOnlyComparisonEditor } from '../../comparison/comparisonEditorLifecycle.ts'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import EditableTable from '../../nodes/EditableTable.js'
+import Table from '../../nodes/Table.js'
+
+describe('comparison editor lifecycle', () => {
+	it('claims only registered state-only comparison editors once', () => {
+		const comparisonEditor = createComparisonEditor('State only')
+		try {
+			expect(() => consumeStateOnlyComparisonEditor(comparisonEditor)).not.toThrow()
+			expect(() => consumeStateOnlyComparisonEditor(comparisonEditor))
+				.toThrow('Comparison editor plugin initialization failed')
+		} finally {
+			comparisonEditor.destroy()
+		}
+	})
+
+	it('parses the complete read-only document without creating a detached view', () => {
+		const mount = vi.spyOn(Editor.prototype, 'mount')
+		const editor = createComparisonEditor('Before\n\n| A |\n| --- |\n| one |')
+		try {
+			expect(mount).not.toHaveBeenCalled()
+			expect(editor.options.element).toBeNull()
+			expect(editor.state.doc.textContent).toBe('BeforeAone')
+			expect(editor.state.plugins).toEqual([])
+			expect(editor.isDestroyed).toBe(true)
+			expect(() => editor.view.dom).toThrow('editor view is not available')
+			expect(editor.extensionManager.nodeViews.callout).toBeTypeOf('function')
+			const table = editor.extensionManager.extensions.find(({ name }) => name === 'table')
+			expect(table).toBe(Table)
+			expect(table).not.toBe(EditableTable)
+		} finally {
+			editor.destroy()
+			mount.mockRestore()
+		}
+	})
+
+	it('infers text direction while parsing an immutable comparison document', () => {
+		const editor = createComparisonEditor('English\n\nالعربية')
+		try {
+			const directions: Array<string | null> = []
+			editor.state.doc.descendants((node) => {
+				if (node.type.name === 'paragraph') {
+					directions.push(node.attrs.dir as string | null)
+				}
+				return true
+			})
+
+			expect(directions.slice(0, 2)).toEqual(['ltr', 'rtl'])
+			expect(editor.state.plugins).toEqual([])
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('can parse both documents with one schema', () => {
+		const before = createComparisonEditor('::: info\nBefore\n:::')
+		const after = createComparisonEditor('::: warn\nAfter\n:::', { schema: before.schema })
+		try {
+			expect(after.schema).toBe(before.schema)
+			expect(after.extensionManager.schema).toBe(before.schema)
+			expect(after.state.doc.type.schema).toBe(before.state.doc.type.schema)
+			expect(before.state.doc.firstChild?.attrs.type).toBe('info')
+			expect(after.state.doc.firstChild?.attrs.type).toBe('warn')
+		} finally {
+			before.destroy()
+			after.destroy()
+		}
+	})
+})

--- a/src/tests/comparison/editorCallbackIsolation.spec.ts
+++ b/src/tests/comparison/editorCallbackIsolation.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { describe, expect, it, vi } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+
+describe('comparison editor isolation', () => {
+	it('disables interactive extensions and global editor events', () => {
+		const attachments = vi.fn()
+		const search = vi.fn()
+		subscribe('text:editor:attachments:updated', attachments)
+		subscribe('text:editor:search-results', search)
+		const editor = createComparisonEditor('![One](.attachments.1/one.png) find')
+
+		try {
+			const extensionNames = editor.extensionManager.extensions.map(({ name }) => name)
+			expect(extensionNames).not.toContain('focustrap')
+			expect(extensionNames).not.toContain('CustomKeymap')
+			expect(extensionNames).not.toContain('Search')
+			expect(attachments).not.toHaveBeenCalled()
+			expect(search).not.toHaveBeenCalled()
+		} finally {
+			editor.destroy()
+			unsubscribe('text:editor:attachments:updated', attachments)
+			unsubscribe('text:editor:search-results', search)
+		}
+	})
+})

--- a/src/tests/comparison/fixtures/atlasComparison.ts
+++ b/src/tests/comparison/fixtures/atlasComparison.ts
@@ -1,0 +1,214 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const ATLAS_ROLLBACK_SECTION = `## Rollback ownership
+
+Maya owns rollback approval.
+
+Escalate checkout regressions to the release commander.`
+
+const ATLAS_EVIDENCE_SECTION = `## Audit archive
+
+Each decision receives a durable timestamp.
+
+Signed records remain with the project history.`
+
+const ATLAS_READINESS_SECTION = `## Regional readiness
+
+All checkout regions use the same health gate.
+
+Regional owners confirm capacity before launch.`
+
+export const ATLAS_INITIAL_CONTENT = `---
+release: atlas-2.4
+status: draft
+owner: Maya Chen
+---
+
+# Atlas 2.4 release plan
+
+> Draft rollout window: Thursday, 18 July.
+
+## Objective
+
+Ship **Atlas 2.4** to a 10% pilot cohort while protecting checkout availability.
+
+Release owner: Maya Chen.
+
+Status cadence: every 15 minutes.
+
+All named owners have acknowledged the window.
+
+Status dashboard is available to the release team.
+
+The dashboard is reviewed before each traffic increase.
+
+Keep the [incident channel](https://chat.example.test/atlas) staffed during rollout.
+
+The incident commander acknowledges every escalation.
+
+Follow the [operator runbook](https://docs.example.test/atlas/draft).
+
+The release commander validates every operator handoff.
+
+Customer update is ready for review.
+
+Checkout remains available throughout the launch.
+
+${ATLAS_ROLLBACK_SECTION}
+
+${ATLAS_EVIDENCE_SECTION}
+
+${ATLAS_READINESS_SECTION}
+
+## Decision protocol
+
+The release commander records every traffic decision.
+
+## Rollout checklist
+
+- [x] Freeze schema changes
+- [ ] Confirm support coverage
+- [ ] Enable the pilot cohort
+
+## Schedule
+
+| Stage | Owner | Traffic |
+| --- | --- | --- |
+| Pilot | Maya | 10% |
+| General availability | Lee | Pending |
+
+Checkout remains available throughout the launch.
+
+::: info
+The checkout health gate must remain green for fifteen minutes.
+:::
+
+Health checks are sampled from every checkout region.
+
+<details>
+<summary>Escalation contacts</summary>
+Maya leads release decisions; Noor leads rollback execution.
+</details>
+
+## Guardrail
+
+\`\`\`js
+const rolloutPercent = 10
+const rollbackThreshold = 0.02
+\`\`\`
+
+Rollback if error rate exceeds \`2%\`.
+
+The rollout decision is recorded in the release evidence.[^atlas-draft]
+
+Visual evidence follows the signed release decision.
+
+![Atlas rollout dashboard](/core/img/logo/logo.svg)
+
+The image checksum is recorded separately.
+
+[^atlas-draft]: Draft approval requires checkout error rate below two percent.
+`
+
+export const ATLAS_SYNTAX_ONLY_CONTENT = ATLAS_INITIAL_CONTENT
+	.replace('# Atlas 2.4 release plan', '# Atlas 2.4 release plan #')
+	.replace('Status dashboard is available to the release team.', 'Status dashboard is available to the release team. ')
+	.replaceAll('\n', '\r\n')
+	.replace(/\r\n$/, '')
+
+export const ATLAS_CURRENT_CONTENT = `---
+release: atlas-2.4
+status: launch-ready
+owner: Maya Chen and Noor Patel
+---
+
+# Atlas 2.4 launch plan
+
+> Approved rollout window: Friday, 19 July.
+
+## Objective
+
+Ship **Atlas 2.4** through a 25% progressive rollout while protecting checkout availability.
+
+Release owner: **Maya Chen**.
+
+Status cadence: *every 15 minutes*.
+
+All named owners have acknowledged the window.
+
+[Status dashboard](https://status.example.test/atlas) is available to the release team.
+
+The dashboard is reviewed before each traffic increase.
+
+Keep the incident channel staffed during rollout.
+
+The incident commander acknowledges every escalation.
+
+Follow the [operator runbook](https://docs.example.test/atlas/2.4).
+
+The release commander validates every operator handoff.
+
+Customer **launch update** is ready for publication.
+
+Checkout remains available throughout the launch.
+
+${ATLAS_EVIDENCE_SECTION}
+
+${ATLAS_READINESS_SECTION}
+
+${ATLAS_ROLLBACK_SECTION}
+
+## Decision protocol
+
+The release commander records every traffic decision.
+
+## Rollout checklist
+
+- [x] Freeze schema changes
+- [x] Confirm support coverage
+- [x] Enable the pilot cohort
+- [ ] Publish the customer update
+
+## Schedule
+
+| Stage | Owner | Traffic |
+| --- | --- | --- |
+| Canary | Maya | 25% |
+| General availability | Lee | 100% |
+| Rollback rehearsal | Noor | Complete |
+
+Checkout remains available throughout the launch.
+
+::: warn
+The checkout health gate must remain green for fifteen minutes.
+:::
+
+Health checks are sampled from every checkout region.
+
+<details>
+<summary>Escalation contacts</summary>
+Maya leads release decisions; Noor executes rollback and Lee owns customer communication.
+</details>
+
+## Guardrail
+
+\`\`\`js
+const rolloutPercent = 25
+const rollbackThreshold = 0.015
+\`\`\`
+
+Rollback if error rate exceeds \`1.5%\` for five minutes.
+
+The rollout decision is recorded in the release evidence.[^atlas-launch]
+
+Visual evidence follows the signed release decision.
+
+![Atlas launch control room](/core/img/logo/logo.svg)
+
+The image checksum is recorded separately.
+
+[^atlas-launch]: Launch approval requires checkout error rate below one and a half percent for five minutes.
+`

--- a/src/tests/comparison/hierarchicalMarkdownComparison.spec.ts
+++ b/src/tests/comparison/hierarchicalMarkdownComparison.spec.ts
@@ -1,0 +1,586 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonModelAudit } from '../../comparison/hierarchicalMarkdownComparisonModel.ts'
+import type { ComparisonDescriptor, ComparisonSide } from '../../comparison/markdownComparisonTypes.ts'
+
+import { describe, expect, it } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import {
+	ComparisonModelLimitError,
+	createHierarchicalMarkdownComparisonModel,
+	MAX_ALIGNMENT_PRODUCT,
+	MAX_INLINE_ENVELOPE_SIZE,
+} from '../../comparison/hierarchicalMarkdownComparisonModel.ts'
+import {
+	ATLAS_CURRENT_CONTENT,
+	ATLAS_INITIAL_CONTENT,
+	ATLAS_SYNTAX_ONLY_CONTENT,
+} from './fixtures/atlasComparison.ts'
+
+function compare(beforeContent: string, afterContent: string, audit?: ComparisonModelAudit) {
+	const beforeEditor = createComparisonEditor(beforeContent)
+	const afterEditor = createComparisonEditor(afterContent)
+	try {
+		const before = beforeEditor.state.doc
+		const after = afterEditor.state.doc
+		return {
+			before,
+			after,
+			model: createHierarchicalMarkdownComparisonModel(before, after, { audit }),
+		}
+	} finally {
+		beforeEditor.destroy()
+		afterEditor.destroy()
+	}
+}
+
+function rangeText(doc: Node, descriptor: ComparisonDescriptor, side: ComparisonSide) {
+	const { from, to } = descriptor[side]
+	return doc.textBetween(from, to, '\n', '\ufffc')
+}
+
+function expectValidRanges(doc: Node, descriptors: readonly ComparisonDescriptor[], side: ComparisonSide) {
+	for (const descriptor of descriptors) {
+		const range = descriptor[side]
+		expect(range.from, `${side} ${descriptor.id} starts before the document`).toBeGreaterThanOrEqual(0)
+		expect(range.to, `${side} ${descriptor.id} ends before it starts`).toBeGreaterThanOrEqual(range.from)
+		expect(range.to, `${side} ${descriptor.id} ends after the document`).toBeLessThanOrEqual(doc.content.size)
+	}
+}
+
+function topLevelRanges(doc: Node) {
+	const ranges: Array<{ from: number, to: number, text: string }> = []
+	doc.forEach((node, from) => ranges.push({
+		from,
+		to: from + node.nodeSize,
+		text: node.textContent,
+	}))
+	return ranges
+}
+
+function touched(range: { from: number, to: number }, block: { from: number, to: number }) {
+	return range.from < block.to && range.to > block.from
+}
+
+describe('hierarchical Markdown comparison', () => {
+	it('normalizes documents created by separate schema instances before comparing them', () => {
+		const { model } = compare('# Heading\n\nSame content', '# Heading\n\nSame content')
+		expect(model.descriptors).toEqual([])
+	})
+
+	it('detects attrs-only textblock changes before content diffing', () => {
+		const { model } = compare('# Title', '## Title')
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]).toMatchObject({
+			detail: 'block',
+			facets: ['attribute'],
+			signals: [{ type: 'attribute', attribute: 'heading-level', change: 'changed' }],
+		})
+	})
+
+	it('keeps unsupported semantic attributes visible without exposing values', () => {
+		const { model } = compare('- item', '* item')
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]).toMatchObject({
+			facets: ['attribute', 'unknown'],
+			signals: [{ type: 'attribute', attribute: 'unknown-attribute', change: 'changed' }],
+		})
+		expect(JSON.stringify(model.descriptors)).not.toContain('bullet')
+	})
+
+	it.each([
+		['text', 'Before text', 'After text', 'text'],
+		['formatting', 'plain text', 'plain **text**', 'bold'],
+		['link', 'plain text', '[plain text](https://example.test)', 'link'],
+		['list start', '1. item', '3. item', 'list-start'],
+		['task state', '- [ ] item', '- [x] item', 'task-state'],
+		['code language', '```js\nsame\n```', '```ts\nsame\n```', 'code-language'],
+		['callout type', '::: info\nsame\n:::', '::: warn\nsame\n:::', 'callout-type'],
+		['image identity', '![Before](before.png)', '![After](after.png)', 'image-target'],
+		['mention identity', '@[Jane](mention://user/jane)', '@[John](mention://user/john)', 'mention-identity'],
+		['preview target', '[Preview](https://before.test (preview))', '[Preview](https://after.test (preview))', 'preview-target'],
+		['mathematics', '$1 + 1 = 2$', '$1 + 2 = 3$', 'mathematics'],
+		['footnote identity', 'Text[^before].\n\n[^before]: Same', 'Text[^after].\n\n[^after]: Same', 'footnote-reference'],
+	] as const)('classifies supported %s semantics', (_name, before, after, semantic) => {
+		const descriptors = compare(before, after).model.descriptors
+		expect(descriptors.length).toBeGreaterThan(0)
+		const encoded = JSON.stringify(descriptors.flatMap(({ facets, signals }) => [facets, signals]))
+		expect(encoded).toContain(semantic)
+	})
+
+	it.each([
+		['bold', 'plain text', 'plain **text**', { type: 'mark', mark: 'bold', change: 'added' }],
+		['italic', 'plain text', 'plain *text*', { type: 'mark', mark: 'italic', change: 'added' }],
+		['strike', 'plain text', 'plain ~~text~~', { type: 'mark', mark: 'strike', change: 'added' }],
+		['highlight', 'plain text', 'plain ==text==', { type: 'mark', mark: 'highlight', change: 'added' }],
+		['inline code', 'plain text', 'plain `text`', { type: 'mark', mark: 'inline-code', change: 'added' }],
+		['link added', 'text', '[text](https://example.test)', { type: 'attribute', attribute: 'link', change: 'added' }],
+		['link removed', '[text](https://example.test)', 'text', { type: 'attribute', attribute: 'link', change: 'removed' }],
+		['link target', '[text](https://before.test)', '[text](https://after.test)', { type: 'attribute', attribute: 'link-target', change: 'changed' }],
+		['heading level', '# Heading', '## Heading', { type: 'attribute', attribute: 'heading-level', change: 'changed' }],
+		['list start', '1. item', '3. item', { type: 'attribute', attribute: 'list-start', change: 'changed' }],
+		['task state', '- [ ] item', '- [x] item', { type: 'attribute', attribute: 'task-state', change: 'changed' }],
+		['code language', '```js\nsame\n```', '```ts\nsame\n```', { type: 'attribute', attribute: 'code-language', change: 'changed' }],
+		['callout type', '::: info\nsame\n:::', '::: warn\nsame\n:::', { type: 'attribute', attribute: 'callout-type', change: 'changed' }],
+		['image description', '![Before](same.png)', '![After](same.png)', { type: 'attribute', attribute: 'image-alt', change: 'changed' }],
+		['image target', '![Same](before.png)', '![Same](after.png)', { type: 'attribute', attribute: 'image-target', change: 'changed' }],
+		['mention identity', '@[Jane](mention://user/jane)', '@[John](mention://user/john)', { type: 'attribute', attribute: 'mention-identity', change: 'changed' }],
+		['mathematics', '$1 + 1 = 2$', '$1 + 2 = 3$', { type: 'attribute', attribute: 'mathematics', change: 'changed' }],
+		['preview target', '[Preview](https://before.test (preview))', '[Preview](https://after.test (preview))', { type: 'attribute', attribute: 'preview-target', change: 'changed' }],
+		['footnote identity', 'Text[^before].\n\n[^before]: Same', 'Text[^after].\n\n[^after]: Same', { type: 'attribute', attribute: 'footnote-reference', change: 'changed' }],
+		['table alignment', '| A |\n|:---|\n| 1 |', '| A |\n|---:|\n| 1 |', { type: 'attribute', attribute: 'table-alignment', change: 'changed' }],
+	] as const)('emits the supported %s signal', (_name, before, after, signal) => {
+		expect(compare(before, after).model.descriptors.flatMap(({ signals }) => signals)).toContainEqual(signal)
+	})
+
+	it('classifies underline marks present in editor documents', () => {
+		const editor = createComparisonEditor('plain text')
+		try {
+			const before = editor.state.doc
+			const after = editor.state.tr.addMark(7, 11, editor.schema.marks.underline!.create()).doc
+			expect(createHierarchicalMarkdownComparisonModel(before, after).descriptors.flatMap(({ signals }) => signals))
+				.toContainEqual({ type: 'mark', mark: 'underline', change: 'added' })
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('matches nested attributes after an earlier top-level insertion shifts their paths', () => {
+		const { model } = compare(
+			'Introduction\n\n- [ ] Confirm support coverage',
+			'New preface\n\nIntroduction\n\n- [x] Confirm support coverage',
+		)
+		expect(model.descriptors.flatMap(({ signals }) => signals)).toContainEqual({
+			type: 'attribute',
+			attribute: 'task-state',
+			change: 'changed',
+		})
+	})
+
+	it('keeps Atlas semantics and conservative exact moves', () => {
+		const { model } = compare(ATLAS_INITIAL_CONTENT, ATLAS_CURRENT_CONTENT)
+		const signals = model.descriptors.flatMap(({ signals }) => signals)
+		const contexts = model.descriptors.flatMap(({ context }) => [context.before?.code, context.after?.code])
+
+		expect(model.descriptors.some(({ operation }) => operation === 'move')).toBe(true)
+		expect(signals).toEqual(expect.arrayContaining([
+			{ type: 'mark', mark: 'bold', change: 'added' },
+			{ type: 'mark', mark: 'italic', change: 'added' },
+			{ type: 'attribute', attribute: 'link', change: 'added' },
+			{ type: 'attribute', attribute: 'link', change: 'removed' },
+			{ type: 'attribute', attribute: 'link-target', change: 'changed' },
+			{ type: 'attribute', attribute: 'task-state', change: 'changed' },
+			{ type: 'attribute', attribute: 'callout-type', change: 'changed' },
+			{ type: 'attribute', attribute: 'footnote-reference', change: 'changed' },
+			{ type: 'attribute', attribute: 'image-alt', change: 'changed' },
+		]))
+		expect(contexts).toEqual(expect.arrayContaining([
+			'front-matter',
+			'quote',
+			'paragraph',
+			'heading',
+			'task',
+			'table-cell',
+			'callout',
+			'details',
+			'code-block',
+			'footnote-reference',
+			'image',
+			'footnote',
+		]))
+		const trafficChanges = model.descriptors.filter(({ preview }) => (
+			preview.before?.kind === 'text'
+			&& preview.before.text === 'Pending'
+			&& preview.after?.kind === 'text'
+			&& preview.after.text === '100%'
+		))
+		expect(model.descriptors).toHaveLength(35)
+		expect(trafficChanges).toHaveLength(1)
+		expect(trafficChanges[0]).toMatchObject({ detail: 'inline', facets: ['text'] })
+	})
+
+	it('treats syntax-only Markdown differences as the same rendered document', () => {
+		expect(compare(ATLAS_INITIAL_CONTENT, ATLAS_SYNTAX_ONLY_CONTENT).model.descriptors).toEqual([])
+	})
+
+	it('falls back to one honest block range for a changed token island over the inline budget', () => {
+		const stableIsland = ' UNCHANGED ISLAND '
+		const before = `prefix ${'a'.repeat(2600)}${stableIsland}${'b'.repeat(2600)} suffix`
+		const after = `prefix ${'x'.repeat(2600)}${stableIsland}${'y'.repeat(2600)} suffix`
+		const result = compare(before, after)
+
+		expect(result.model.descriptors).toHaveLength(1)
+		expect(result.model.descriptors[0]?.detail).toBe('block')
+		expect(result.model.descriptors.every(({ detail }) => detail !== 'inline')).toBe(true)
+		expect(rangeText(result.before, result.model.descriptors[0]!, 'before')).toContain(stableIsland.trim())
+		expect(rangeText(result.after, result.model.descriptors[0]!, 'after')).toContain(stableIsland.trim())
+	})
+
+	it.each([
+		[MAX_INLINE_ENVELOPE_SIZE - 2, 'inline'],
+		[MAX_INLINE_ENVELOPE_SIZE, 'inline'],
+		[MAX_INLINE_ENVELOPE_SIZE + 2, 'block'],
+	] as const)('bounds a leaf ChangeSet at an envelope of %i', (envelope, detail) => {
+		const sideLength = envelope / 2
+		const { model } = compare(`prefix${'a'.repeat(sideLength)}suffix`, `prefix${'b'.repeat(sideLength)}suffix`)
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]?.detail).toBe(detail)
+	})
+
+	it.each([
+		['pure insertion overlap clamp', 'aa', 'aaa', 'insert'],
+		['pure deletion overlap clamp', 'aaa', 'aa', 'delete'],
+		['start insertion', 'middle end', 'start middle end', 'insert'],
+		['middle insertion', 'start end', 'start middle end', 'insert'],
+		['end insertion', 'start middle', 'start middle end', 'insert'],
+		['start deletion', 'start middle end', 'middle end', 'delete'],
+		['middle deletion', 'start middle end', 'start end', 'delete'],
+		['end deletion', 'start middle end', 'start middle', 'delete'],
+	] as const)('keeps a bounded inline %s valid', (_name, before, after, operation) => {
+		const result = compare(before, after)
+		expect(result.model.descriptors).toHaveLength(1)
+		expect(result.model.descriptors[0]).toMatchObject({ detail: 'inline', operation })
+		expectValidRanges(result.before, result.model.descriptors, 'before')
+		expectValidRanges(result.after, result.model.descriptors, 'after')
+	})
+
+	it('keeps a small edit inline inside a very long paragraph', () => {
+		const shared = 'same '.repeat(1500)
+		const { before, after, model } = compare(`${shared}before ${shared}`, `${shared}after ${shared}`)
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]?.detail).toBe('inline')
+		expect(rangeText(before, model.descriptors[0]!, 'before')).toBe('before')
+		expect(rangeText(after, model.descriptors[0]!, 'after')).toBe('after')
+	})
+
+	it('aligns more than 500 siblings around one sparse edit', () => {
+		const paragraphs = Array.from({ length: 512 }, (_, index) => `paragraph ${index}`)
+		const before = paragraphs.join('\n\n')
+		const after = paragraphs.with(256, 'paragraph changed').join('\n\n')
+		const { model } = compare(before, after)
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]?.detail).toBe('inline')
+	})
+
+	it('classifies every block in a large document with more than 500 siblings', () => {
+		const before = Array.from({ length: 512 }, (_, index) => `before ${index}`).join('\n\n')
+		const after = Array.from({ length: 512 }, (_, index) => `after ${index}`).join('\n\n')
+		const result = compare(before, after)
+		const beforeBlocks = topLevelRanges(result.before).filter(({ text }) => text)
+		const afterBlocks = topLevelRanges(result.after).filter(({ text }) => text)
+
+		expect(result.model.descriptors).toHaveLength(512)
+		for (const block of beforeBlocks) {
+			expect(result.model.descriptors.some(({ before: range }) => touched(range, block))).toBe(true)
+		}
+		for (const block of afterBlocks) {
+			expect(result.model.descriptors.some(({ after: range }) => touched(range, block))).toBe(true)
+		}
+	})
+
+	it.each([
+		[199, 200, MAX_ALIGNMENT_PRODUCT - 200],
+		[200, 200, MAX_ALIGNMENT_PRODUCT],
+		[201, 200, MAX_ALIGNMENT_PRODUCT + 200],
+	] as const)('keeps sibling alignment bounded for %i by %i nodes', (beforeCount, afterCount, product) => {
+		expect(beforeCount * afterCount).toBe(product)
+		const before = Array.from({ length: beforeCount }, (_, index) => `before ${index}`).join('\n\n')
+		const after = Array.from({ length: afterCount }, (_, index) => `after ${index}`).join('\n\n')
+		const result = compare(before, after)
+		expectValidRanges(result.before, result.model.descriptors, 'before')
+		expectValidRanges(result.after, result.model.descriptors, 'after')
+		for (const block of topLevelRanges(result.before).filter(({ text }) => text)) {
+			expect(result.model.descriptors.some(({ before: range }) => touched(range, block))).toBe(true)
+		}
+		for (const block of topLevelRanges(result.after).filter(({ text }) => text)) {
+			expect(result.model.descriptors.some(({ after: range }) => touched(range, block))).toBe(true)
+		}
+	})
+
+	it('keeps inline precision for a global edit plus one added block', () => {
+		const before = Array.from({ length: 80 }, (_, index) => `Foo release block ${index}`).join('\n\n')
+		const after = [
+			...Array.from({ length: 80 }, (_, index) => `Bar release block ${index}`),
+			'Appended release block',
+		].join('\n\n')
+		const { model } = compare(before, after)
+
+		expect(model.descriptors.filter(({ operation }) => operation === 'delete')).toHaveLength(0)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'insert' && detail === 'block')).toHaveLength(1)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'replace' && detail === 'inline')).toHaveLength(80)
+	})
+
+	it('degrades linearly beyond the alignment ceiling without rewriting the document', () => {
+		const beforeBlocks = Array.from({ length: 250 }, (_, index) => `Foo release block ${index}`)
+		const afterBlocks = Array.from({ length: 250 }, (_, index) => `Bar release block ${index}`)
+		afterBlocks.splice(125, 0, 'Inserted release block')
+		const { model } = compare(beforeBlocks.join('\n\n'), afterBlocks.join('\n\n'))
+
+		expect(beforeBlocks.length * afterBlocks.length).toBeGreaterThan(MAX_ALIGNMENT_PRODUCT)
+		expect(model.descriptors.filter(({ operation }) => operation === 'delete')).toHaveLength(0)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'insert' && detail === 'block')).toHaveLength(1)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'replace' && detail === 'inline')).toHaveLength(250)
+	})
+
+	it('isolates one type change beyond the alignment ceiling', () => {
+		const before = Array.from({ length: 250 }, (_, index) => `Foo release block ${index}`)
+		const after = Array.from({ length: 250 }, (_, index) => `Bar release block ${index}`)
+		after[125] = '# Bar release block 125'
+		const { model } = compare(before.join('\n\n'), after.join('\n\n'))
+
+		expect(model.descriptors.filter(({ operation }) => operation === 'delete')).toHaveLength(1)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'insert' && detail === 'block')).toHaveLength(1)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'replace' && detail === 'inline')).toHaveLength(249)
+	})
+
+	it('bounds classification work for dense checklist edits', () => {
+		const count = 200
+		const audit: ComparisonModelAudit = { examinedNodes: 0, fingerprintGroupAllocations: 0 }
+		const result = compare(
+			Array.from({ length: count }, () => '- [ ] a x a x a x a x a x a x a x a x').join('\n'),
+			Array.from({ length: count }, () => '- [ ] b x b x b x b x b x b x b x b x').join('\n'),
+			audit,
+		)
+
+		expect(result.model.descriptors).toHaveLength(count * 8)
+		expect(audit.examinedNodes).toBeLessThan(result.model.descriptors.length * 50)
+	})
+
+	it('stops at the shared descriptor boundary before more classification', () => {
+		const before = createComparisonEditor(Array.from({ length: 20 }, () => '- [ ] a x a x a x a x').join('\n'))
+		const after = createComparisonEditor(Array.from({ length: 20 }, () => '- [ ] b x b x b x b x').join('\n'))
+		const audit: ComparisonModelAudit = { examinedNodes: 0, fingerprintGroupAllocations: 0 }
+		try {
+			expect(() => createHierarchicalMarkdownComparisonModel(
+				before.state.doc,
+				after.state.doc,
+				{ audit, maximumDescriptors: 10 },
+			)).toThrow(ComparisonModelLimitError)
+			expect(audit.examinedNodes).toBeLessThan(1000)
+		} finally {
+			before.destroy()
+			after.destroy()
+		}
+	})
+
+	it.each([
+		[
+			'interleaved insertions',
+			Array.from({ length: 80 }, (_, index) => `- item ${index * 2}`).join('\n'),
+			Array.from({ length: 160 }, (_, index) => `- item ${index}`).join('\n'),
+		],
+		[
+			'interleaved deletions',
+			Array.from({ length: 160 }, (_, index) => `- item ${index}`).join('\n'),
+			Array.from({ length: 80 }, (_, index) => `- item ${index * 2}`).join('\n'),
+		],
+		[
+			'multiple moved groups',
+			Array.from({ length: 60 }, (_, index) => `Block ${index}`).join('\n\n'),
+			[
+				...Array.from({ length: 20 }, (_, index) => `Block ${index + 40}`),
+				...Array.from({ length: 20 }, (_, index) => `Block ${index}`),
+				...Array.from({ length: 20 }, (_, index) => `Block ${index + 20}`),
+			].join('\n\n'),
+		],
+	] as const)('keeps %s classification output-sensitive', (_name, before, after) => {
+		const audit: ComparisonModelAudit = { examinedNodes: 0, fingerprintGroupAllocations: 0 }
+		const result = compare(before, after, audit)
+		let nodes = 0
+		for (const doc of [result.before, result.after]) {
+			doc.descendants(() => {
+				nodes++
+			})
+		}
+
+		expect(result.model.descriptors.length).toBeGreaterThan(0)
+		expect(audit.examinedNodes).toBeLessThan((nodes + result.model.descriptors.length) * 80)
+	})
+
+	it('allocates repeated sibling fingerprint groups by distinct fingerprint', () => {
+		const count = 400
+		const before = Array.from({ length: count }, () => '- [ ] TODO')
+		const after = [...before]
+		after[Math.floor(count / 2)] = '- [x] DONE'
+		const audit: ComparisonModelAudit = { examinedNodes: 0, fingerprintGroupAllocations: 0 }
+		const { model } = compare(before.join('\n'), after.join('\n'), audit)
+
+		expect(model.descriptors.length).toBeGreaterThan(0)
+		expect(audit.fingerprintGroupAllocations).toBeLessThan(count / 4)
+	})
+
+	it.each([
+		['start insertion', 'two\n\nthree', 'one\n\ntwo\n\nthree', 'insert'],
+		['middle insertion', 'one\n\nthree', 'one\n\ntwo\n\nthree', 'insert'],
+		['end insertion', 'one\n\ntwo', 'one\n\ntwo\n\nthree', 'insert'],
+		['start deletion', 'one\n\ntwo\n\nthree', 'two\n\nthree', 'delete'],
+		['middle deletion', 'one\n\ntwo\n\nthree', 'one\n\nthree', 'delete'],
+		['end deletion', 'one\n\ntwo\n\nthree', 'one\n\ntwo', 'delete'],
+	] as const)('represents a block %s', (_name, before, after, operation) => {
+		const { model } = compare(before, after)
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]).toMatchObject({ operation, detail: 'block' })
+	})
+
+	it('pairs the later duplicate on equal alignment scores', () => {
+		const { before, model } = compare('Same\n\nSame', 'Same')
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]?.operation).toBe('delete')
+		const firstBlock = topLevelRanges(before)[0]!
+		expect(model.descriptors[0]?.before).toEqual({ from: firstBlock.from, to: firstBlock.to })
+	})
+
+	it('uses the same deterministic duplicate convention for list items', () => {
+		const { model } = compare('- Same\n- Same', '- Same')
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]).toMatchObject({ operation: 'delete', detail: 'block' })
+		expect(model.descriptors[0]?.context.before?.code).toBe('list-item')
+	})
+
+	it.each([
+		['duplicate top-level blocks', 'Same\n\nSame\n\nOther', 'Other\n\nSame\n\nSame'],
+		['top-level block duplicated inside a blockquote', 'Moved\n\nAlpha\n\nBravo\n\n> Moved', 'Alpha\n\nBravo\n\nMoved\n\n> Moved'],
+		['nested list reorder', '- Alpha\n- Bravo', '- Bravo\n- Alpha'],
+	])('does not infer an ambiguous %s move', (_name, before, after) => {
+		const { model } = compare(before, after)
+		expect(model.descriptors.some(({ operation }) => operation === 'move')).toBe(false)
+		expect(model.descriptors.length).toBeGreaterThan(0)
+	})
+
+	it.each([
+		['heading reorder', '# Alpha\n\n# Bravo\n\n# Charlie', '# Bravo\n\n# Charlie\n\n# Alpha'],
+		['section move', '# Alpha\n\nAlpha body\n\n# Bravo\n\nBravo body', '# Bravo\n\nBravo body\n\n# Alpha\n\nAlpha body'],
+		['crossing moves', 'Alpha\n\nBravo\n\nCharlie\n\nDelta', 'Charlie\n\nDelta\n\nAlpha\n\nBravo'],
+	] as const)('detects a conservative exact %s', (_name, before, after) => {
+		const { model } = compare(before, after)
+		expect(model.descriptors.some(({ operation }) => operation === 'move')).toBe(true)
+		expect(model.descriptors.every(({ operation, detail }) => operation !== 'move' || detail === 'block')).toBe(true)
+	})
+
+	it('keeps the exact move separate from the nearby Zed edit reproduction', () => {
+		const result = compare(
+			['Zed', 'One', 'Two', 'Three', 'Four', 'Five', 'Six'].join('\n\n'),
+			['One', 'Two modified', 'Three', 'Four', 'Five', 'Six', 'Zed'].join('\n\n'),
+		)
+		expect(result.model.descriptors.filter(({ operation }) => operation === 'move')).toHaveLength(1)
+		const edit = result.model.descriptors.find(({ detail, operation }) => detail === 'inline' && operation === 'insert')
+		expect(edit).toBeDefined()
+		expect(rangeText(result.before, edit!, 'before')).toBe('')
+		expect(rangeText(result.after, edit!, 'after')).toBe(' modified')
+	})
+
+	it('does not label an edited moved block as an exact move', () => {
+		const result = compare('Zed\n\nOne\n\nTwo', 'One\n\nTwo\n\nZed modified')
+		expect(result.model.descriptors.some(({ operation }) => operation === 'move')).toBe(false)
+		expect(result.model.descriptors.some(({ before }) => result.before.textBetween(before.from, before.to).includes('Zed'))).toBe(true)
+		expect(result.model.descriptors.some(({ after }) => result.after.textBetween(after.from, after.to).includes('Zed modified'))).toBe(true)
+	})
+
+	it.each([
+		['front matter', '---\ntitle: Before\n---\n\nBody', '---\ntitle: After\n---\n\nBody', 'front-matter'],
+		['nested bullet and ordered lists', '- Parent\n  1. Before', '- Parent\n  1. After', 'list-item'],
+		['nested task list', '- [ ] Parent\n  - [ ] Before', '- [x] Parent\n  - [ ] After', 'task'],
+		['table text', '| A | B |\n|---|---|\n| 1 | Before |', '| A | B |\n|---|---|\n| 1 | After |', 'table-cell'],
+		['table row insertion', '| A |\n|---|\n| 1 |', '| A |\n|---|\n| 1 |\n| 2 |', 'table-cell'],
+		['table row deletion', '| A |\n|---|\n| 1 |\n| 2 |', '| A |\n|---|\n| 1 |', 'table-cell'],
+		['table cell insertion', '| A |\n|---|\n| 1 |', '| A | B |\n|---|---|\n| 1 | 2 |', 'table-cell'],
+		['table cell deletion', '| A | B |\n|---|---|\n| 1 | 2 |', '| A |\n|---|\n| 1 |', 'table-cell'],
+		['table alignment', '| A |\n|:---|\n| 1 |', '| A |\n|---:|\n| 1 |', 'table-cell'],
+	] as const)('recurses through %s', (_name, before, after, context) => {
+		const { model } = compare(before, after)
+		expect(model.descriptors.length).toBeGreaterThan(0)
+		expect(model.descriptors.some(({ context: descriptorContext }) => (
+			descriptorContext.before?.code === context || descriptorContext.after?.code === context
+		))).toBe(true)
+	})
+
+	it('does not leak a sibling structural edit into an inline text descriptor', () => {
+		const result = compare(
+			'- Alpha old\n- Bravo',
+			'- Alpha new\n- Bravo\n  - Nested',
+		)
+		const textChange = result.model.descriptors.find(({ preview }) => (
+			preview.before?.kind === 'text'
+			&& preview.before.text === 'old'
+			&& preview.after?.kind === 'text'
+			&& preview.after.text === 'new'
+		))
+
+		expect(textChange).toMatchObject({ detail: 'inline', facets: ['text'] })
+		expect(textChange?.signals).not.toContainEqual(expect.objectContaining({ type: 'node' }))
+	})
+
+	it('classifies details state, table span, and explicit direction attributes', () => {
+		const editor = createComparisonEditor('<details>\n<summary>Title</summary>\nBody\n</details>\n\n| A |\n|---|\n| 1 |\n\nDirection')
+		try {
+			const before = editor.state.doc
+			let detailsPosition = -1
+			let cellPosition = -1
+			let paragraphPosition = -1
+			before.descendants((node, position) => {
+				if (node.type.name === 'details') {
+					detailsPosition = position
+				}
+				if (cellPosition < 0 && node.type.name === 'tableCell') {
+					cellPosition = position
+				}
+				if (node.type.name === 'paragraph' && node.textContent === 'Direction') {
+					paragraphPosition = position
+				}
+			})
+			const after = editor.state.tr
+				.setNodeAttribute(detailsPosition, 'openDetails', true)
+				.setNodeAttribute(cellPosition, 'colspan', 2)
+				.setNodeAttribute(paragraphPosition, 'dir', 'rtl')
+				.doc
+			const signals = createHierarchicalMarkdownComparisonModel(before, after).descriptors.flatMap(({ signals }) => signals)
+			expect(signals).toEqual(expect.arrayContaining([
+				{ type: 'attribute', attribute: 'details-state', change: 'changed' },
+				{ type: 'attribute', attribute: 'table-span', change: 'changed' },
+				{ type: 'attribute', attribute: 'text-direction', change: 'changed' },
+			]))
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('keeps ranges valid, anchors unchanged, output deterministic, and swap coverage symmetric', () => {
+		for (let seed = 1; seed <= 12; seed++) {
+			const unchanged = `anchor ${seed}`
+			const beforeContent = [`before ${seed}`, unchanged, `tail ${seed}`].join('\n\n')
+			const afterContent = [seed % 2 ? `insert ${seed}` : `after ${seed}`, unchanged, seed % 2 ? `after ${seed}` : `tail ${seed}`].join('\n\n')
+			const result = compare(beforeContent, afterContent)
+			const repeated = compare(beforeContent, afterContent)
+			const swapped = compare(afterContent, beforeContent)
+
+			expect(result.model.descriptors).toEqual(repeated.model.descriptors)
+			expectValidRanges(result.before, result.model.descriptors, 'before')
+			expectValidRanges(result.after, result.model.descriptors, 'after')
+			const beforeAnchor = topLevelRanges(result.before).find(({ text }) => text === unchanged)!
+			const afterAnchor = topLevelRanges(result.after).find(({ text }) => text === unchanged)!
+			expect(result.model.descriptors.some(({ before }) => touched(before, beforeAnchor))).toBe(false)
+			expect(result.model.descriptors.some(({ after }) => touched(after, afterAnchor))).toBe(false)
+			const beforeBlocks = topLevelRanges(result.before).filter(({ text }) => text)
+			const afterBlocks = topLevelRanges(result.after).filter(({ text }) => text)
+			const beforeTexts = new Set(beforeBlocks.map(({ text }) => text))
+			const afterTexts = new Set(afterBlocks.map(({ text }) => text))
+			for (const block of beforeBlocks.filter(({ text }) => !afterTexts.has(text))) {
+				expect(result.model.descriptors.filter(({ before }) => touched(before, block))).toHaveLength(1)
+			}
+			for (const block of afterBlocks.filter(({ text }) => !beforeTexts.has(text))) {
+				expect(result.model.descriptors.filter(({ after }) => touched(after, block))).toHaveLength(1)
+			}
+			const inserted = result.model.descriptors.filter(({ operation }) => operation === 'insert').length
+			const deleted = result.model.descriptors.filter(({ operation }) => operation === 'delete').length
+			expect(swapped.model.descriptors.filter(({ operation }) => operation === 'insert')).toHaveLength(deleted)
+			expect(swapped.model.descriptors.filter(({ operation }) => operation === 'delete')).toHaveLength(inserted)
+			const beforeCoverage = result.model.descriptors.map((descriptor) => rangeText(result.before, descriptor, 'before')).toSorted()
+			const swappedAfterCoverage = swapped.model.descriptors.map((descriptor) => rangeText(swapped.after, descriptor, 'after')).toSorted()
+			expect(swappedAfterCoverage).toEqual(beforeCoverage)
+		}
+	})
+})

--- a/src/tests/comparison/markdownComparison.spec.ts
+++ b/src/tests/comparison/markdownComparison.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import { createMarkdownComparisonModel } from '../../comparison/markdownComparison.ts'
+import { stableSerialize } from '../../comparison/markdownComparisonClassification.ts'
+import {
+	ATLAS_CURRENT_CONTENT,
+	ATLAS_INITIAL_CONTENT,
+} from './fixtures/atlasComparison.ts'
+
+function compare(beforeContent: string, afterContent: string) {
+	const before = createComparisonEditor(beforeContent)
+	const after = createComparisonEditor(afterContent)
+	try {
+		return {
+			before: before.state.doc,
+			after: after.state.doc,
+			model: createMarkdownComparisonModel(before.state.doc, after.state.doc),
+		}
+	} finally {
+		before.destroy()
+		after.destroy()
+	}
+}
+
+describe('semantic Markdown comparison', () => {
+	it('serializes object keys by code units rather than locale collation', () => {
+		expect(stableSerialize({ ä: 1, z: 2, a: 3 })).toBe('{"a":3,"z":2,"ä":1}')
+	})
+
+	it.each([
+		['identical documents', '# Heading\n\nText', '# Heading\n\nText'],
+		['both empty', '', ''],
+		['equivalent heading syntax', '# Heading', '# Heading #'],
+	])('finds no semantic change for %s', (_name, before, after) => {
+		expect(compare(before, after).model.descriptors).toEqual([])
+	})
+
+	it.each([
+		['empty to content', '', 'content'],
+		['content to empty', 'content', ''],
+		['text insertion', 'one', 'one two'],
+		['text deletion', 'one two', 'one'],
+		['text replacement', 'one two', 'one three'],
+		['punctuation-heavy words', 'wait...what?!', 'wait—what?'],
+		['semantic whitespace', 'one\ntwo', 'one  \ntwo'],
+		['Unicode', 'café', 'cafe'],
+		['CJK', '发布计划', '发布方案'],
+		['emoji and graphemes', '👩‍💻 e\u0301', '👨‍💻 é'],
+		['bidi and RTL', 'English', 'العربية'],
+		['bold', 'text', '**text**'],
+		['italic', 'text', '*text*'],
+		['strike', 'text', '~~text~~'],
+		['inline code', 'text', '`text`'],
+		['link target', '[text](https://before.example)', '[text](https://after.example)'],
+		['heading attribute', '# Heading', '## Heading'],
+		['list attribute', '1. item', '3. item'],
+		['task attribute', '- [ ] item', '- [x] item'],
+		['paragraph and blockquote', 'paragraph', '> paragraph'],
+		['code block', '```js\nconst value = 1\n```', '```js\nconst value = 2\n```'],
+		['nested list', '- parent\n  - child one', '- parent\n  - child two'],
+		['deleted list item', '- one\n- two\n- three', '- one\n- three'],
+		['table cell', '| A | B |\n|---|---|\n| 1 | 2 |', '| A | B |\n|---|---|\n| 1 | 3 |'],
+		['deleted table row', '| A |\n|---|\n| 1 |\n| 2 |', '| A |\n|---|\n| 1 |'],
+		['deleted table cell', '| A | B |\n|---|---|\n| 1 | 2 |', '| A |\n|---|\n| 1 |'],
+		['whole table', '| A |\n|---|\n| 1 |', 'No table'],
+		['whole list', '- one\n- two', 'No list'],
+		['callout', '::: info\nBefore\n:::', '::: info\nAfter\n:::'],
+		['details', '<details>\n<summary>Title</summary>\nBefore\n</details>', '<details>\n<summary>Title</summary>\nAfter\n</details>'],
+		['mention', '@[Jane](mention://user/jane)', '@[John](mention://user/john)'],
+		['preview', '[Before](https://example.test (preview))', '[After](https://example.test (preview))'],
+		['image', '![Before](.attachments.1/before.png)', '![After](.attachments.1/after.png)'],
+		['missing historical attachment', '![Missing](.attachments.1/missing.png)', 'No image'],
+		['mathematics', '$1 + 1 = 2$', '$1 + 2 = 3$'],
+		['open cross-parent change', 'one\n\ntwo', '- one\n- two'],
+	])('detects %s', (_name, before, after) => {
+		expect(compare(before, after).model.descriptors.length).toBeGreaterThan(0)
+	})
+
+	it.each([
+		['text replacement', 'one two', 'one three', ['text'], []],
+		['bold added', 'plain text', 'plain **text**', ['formatting'], [{ type: 'mark', mark: 'bold', change: 'added' }]],
+		['bold removed', 'plain **text**', 'plain text', ['formatting'], [{ type: 'mark', mark: 'bold', change: 'removed' }]],
+		['italic added', 'plain text', 'plain *text*', ['formatting'], [{ type: 'mark', mark: 'italic', change: 'added' }]],
+		['strike added', 'plain text', 'plain ~~text~~', ['formatting'], [{ type: 'mark', mark: 'strike', change: 'added' }]],
+		['highlight added', 'plain text', 'plain ==text==', ['formatting'], [{ type: 'mark', mark: 'highlight', change: 'added' }]],
+		['mixed text and formatting', 'plain text', 'plain **changed**', ['text', 'formatting'], [{ type: 'mark', mark: 'bold', change: 'added' }]],
+		['link added', 'text', '[text](https://example.test)', ['attribute'], [{ type: 'attribute', attribute: 'link', change: 'added' }]],
+		['link removed', '[text](https://example.test)', 'text', ['attribute'], [{ type: 'attribute', attribute: 'link', change: 'removed' }]],
+		['link target', '[text](https://before.test)', '[text](https://after.test)', ['attribute'], [{ type: 'attribute', attribute: 'link-target', change: 'changed' }]],
+		['heading level', '# Heading', '## Heading', ['attribute'], [{ type: 'attribute', attribute: 'heading-level', change: 'changed' }]],
+		['list start', '1. item', '3. item', ['attribute'], [{ type: 'attribute', attribute: 'list-start', change: 'changed' }]],
+		['task state', '- [ ] item', '- [x] item', ['attribute'], [{ type: 'attribute', attribute: 'task-state', change: 'changed' }]],
+		['code language', '```js\nsame\n```', '```ts\nsame\n```', ['attribute'], [{ type: 'attribute', attribute: 'code-language', change: 'changed' }]],
+		['image attributes', '![Before](before.png)', '![After](after.png)', ['attribute'], [
+			{ type: 'attribute', attribute: 'image-alt', change: 'changed' },
+			{ type: 'attribute', attribute: 'image-target', change: 'changed' },
+		]],
+	] as const)('classifies %s', (_name, before, after, facets, signals) => {
+		const descriptors = compare(before, after).model.descriptors
+		expect(descriptors).toHaveLength(1)
+		expect(descriptors[0]?.facets).toEqual(facets)
+		expect(descriptors[0]?.signals).toEqual(signals)
+	})
+
+	it.each([
+		['front matter', '---\ntitle: Before\n---\n\nBody', '---\ntitle: After\n---\n\nBody', 'front-matter'],
+		['nested list', '- parent\n  - before', '- parent\n  - after', 'list-item'],
+		['table cell', '| A |\n|---|\n| Before |', '| A |\n|---|\n| After |', 'table-cell'],
+		['callout', '::: info\nBefore\n:::', '::: info\nAfter\n:::', 'callout'],
+		['details', '<details>\n<summary>Title</summary>\nBefore\n</details>', '<details>\n<summary>Title</summary>\nAfter\n</details>', 'details'],
+		['footnote definition', 'Text[^one].\n\n[^one]: Before', 'Text[^one].\n\n[^one]: After', 'footnote'],
+	] as const)('uses a meaningful %s context', (_name, before, after, context) => {
+		for (const descriptor of compare(before, after).model.descriptors) {
+			expect(descriptor.context.before?.code).toBe(context)
+			expect(descriptor.context.after?.code).toBe(context)
+		}
+	})
+
+	it('returns immutable, translation-independent descriptors with safe leaf previews', () => {
+		const { model } = compare('![Before](before.png)', '![After](after.png)')
+		const descriptor = model.descriptors[0]!
+		expect(Object.isFrozen(model)).toBe(true)
+		expect(Object.isFrozen(model.descriptors)).toBe(true)
+		expect(Object.isFrozen(descriptor.signals)).toBe(true)
+		expect(descriptor.preview).toEqual({
+			before: { kind: 'node', node: 'image' },
+			after: { kind: 'node', node: 'image' },
+		})
+		expect(JSON.stringify(descriptor)).not.toContain('before.png')
+		expect(JSON.stringify(descriptor)).not.toContain('After changed')
+	})
+
+	it.each([
+		['text replacement', 'one two', 'one three', 'two', 'three'],
+		['formatting-only replacement', 'plain text', 'plain **text**', 'text', 'text'],
+		['link-target replacement', '[text](https://before.example)', '[text](https://after.example)', 'text', 'text'],
+		['table-cell replacement', '| A | B |\n|---|---|\n| 1 | 2 |', '| A | B |\n|---|---|\n| 1 | 3 |', '2', '3'],
+	])('keeps %s ranges on the changed content', (_name, beforeContent, afterContent, beforeText, afterText) => {
+		const { before, after, model } = compare(beforeContent, afterContent)
+		expect(model.descriptors).toHaveLength(1)
+		const [change] = model.descriptors
+		expect(before.textBetween(change!.before.from, change!.before.to)).toBe(beforeText)
+		expect(after.textBetween(change!.after.from, change!.after.to)).toBe(afterText)
+	})
+
+	it('detects normalized node attributes without a text change', () => {
+		const beforeEditor = createComparisonEditor('same text')
+		try {
+			const before = beforeEditor.state.doc
+			const after = beforeEditor.state.tr.setNodeAttribute(0, 'dir', 'rtl').doc
+			expect(createMarkdownComparisonModel(before, after).descriptors).not.toEqual([])
+		} finally {
+			beforeEditor.destroy()
+		}
+	})
+
+	it('classifies a normalized text-direction attribute without exposing its raw value', () => {
+		const editor = createComparisonEditor('same text')
+		try {
+			const before = editor.state.doc
+			const after = editor.state.tr.setNodeAttribute(0, 'dir', 'rtl').doc
+			const descriptor = createMarkdownComparisonModel(before, after).descriptors[0]
+			expect(descriptor).toMatchObject({
+				facets: ['attribute'],
+				signals: [{ type: 'attribute', attribute: 'text-direction', change: 'changed' }],
+			})
+			expect(JSON.stringify(descriptor)).not.toContain('rtl')
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('keeps an explicit direction removal on unchanged neutral text', () => {
+		const editor = createComparisonEditor('1234')
+		try {
+			const before = editor.state.tr.setNodeAttribute(0, 'dir', 'rtl').doc
+			const after = editor.state.tr.setNodeAttribute(0, 'dir', null).doc
+			expect(createMarkdownComparisonModel(before, after).descriptors[0]?.signals)
+				.toContainEqual({ type: 'attribute', attribute: 'text-direction', change: 'changed' })
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('keeps an explicit direction removal when neutral text also changes', () => {
+		const beforeEditor = createComparisonEditor('1234')
+		const afterEditor = createComparisonEditor('5678')
+		try {
+			const before = beforeEditor.state.tr.setNodeAttribute(0, 'dir', 'rtl').doc
+			const signals = createMarkdownComparisonModel(before, afterEditor.state.doc)
+				.descriptors.flatMap(({ signals }) => signals)
+
+			expect(signals)
+				.toContainEqual({ type: 'attribute', attribute: 'text-direction', change: 'changed' })
+		} finally {
+			beforeEditor.destroy()
+			afterEditor.destroy()
+		}
+	})
+
+	it('keeps a small edit in a large document narrow', () => {
+		const common = Array.from({ length: 1000 }, (_, index) => `line ${index}`).join('\n\n')
+		const { model } = compare(common, common.replace('line 500', 'line changed'))
+		expect(model.descriptors).toHaveLength(1)
+		const [change] = model.descriptors
+		expect(change!.before.to - change!.before.from).toBeLessThan(20)
+		expect(change!.after.to - change!.after.from).toBeLessThan(20)
+		expect(change!.detail).toBe('inline')
+	})
+
+	it('uses honest block detail beyond the bounded inline budget', () => {
+		const before = `# Before\n\n${'a'.repeat(6000)}`
+		const after = `# After\n\n${'b'.repeat(6000)}`
+		const { model } = compare(before, after)
+		expect(model.descriptors).toHaveLength(2)
+		expect(model.descriptors.map(({ detail }) => detail)).toEqual(['inline', 'block'])
+	})
+
+	it('pins the Atlas launch-plan semantic classifications', () => {
+		const { model } = compare(ATLAS_INITIAL_CONTENT, ATLAS_CURRENT_CONTENT)
+		const signals = model.descriptors.flatMap(({ signals }) => signals)
+		const contexts = model.descriptors.flatMap(({ context }) => [
+			context.before?.code,
+			context.after?.code,
+		])
+
+		expect(model.descriptors.filter(({ operation }) => operation === 'move')).toHaveLength(1)
+		expect(model.descriptors.filter(({ facets }) => facets.length === 1 && facets[0] === 'formatting'))
+			.toHaveLength(2)
+		expect(model.descriptors).toContainEqual(expect.objectContaining({ facets: ['text', 'formatting'] }))
+		expect(signals).toEqual(expect.arrayContaining([
+			{ type: 'mark', mark: 'bold', change: 'added' },
+			{ type: 'mark', mark: 'italic', change: 'added' },
+			{ type: 'attribute', attribute: 'link', change: 'added' },
+			{ type: 'attribute', attribute: 'link', change: 'removed' },
+			{ type: 'attribute', attribute: 'link-target', change: 'changed' },
+			{ type: 'attribute', attribute: 'task-state', change: 'changed' },
+			{ type: 'attribute', attribute: 'callout-type', change: 'changed' },
+			{ type: 'attribute', attribute: 'footnote-reference', change: 'changed' },
+			{ type: 'attribute', attribute: 'image-alt', change: 'changed' },
+		]))
+		expect(signals).not.toContainEqual({ type: 'attribute', attribute: 'text-direction', change: 'changed' })
+		expect(contexts).toEqual(expect.arrayContaining([
+			'front-matter',
+			'quote',
+			'paragraph',
+			'heading',
+			'task',
+			'table-cell',
+			'callout',
+			'details',
+			'code-block',
+			'footnote-reference',
+			'image',
+			'footnote',
+		]))
+	})
+})

--- a/src/tests/comparison/markdownComparisonMoves.spec.ts
+++ b/src/tests/comparison/markdownComparisonMoves.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import { confirmReservedExactMoves } from '../../comparison/markdownComparisonMoves.ts'
+
+describe('Markdown comparison moves', () => {
+	it('does not traverse either document without reserved move candidates', () => {
+		const beforeEditor = createComparisonEditor('Before')
+		const afterEditor = createComparisonEditor('After')
+		try {
+			const beforeDescendants = vi.spyOn(beforeEditor.state.doc, 'descendants')
+			const afterDescendants = vi.spyOn(afterEditor.state.doc, 'descendants')
+
+			expect(confirmReservedExactMoves(beforeEditor.state.doc, afterEditor.state.doc, []))
+				.toEqual({ groups: [], rejected: [] })
+			expect(beforeDescendants).not.toHaveBeenCalled()
+			expect(afterDescendants).not.toHaveBeenCalled()
+		} finally {
+			beforeEditor.destroy()
+			afterEditor.destroy()
+		}
+	})
+})

--- a/src/tests/comparison/renderedComparisonLimit.spec.ts
+++ b/src/tests/comparison/renderedComparisonLimit.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+	exceedsRenderedComparisonLimit,
+	RENDERED_COMPARISON_LIMITS,
+} from '../../comparison/renderedComparisonLimit.ts'
+
+describe('renderedComparisonLimit', () => {
+	it('keeps at least 20% below the smallest measured failing dimensions', () => {
+		expect(RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot).toBeLessThanOrEqual(Math.floor(264_599 * 0.8))
+		expect(RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot).toBeLessThanOrEqual(Math.floor(8_163 * 0.8))
+	})
+
+	it('allows a normal page comparison', () => {
+		expect(exceedsRenderedComparisonLimit('# Before\n\nContent', '# After\n\nRevised content')).toBe(false)
+	})
+
+	it.each([
+		RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot - 1,
+		RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot,
+	])('allows a snapshot with %i characters', (length) => {
+		expect(exceedsRenderedComparisonLimit('a'.repeat(length), 'After')).toBe(false)
+	})
+
+	it('rejects either snapshot above the character limit', () => {
+		const oversized = 'a'.repeat(RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot + 1)
+		expect(exceedsRenderedComparisonLimit(oversized, 'After')).toBe(true)
+		expect(exceedsRenderedComparisonLimit('Before', oversized)).toBe(true)
+	})
+
+	it.each([
+		RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot - 1,
+		RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot,
+	])('allows a snapshot with %i lines', (lineCount) => {
+		const content = Array.from({ length: lineCount }, () => 'line').join('\n')
+		expect(exceedsRenderedComparisonLimit(content, 'After')).toBe(false)
+	})
+
+	it('rejects either snapshot above the line limit with LF, CRLF, or CR separators', () => {
+		const lineCount = RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot + 1
+		for (const separator of ['\n', '\r\n', '\r']) {
+			const oversized = Array.from({ length: lineCount }, () => 'line').join(separator)
+			expect(exceedsRenderedComparisonLimit(oversized, 'After')).toBe(true)
+			expect(exceedsRenderedComparisonLimit('Before', oversized)).toBe(true)
+		}
+	})
+})

--- a/src/tests/extensions/TextDirection.spec.ts
+++ b/src/tests/extensions/TextDirection.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Transaction } from '@tiptap/pm/state'
+
+import { Editor } from '@tiptap/core'
+import { afterEach, describe, expect, it } from 'vitest'
+import RichText from '../../extensions/RichText.ts'
+import TextDirection from '../../extensions/TextDirection.ts'
+import markdownit from '../../markdownit/index.js'
+
+const directionTypes = [
+	'blockquote',
+	'callout',
+	'detailsSummary',
+	'footnote',
+	'heading',
+	'listItem',
+	'paragraph',
+	'tableCell',
+	'tableHeader',
+	'taskItem',
+]
+
+const editors: Editor[] = []
+
+afterEach(() => {
+	for (const editor of editors.splice(0)) {
+		editor.destroy()
+	}
+})
+
+function createEditor(
+	defaultDirection: 'ltr' | 'rtl' | 'auto' | null = null,
+	content?: string,
+	inferTextDirectionOnParse = true,
+) {
+	const editor = new Editor({
+		content,
+		extensions: [
+			RichText.configure({
+				editing: false,
+				extensions: [TextDirection.configure({
+					defaultDirection,
+					inferTextDirectionOnParse,
+					types: directionTypes,
+				})],
+			}),
+		],
+	})
+	editors.push(editor)
+	return editor
+}
+
+function captureAppendedTransactions(editor: Editor) {
+	const transactions: Transaction[] = []
+	editor.on('transaction', ({ appendedTransactions }) => transactions.push(...appendedTransactions))
+	return transactions
+}
+
+function directionSteps(transactions: readonly Transaction[]) {
+	return transactions.flatMap(({ steps }) => steps).filter((step) => {
+		const json = step.toJSON() as { attr?: string, attrs?: Record<string, unknown> }
+		return json.attr === 'dir' || json.attrs?.dir !== undefined
+	})
+}
+
+function nodeDirections(editor: Editor, type: string) {
+	const directions: Array<string | null> = []
+	editor.state.doc.descendants((node) => {
+		if (node.type.name === type) {
+			directions.push(node.attrs.dir as string | null)
+		}
+		return true
+	})
+	return directions
+}
+
+describe('TextDirection', () => {
+	it('keeps parse-time inference opt-in', () => {
+		const editor = createEditor(null, '<p>English</p>', false)
+		expect(nodeDirections(editor, 'paragraph')[0]).toBeNull()
+	})
+
+	it('infers parsed LTR and RTL content without an appended direction transaction', () => {
+		const editor = createEditor()
+		const appended = captureAppendedTransactions(editor)
+		editor.commands.setContent('<p>English</p><p>العربية</p>')
+
+		expect(nodeDirections(editor, 'paragraph').slice(0, 2)).toEqual(['ltr', 'rtl'])
+		expect(directionSteps(appended)).toEqual([])
+	})
+
+	it('preserves explicit valid direction before inferred content direction', () => {
+		const editor = createEditor()
+		editor.commands.setContent([
+			'<p dir="rtl">English</p>',
+			'<p dir="ltr">العربية</p>',
+			'<p dir="auto">English</p>',
+			'<p dir="invalid">English</p>',
+		].join(''))
+
+		expect(nodeDirections(editor, 'paragraph').slice(0, 4)).toEqual(['rtl', 'ltr', 'auto', 'ltr'])
+	})
+
+	it.each([
+		[null, [null, null]],
+		['rtl', ['rtl', 'rtl']],
+	] as const)('uses the %s default for neutral and empty parsed content', (defaultDirection, expected) => {
+		const editor = createEditor(defaultDirection, '<p>1234</p><p></p>')
+		expect(nodeDirections(editor, 'paragraph').slice(0, 2)).toEqual(expected)
+	})
+
+	it('infers direction for every configured nested RichText node', () => {
+		const editor = createEditor()
+		const markdown = [
+			'# Heading',
+			'',
+			'> Quote',
+			'',
+			'- List item',
+			'',
+			'- [ ] Task item',
+			'',
+			'::: info',
+			'Callout',
+			':::',
+			'',
+			'<details>',
+			'<summary>Summary</summary>',
+			'Details',
+			'</details>',
+			'',
+			'| Header |',
+			'|---|',
+			'| Cell |',
+			'',
+			'Reference[^note].',
+			'',
+			'[^note]: Footnote',
+		].join('\n')
+		editor.commands.setContent(markdownit.render(markdown))
+
+		for (const type of directionTypes) {
+			expect(nodeDirections(editor, type), type).not.toEqual([])
+			expect(nodeDirections(editor, type), type).toEqual(expect.arrayContaining(['ltr']))
+		}
+	})
+})


### PR DESCRIPTION
**In one sentence:** the semantic model that turns two Markdown documents into a typed list of what changed.

## What and why

Text cannot tell you what changed between two versions of a Markdown document. Byte diffs report edits, not meaning — nothing says a paragraph was inserted, a table row changed, or a link target moved. This PR adds the model that answers that question: two documents in, a typed list of changes out.

## What's in this PR

- A comparison model built on ProseMirror `ChangeSet`
- Every change classified as text, formatting, attribute, structure, or unknown
- Conservative move detection and position mapping between the two revisions
- An explicit complexity limit — the caller gets a "limited" result, never a silent partial list
- No UI. This unit deliberately has no screenshot; the three views arrive in the next PRs.

## Design notes

- **One shared schema is an invariant.** ProseMirror compares node types by identity, so both editors must parse against the same schema instance — otherwise the result is wrong, not slow. Tests pin this.
- **Moves under-report on purpose.** Only exact moves are detected; anything ambiguous becomes a remove + insert. A missed move is noise; a wrong move claims edited content is unchanged.
- **Attributes and formatting stay separate** so "hide formatting-only changes" can never hide a changed link target.

## Stack

First of six. #9044 builds on it, then #9045 and #9046. The Collectives side lands in nextcloud/collectives#2697 and #2698 after all four Text PRs.

## Verification

`ts:check` and `lint` pass; complete suite 1,768/1,768 at this tip. Zero drift against upstream `main`; the sign-off rebase changed only commit metadata.

## AI assistance

Commits carry `Assisted-by: Codex:gpt-5.6-sol`; an independent review pass was run with Claude Opus 5. This description was drafted with Hermes (deepseek-v4-pro) from my notes, then reviewed by me.

## Related

- https://github.com/nextcloud/collectives/issues/599
- https://github.com/nextcloud/text/issues/4422
