### PR TITLE
Compare literal Markdown off the main thread

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@tiptap/vue-3": "^3.30.0",
         "@vueuse/shared": "^14.4.0",
         "debounce": "^3.0.0",
+        "diff": "^8.0.3",
         "escape-html": "^1.0.3",
         "highlight.js": "^11.11.1",
         "katex": "^0.18.1",
@@ -9750,7 +9751,6 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
       "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@tiptap/vue-3": "^3.30.0",
     "@vueuse/shared": "^14.4.0",
     "debounce": "^3.0.0",
+    "diff": "^8.0.3",
     "escape-html": "^1.0.3",
     "highlight.js": "^11.11.1",
     "katex": "^0.18.1",

--- a/src/comparison/comparisonDocumentIndex.ts
+++ b/src/comparison/comparisonDocumentIndex.ts
@@ -1,0 +1,242 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonRange } from './markdownComparisonTypes.ts'
+
+export interface LocatedComparisonNode {
+	node: Node
+	path: readonly number[]
+	index: number
+	from: number
+	to: number
+	parent: LocatedComparisonNode | null
+	children: readonly LocatedComparisonNode[]
+}
+
+export interface ComparisonDocumentIndex {
+	children: readonly LocatedComparisonNode[]
+	nodes: readonly LocatedComparisonNode[]
+	nodeAtPath: (path: readonly number[]) => LocatedComparisonNode
+}
+
+export interface ComparisonNodeSearchAudit {
+	examinedNodes: number
+}
+
+interface MutableLocatedComparisonNode extends Omit<LocatedComparisonNode, 'children'> {
+	children: MutableLocatedComparisonNode[]
+}
+
+/**
+ * Build one reusable position and path index for an immutable document.
+ *
+ * @param doc Immutable ProseMirror document
+ * @param audit Optional operation counter for structural regression tests
+ */
+export function createComparisonDocumentIndex(
+	doc: Node,
+	audit?: ComparisonNodeSearchAudit,
+): ComparisonDocumentIndex {
+	const nodes: MutableLocatedComparisonNode[] = []
+	const byPath = new Map<string, MutableLocatedComparisonNode>()
+	const locateChildren = (
+		parentNode: Node,
+		parentLocation: MutableLocatedComparisonNode | null,
+		parentPath: readonly number[],
+		contentFrom: number,
+	) => {
+		const children: MutableLocatedComparisonNode[] = []
+		parentNode.forEach((node, offset, index) => {
+			if (audit) {
+				audit.examinedNodes++
+			}
+			const from = contentFrom + offset
+			const path = [...parentPath, index]
+			const location: MutableLocatedComparisonNode = {
+				node,
+				path,
+				index,
+				from,
+				to: from + node.nodeSize,
+				parent: parentLocation,
+				children: [],
+			}
+			children.push(location)
+			nodes.push(location)
+			byPath.set(pathKey(path), location)
+			if (!node.isLeaf) {
+				location.children = locateChildren(node, location, path, from + 1)
+			}
+		})
+		return children
+	}
+	const children = locateChildren(doc, null, [], 0)
+	return {
+		children,
+		nodes,
+		nodeAtPath(path) {
+			const location = byPath.get(pathKey(path))
+			if (!location) {
+				throw new Error(`Comparison document path does not exist: ${path.join('.')}`)
+			}
+			return location
+		},
+	}
+}
+
+/**
+ * Find touched nodes without scanning unrelated siblings.
+ *
+ * @param range Absolute document range
+ * @param roots Smallest known roots for the range
+ * @param audit Optional operation counter for structural regression tests
+ */
+export function findComparisonNodes(
+	range: ComparisonRange,
+	roots: readonly LocatedComparisonNode[],
+	audit?: ComparisonNodeSearchAudit,
+) {
+	const found = new Map<string, LocatedComparisonNode>()
+	const add = (location: LocatedComparisonNode) => found.set(pathKey(location.path), location)
+	const visit = (location: LocatedComparisonNode) => {
+		if (audit) {
+			audit.examinedNodes++
+		}
+		if (!touches(location, range)) {
+			return
+		}
+		add(location)
+		visitChildren(location.children, range, visit, audit)
+	}
+	for (const root of minimalRoots(roots)) {
+		for (let ancestor = root.parent; ancestor; ancestor = ancestor.parent) {
+			add(ancestor)
+		}
+		visit(root)
+	}
+	return [...found.values()].toSorted((a, b) => a.from - b.from || a.path.length - b.path.length)
+}
+
+/**
+ * Read text from the known roots instead of resolving the range from the document root.
+ *
+ * @param range Absolute document range
+ * @param roots Known range roots
+ */
+export function comparisonRangeText(range: ComparisonRange, roots: readonly LocatedComparisonNode[]) {
+	if (range.from === range.to) {
+		return ''
+	}
+	return minimalRoots(roots)
+		.filter((root) => touches(root, range))
+		.map((root) => textFromRoot(root, range))
+		.join('\n')
+}
+
+/**
+ * Visit child nodes that can intersect the requested range.
+ *
+ * @param children Candidate child nodes
+ * @param range Absolute document range
+ * @param visit Callback for each matching node
+ * @param audit Optional operation counter for structural regression tests
+ */
+function visitChildren(
+	children: readonly LocatedComparisonNode[],
+	range: ComparisonRange,
+	visit: (location: LocatedComparisonNode) => void,
+	audit?: ComparisonNodeSearchAudit,
+) {
+	let lower = 0
+	let upper = children.length
+	while (lower < upper) {
+		const middle = (lower + upper) >>> 1
+		if (audit) {
+			audit.examinedNodes++
+		}
+		const beforeRange = range.from === range.to
+			? children[middle]!.to < range.from
+			: children[middle]!.to <= range.from
+		if (beforeRange) {
+			lower = middle + 1
+		} else {
+			upper = middle
+		}
+	}
+	for (let index = lower; index < children.length; index++) {
+		const child = children[index]!
+		if (audit) {
+			audit.examinedNodes++
+		}
+		if (range.from === range.to ? child.from > range.from : child.from >= range.to) {
+			break
+		}
+		visit(child)
+	}
+}
+
+/**
+ * Check whether a located node intersects a document range.
+ *
+ * @param location Located document node
+ * @param range Absolute document range
+ */
+function touches(location: LocatedComparisonNode, range: ComparisonRange) {
+	return range.from === range.to
+		? range.from >= location.from && range.from <= location.to
+		: range.from < location.to && range.to > location.from
+}
+
+/**
+ * Remove roots whose ancestor is already present.
+ *
+ * @param roots Known range roots
+ */
+function minimalRoots(roots: readonly LocatedComparisonNode[]) {
+	const rootPaths = new Set(roots.map(({ path }) => pathKey(path)))
+	return roots.filter((root) => {
+		for (let ancestor = root.parent; ancestor; ancestor = ancestor.parent) {
+			if (rootPaths.has(pathKey(ancestor.path))) {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+/**
+ * Read the requested text from one known root.
+ *
+ * @param root Known range root
+ * @param range Absolute document range
+ */
+function textFromRoot(root: LocatedComparisonNode, range: ComparisonRange) {
+	if (root.node.isText) {
+		return root.node.text?.slice(
+			Math.max(0, range.from - root.from),
+			Math.min(root.node.nodeSize, range.to - root.from),
+		) ?? ''
+	}
+	if (root.node.isLeaf) {
+		return '\ufffc'
+	}
+	const contentFrom = root.from + 1
+	return root.node.textBetween(
+		Math.max(0, range.from - contentFrom),
+		Math.min(root.node.content.size, range.to - contentFrom),
+		'\n',
+		'\ufffc',
+	)
+}
+
+/**
+ * Encode a document path for map lookup.
+ *
+ * @param path Document child-index path
+ */
+function pathKey(path: readonly number[]) {
+	return path.join('.')
+}

--- a/src/comparison/comparisonDocumentLocation.ts
+++ b/src/comparison/comparisonDocumentLocation.ts
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Center one comparison target inside its own document scroller.
+ *
+ * @param pane Side-specific document pane
+ * @param scroller Side-specific document scroller
+ * @param id Opaque comparison descriptor ID
+ * @param behavior Motion preference
+ */
+export function locateComparisonTarget(
+	pane: HTMLElement | null,
+	scroller: HTMLElement | null,
+	id: string,
+	behavior: ScrollBehavior,
+) {
+	if (!pane || !scroller || !pane.contains(scroller)) {
+		return false
+	}
+	if (pane.hidden || pane.style.display === 'none') {
+		return false
+	}
+	const target = [...pane.querySelectorAll<HTMLElement>('[data-comparison-change]')]
+		.find((element) => element.dataset.comparisonChange === id)
+	if (!target) {
+		return false
+	}
+
+	const scrollerRect = scroller.getBoundingClientRect()
+	const targetRect = target.getBoundingClientRect()
+	const centeredTop = scroller.scrollTop
+		+ targetRect.top
+		- scrollerRect.top
+		- (scroller.clientHeight - targetRect.height) / 2
+	const maximumTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight)
+	scroller.scrollTo({
+		behavior,
+		left: scroller.scrollLeft,
+		top: Math.min(Math.max(0, centeredTop), maximumTop),
+	})
+	return true
+}

--- a/src/comparison/comparisonEditorLifecycle.ts
+++ b/src/comparison/comparisonEditorLifecycle.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { EditorState, Plugin } from '@tiptap/pm/state'
+import type { Editor } from '@tiptap/vue-3'
+
+const INITIALIZATION_ERROR = 'Comparison editor plugin initialization failed'
+const stateOnlyEditors = new WeakSet<Editor>()
+
+/**
+ * Register one comparison editor created without a view.
+ *
+ * @param editor State-only comparison editor
+ */
+export function registerStateOnlyComparisonEditor(editor: Editor) {
+	if (editor.options.element !== null || editor.contentComponent !== null || editor.appContext !== null) {
+		throw new Error(INITIALIZATION_ERROR)
+	}
+	stateOnlyEditors.add(editor)
+}
+
+/**
+ * Register one comparison plugin against the live mounted state.
+ *
+ * @param editor Mounted comparison editor
+ * @param plugin Comparison plugin
+ */
+export function registerMountedPlugin(editor: Editor, plugin: Plugin): EditorState {
+	const previousPlugins = new Set(editor.view.state.plugins)
+	let nextState: EditorState
+	try {
+		nextState = editor.registerPlugin(plugin, (newPlugin) => [
+			...editor.view.state.plugins.filter((item) => item.spec.key !== newPlugin.spec.key),
+			newPlugin,
+		])
+	} catch (error) {
+		throw new Error(INITIALIZATION_ERROR, { cause: error })
+	}
+	if ([...previousPlugins].some((item) => !nextState.plugins.includes(item))
+		|| nextState.plugins.filter((item) => item === plugin).length !== 1
+		|| nextState !== editor.view.state
+		|| editor.state !== nextState) {
+		throw new Error(INITIALIZATION_ERROR)
+	}
+	return nextState
+}
+
+/**
+ * Consume the one-shot state-only registration before the visible mount.
+ *
+ * @param editor State-only comparison editor
+ */
+export function consumeStateOnlyComparisonEditor(editor: Editor) {
+	if (!stateOnlyEditors.delete(editor)) {
+		throw new Error(INITIALIZATION_ERROR)
+	}
+}

--- a/src/comparison/comparisonNavigation.ts
+++ b/src/comparison/comparisonNavigation.ts
@@ -1,0 +1,163 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonDescriptor } from './markdownComparisonTypes.ts'
+
+export interface ComparisonDescriptorGroup {
+	id: string
+	descriptors: readonly ComparisonDescriptor[]
+}
+
+/**
+ * Reader-facing change kinds.
+ *
+ * `facets` overlap by design, so they cannot be presented as filters directly.
+ * These four kinds are assigned by `comparisonChangeKind`, which is total and
+ * disjoint: every descriptor resolves to exactly one kind, so kind counts
+ * always sum to the descriptor count.
+ */
+export type ComparisonChangeKind = 'content' | 'formatting' | 'move' | 'other'
+
+/** Stable presentation order for change kinds. */
+export const COMPARISON_CHANGE_KINDS: readonly ComparisonChangeKind[] = ['content', 'formatting', 'move', 'other']
+
+/**
+ * Check whether a descriptor contains only formatting changes.
+ *
+ * @param descriptor Semantic comparison descriptor
+ */
+export function isPureFormatting(descriptor: ComparisonDescriptor) {
+	return descriptor.facets.length === 1 && descriptor.facets[0] === 'formatting'
+}
+
+/**
+ * Resolve the single reader-facing kind of one descriptor.
+ *
+ * Ordered so that the strongest claim wins: a relocation is a move even when
+ * its text also changed, and anything touching words or document structure is
+ * content even when it also changed formatting. Everything the reader cannot
+ * act on as text — attribute-only edits and unclassified changes — is `other`.
+ *
+ * @param descriptor Semantic change
+ */
+export function comparisonChangeKind(descriptor: ComparisonDescriptor): ComparisonChangeKind {
+	if (descriptor.operation === 'move') {
+		return 'move'
+	}
+	if (isPureFormatting(descriptor)) {
+		return 'formatting'
+	}
+	if (descriptor.facets.includes('text') || descriptor.facets.includes('structure')) {
+		return 'content'
+	}
+	return 'other'
+}
+
+/**
+ * Select visible descriptor IDs for the active filter.
+ *
+ * @param descriptors Semantic comparison descriptors in source order
+ * @param hidePureFormatting Whether to omit formatting-only descriptors
+ */
+export function visibleDescriptorIds(
+	descriptors: readonly ComparisonDescriptor[],
+	hidePureFormatting: boolean,
+) {
+	return descriptors
+		.filter((descriptor) => !hidePureFormatting || !isPureFormatting(descriptor))
+		.map(({ id }) => id)
+}
+
+/**
+ * Present multiple algorithm ranges in one semantic block as one human edit.
+ * Exact moves remain standalone because one move can span several blocks.
+ *
+ * @param descriptors Visible descriptors in source order
+ */
+export function groupComparisonDescriptors(descriptors: readonly ComparisonDescriptor[]) {
+	const groups: ComparisonDescriptorGroup[] = []
+	const groupIndexByContext = new Map<string, number>()
+	for (const descriptor of descriptors) {
+		const key = descriptor.operation === 'move' ? descriptor.id : descriptorContextKey(descriptor)
+		const existingIndex = groupIndexByContext.get(key)
+		if (existingIndex !== undefined) {
+			const existing = groups[existingIndex]!
+			groups[existingIndex] = { ...existing, descriptors: [...existing.descriptors, descriptor] }
+		} else {
+			const group = { id: descriptor.id, descriptors: [descriptor] }
+			groups.push(group)
+			groupIndexByContext.set(key, groups.length - 1)
+		}
+	}
+	return groups
+}
+
+/** @param descriptor Semantic descriptor */
+function descriptorContextKey(descriptor: ComparisonDescriptor) {
+	const path = (side: 'before' | 'after') => descriptor.context[side]?.path.join('.') ?? '-'
+	return `${path('before')}|${path('after')}`
+}
+
+/**
+ * Preserve current ID or choose the next, then previous, descriptor in full-model order.
+ *
+ * @param descriptors Semantic comparison descriptors in source order
+ * @param activeIds Visible descriptor IDs
+ * @param currentId Selected descriptor ID
+ */
+export function currentIdAfterFilter(
+	descriptors: readonly ComparisonDescriptor[],
+	activeIds: readonly string[],
+	currentId: string | null,
+) {
+	const active = new Set(activeIds)
+	if (currentId && active.has(currentId)) {
+		return currentId
+	}
+	if (active.size === 0) {
+		return null
+	}
+	const currentIndex = descriptors.findIndex(({ id }) => id === currentId)
+	if (currentIndex >= 0) {
+		for (let index = currentIndex + 1; index < descriptors.length; index++) {
+			if (active.has(descriptors[index]!.id)) {
+				return descriptors[index]!.id
+			}
+		}
+		for (let index = currentIndex - 1; index >= 0; index--) {
+			if (active.has(descriptors[index]!.id)) {
+				return descriptors[index]!.id
+			}
+		}
+	}
+	return descriptors.find(({ id }) => active.has(id))?.id ?? null
+}
+
+/**
+ * Move the current selection through visible descriptor IDs.
+ *
+ * @param activeIds Visible descriptor IDs
+ * @param currentId Selected descriptor ID
+ * @param offset Signed navigation offset
+ */
+export function moveCurrentId(activeIds: readonly string[], currentId: string | null, offset: number) {
+	if (activeIds.length === 0) {
+		return null
+	}
+	const current = Math.max(0, activeIds.indexOf(currentId ?? ''))
+	const next = ((current + offset) % activeIds.length + activeIds.length) % activeIds.length
+	return activeIds[next]!
+}
+
+/**
+ * Resolve the one-based ordinal of the current descriptor.
+ *
+ * @param activeIds Visible descriptor IDs
+ * @param currentId Selected descriptor ID
+ */
+export function currentOrdinal(activeIds: readonly string[], currentId: string | null) {
+	const index = currentId ? activeIds.indexOf(currentId) : -1
+	return index < 0 ? 0 : index + 1
+}

--- a/src/comparison/comparisonPresentation.ts
+++ b/src/comparison/comparisonPresentation.ts
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+	ComparisonAttributeCode,
+	ComparisonMarkCode,
+	ComparisonSignal,
+} from './markdownComparisonTypes.ts'
+
+const attributePriority: Record<ComparisonAttributeCode, number> = {
+	'image-target': 219,
+	'image-alt': 218,
+	'link-target': 217,
+	link: 216,
+	'mention-identity': 215,
+	mathematics: 214,
+	'preview-target': 213,
+	'footnote-reference': 212,
+	'task-state': 211,
+	'heading-level': 210,
+	'list-start': 209,
+	'code-language': 208,
+	'text-direction': 207,
+	'table-span': 206,
+	'table-alignment': 205,
+	'callout-type': 204,
+	'details-state': 203,
+	'unknown-attribute': 202,
+}
+
+const markPriority: Record<ComparisonMarkCode, number> = {
+	bold: 106,
+	italic: 105,
+	strike: 104,
+	highlight: 103,
+	underline: 102,
+	'inline-code': 101,
+}
+
+/**
+ * Select the user-facing semantic signal independently of storage order.
+ *
+ * @param signals Canonically stored descriptor signals
+ */
+export function selectComparisonSignal(signals: readonly ComparisonSignal[]): ComparisonSignal | undefined {
+	return signals.reduce<ComparisonSignal | undefined>((selected, signal) => {
+		return !selected || signalPriority(signal) > signalPriority(selected) ? signal : selected
+	}, undefined)
+}
+
+/**
+ * @param signal Comparison signal
+ */
+function signalPriority(signal: ComparisonSignal) {
+	if (signal.type === 'attribute') {
+		return attributePriority[signal.attribute]
+	}
+	if (signal.type === 'mark') {
+		return markPriority[signal.mark]
+	}
+	return 150
+}

--- a/src/comparison/comparisonSections.ts
+++ b/src/comparison/comparisonSections.ts
@@ -1,0 +1,288 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonChangeKind, ComparisonDescriptorGroup } from './comparisonNavigation.ts'
+import type { ComparisonDescriptor } from './markdownComparisonTypes.ts'
+
+import { COMPARISON_CHANGE_KINDS, comparisonChangeKind } from './comparisonNavigation.ts'
+
+export interface ComparisonHeading {
+	from: number
+	text: string
+}
+
+export interface ComparisonSection {
+	/** Opaque, stable: the ID of the first group in the section. */
+	id: string
+	/** Nearest preceding heading, or '' for changes above the first heading. */
+	title: string
+	groups: readonly ComparisonDescriptorGroup[]
+	/** Kinds present in this section, in stable presentation order. */
+	kinds: readonly ComparisonChangeKind[]
+}
+
+/**
+ * Collect every heading in a document, in document order.
+ *
+ * @param doc Complete document
+ */
+export function headingLocations(doc: Node): readonly ComparisonHeading[] {
+	const headings: ComparisonHeading[] = []
+	doc.forEach((node, from) => {
+		const text = node.textContent.trim()
+		if (node.type.name === 'heading' && text) {
+			headings.push({ from, text })
+		}
+	})
+	return headings
+}
+
+/**
+ * Index of the nearest heading at or before a position, or -1 above them all.
+ *
+ * Binary search: `headings` must be ordered by `from`, which is what
+ * `headingLocations` returns.
+ *
+ * @param headings Ordered document headings
+ * @param position Descriptor position
+ */
+function nearestHeadingIndex(headings: readonly ComparisonHeading[], position: number) {
+	let lower = 0
+	let upper = headings.length
+	while (lower < upper) {
+		const middle = Math.floor((lower + upper) / 2)
+		if (headings[middle]!.from <= position) {
+			lower = middle + 1
+		} else {
+			upper = middle
+		}
+	}
+	return lower - 1
+}
+
+/**
+ * Find the nearest heading at or before a position.
+ *
+ * @param headings Ordered document headings
+ * @param position Descriptor position
+ */
+export function nearestHeading(headings: readonly ComparisonHeading[], position: number) {
+	return headings[nearestHeadingIndex(headings, position)]?.text ?? ''
+}
+
+interface HeadingIndex {
+	headings: readonly ComparisonHeading[]
+	keys: readonly string[]
+}
+
+/**
+ * @param headings Ordered document headings
+ */
+function indexByUniqueTitle(headings: readonly ComparisonHeading[]) {
+	const indexes = new Map<string, number>()
+	const repeated = new Set<string>()
+	headings.forEach(({ text }, index) => {
+		if (indexes.has(text)) {
+			repeated.add(text)
+		} else {
+			indexes.set(text, index)
+		}
+	})
+	for (const text of repeated) {
+		indexes.delete(text)
+	}
+	return indexes
+}
+
+/**
+ * Anchor the two heading lists on titles that are unique in both, ordered.
+ *
+ * The same patience strategy the node alignment uses: match only what is
+ * unambiguous, then keep the longest order-preserving run of those matches.
+ * O(n log n), so a document with thousands of headings needs no cutoff — and a
+ * cutoff here would be worse than slow, since falling back to pairing purely by
+ * position reports confident section names that are wrong.
+ *
+ * @param before Ordered Before headings
+ * @param after Ordered After headings
+ */
+function headingAnchors(before: readonly ComparisonHeading[], after: readonly ComparisonHeading[]) {
+	const beforeIndexes = indexByUniqueTitle(before)
+	const afterIndexes = indexByUniqueTitle(after)
+	const pairs: Array<[number, number]> = []
+	after.forEach(({ text }, afterIndex) => {
+		const beforeIndex = beforeIndexes.get(text)
+		if (beforeIndex !== undefined && afterIndexes.get(text) === afterIndex) {
+			pairs.push([beforeIndex, afterIndex])
+		}
+	})
+	return longestIncreasingPairs(pairs)
+}
+
+/**
+ * Select deterministic order-preserving anchors in O(n log n).
+ *
+ * @param pairs Candidate pairs in After order
+ */
+function longestIncreasingPairs(pairs: ReadonlyArray<[number, number]>) {
+	if (pairs.length === 0) {
+		return []
+	}
+	const tails: number[] = []
+	const previous = new Int32Array(pairs.length).fill(-1)
+	for (let candidate = 0; candidate < pairs.length; candidate++) {
+		const beforeIndex = pairs[candidate]![0]
+		let low = 0
+		let high = tails.length
+		while (low < high) {
+			const middle = (low + high) >>> 1
+			if (pairs[tails[middle]!]![0] < beforeIndex) {
+				low = middle + 1
+			} else {
+				high = middle
+			}
+		}
+		if (low > 0) {
+			previous[candidate] = tails[low - 1]!
+		}
+		tails[low] = candidate
+	}
+	const anchors: Array<[number, number]> = []
+	for (let index = tails.at(-1)!; index >= 0; index = previous[index]!) {
+		anchors.push(pairs[index]!)
+	}
+	return anchors.reverse()
+}
+
+/**
+ * Correlate the two documents' headings.
+ *
+ * Neither a position nor a title can do this alone: the documents have separate
+ * coordinate spaces, and a title can both repeat and change. Anchor on headings
+ * whose titles still match in order, then pair whatever is left between two
+ * anchors by position only when each gap contains one heading. A heading that
+ * was only renamed still occupies that slot. Larger or unequal gaps stay
+ * unpaired because insertions and renames have no unambiguous correlation.
+ *
+ * @param before Ordered Before headings
+ * @param after Ordered After headings
+ */
+function correlateHeadings(before: readonly ComparisonHeading[], after: readonly ComparisonHeading[]) {
+	const beforeKeys: string[] = []
+	const afterKeys: string[] = []
+	let next = 0
+	let row = 0
+	let column = 0
+
+	/**
+	 * @param rowEnd Before index the gap runs to
+	 * @param columnEnd After index the gap runs to
+	 */
+	function pairGap(rowEnd: number, columnEnd: number) {
+		const rowCount = rowEnd - row
+		const columnCount = columnEnd - column
+		if (rowCount !== columnCount || rowCount > 1) {
+			while (row < rowEnd) {
+				beforeKeys[row++] = `#${next++}`
+			}
+			while (column < columnEnd) {
+				afterKeys[column++] = `#${next++}`
+			}
+			return
+		}
+		while (row < rowEnd) {
+			const key = `#${next++}`
+			beforeKeys[row++] = key
+			afterKeys[column++] = key
+		}
+	}
+
+	for (const [anchorRow, anchorColumn] of headingAnchors(before, after)) {
+		pairGap(anchorRow, anchorColumn)
+		const key = `#${next++}`
+		beforeKeys[row++] = key
+		afterKeys[column++] = key
+	}
+	pairGap(before.length, after.length)
+	return { after: afterKeys, before: beforeKeys }
+}
+
+/**
+ * Resolve the section a group belongs to.
+ *
+ * @param group Changed semantic block
+ * @param before Indexed Before headings
+ * @param after Indexed After headings
+ */
+function resolveSection(group: ComparisonDescriptorGroup, before: HeadingIndex, after: HeadingIndex) {
+	const descriptor = group.descriptors[0]!
+	// A delete keeps an After context, but it points at the position the content
+	// collapsed to rather than anywhere the reader can still find it.
+	const deleted = descriptor.operation === 'delete'
+	const side = deleted ? before : after
+	const position = deleted
+		? descriptor.context.before?.from ?? descriptor.before.from
+		: descriptor.context.after?.from ?? descriptor.after.from
+	// '' above the first heading, which correlates across the two documents too.
+	return side.keys[nearestHeadingIndex(side.headings, position)] ?? ''
+}
+
+/**
+ * Group changes into the document sections they occurred in.
+ *
+ * Sections are runs, not buckets: a new section starts whenever the resolved
+ * heading changes, so groups stay in document order and a heading that repeats
+ * far apart in the document produces two sections rather than one merged one.
+ *
+ * @param groups Visible groups in source order
+ * @param beforeDocument Original Before document
+ * @param afterDocument Original After document
+ */
+export function buildComparisonSections(
+	groups: readonly ComparisonDescriptorGroup[],
+	beforeDocument: Node,
+	afterDocument: Node,
+): readonly ComparisonSection[] {
+	const beforeHeadings = headingLocations(beforeDocument)
+	const afterHeadings = headingLocations(afterDocument)
+	const correlation = correlateHeadings(beforeHeadings, afterHeadings)
+	const before: HeadingIndex = { headings: beforeHeadings, keys: correlation.before }
+	const after: HeadingIndex = { headings: afterHeadings, keys: correlation.after }
+	// A correlated section is named by the After document, so a rename shows the
+	// name the reader will find; one that no longer exists keeps the name it had.
+	const titleByKey = new Map<string, string>()
+	beforeHeadings.forEach((heading, index) => titleByKey.set(correlation.before[index]!, heading.text))
+	afterHeadings.forEach((heading, index) => titleByKey.set(correlation.after[index]!, heading.text))
+
+	const sections: Array<{ id: string, key: string, title: string, groups: ComparisonDescriptorGroup[] }> = []
+	for (const group of groups) {
+		const key = resolveSection(group, before, after)
+		const title = titleByKey.get(key) ?? ''
+		const current = sections.at(-1)
+		if (current && current.key === key) {
+			current.groups.push(group)
+		} else {
+			sections.push({ id: group.id, key, title, groups: [group] })
+		}
+	}
+	return sections.map((section) => {
+		const descriptors = section.groups.flatMap(({ descriptors }) => descriptors)
+		return {
+			groups: section.groups,
+			id: section.id,
+			kinds: presentChangeKinds(descriptors),
+			title: section.title,
+		}
+	})
+}
+
+/**
+ * @param descriptors Semantic changes
+ */
+function presentChangeKinds(descriptors: readonly ComparisonDescriptor[]) {
+	const present = new Set(descriptors.map(comparisonChangeKind))
+	return COMPARISON_CHANGE_KINDS.filter((kind) => present.has(kind))
+}

--- a/src/comparison/createComparisonEditor.ts
+++ b/src/comparison/createComparisonEditor.ts
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Schema } from '@tiptap/pm/model'
+
+import { Editor } from '@tiptap/vue-3'
+import { renderEditorContent } from '../composables/useEditorMethods.ts'
+import RichText from '../extensions/RichText.ts'
+import { registerStateOnlyComparisonEditor } from './comparisonEditorLifecycle.ts'
+
+interface ComparisonEditorOptions {
+	filePath?: string
+	noLazyImages?: boolean
+	openLink?: (href: string) => void
+	schema?: Schema
+}
+
+/**
+ * Create one normalized, immutable Text editor for comparison rendering.
+ *
+ * @param content Markdown content
+ * @param options Rendering options
+ */
+export function createComparisonEditor(content: string, options: ComparisonEditorOptions = {}) {
+	if (typeof content !== 'string') {
+		throw new TypeError('Comparison content must be a string')
+	}
+
+	const editor = new Editor({
+		content: renderEditorContent(content, true),
+		editable: false,
+		element: null,
+		extensions: [
+			RichText.configure({
+				editing: false,
+				emitAttachmentEvents: false,
+				extensions: [],
+				inferTextDirectionOnParse: true,
+				isEmbedded: true,
+				keymap: false,
+				noLazyImages: options.noLazyImages ?? false,
+				openLink: options.openLink,
+				relativePath: options.filePath,
+				search: false,
+			}),
+		],
+		onBeforeCreate: ({ editor }) => {
+			if (options.schema) {
+				editor.schema = options.schema
+				editor.extensionManager.schema = options.schema
+			}
+		},
+	})
+	registerStateOnlyComparisonEditor(editor)
+	return editor
+}

--- a/src/comparison/hierarchicalMarkdownComparisonModel.ts
+++ b/src/comparison/hierarchicalMarkdownComparisonModel.ts
@@ -1,0 +1,955 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type {
+	ComparisonDocumentIndex,
+	ComparisonNodeSearchAudit,
+	LocatedComparisonNode,
+} from './comparisonDocumentIndex.ts'
+import type { ReservedExactMovePair } from './markdownComparisonMoves.ts'
+import type {
+	ComparisonDescriptor,
+	ComparisonRange,
+	MarkdownComparisonModel,
+} from './markdownComparisonTypes.ts'
+
+import { ChangeSet, simplifyChanges } from '@tiptap/pm/changeset'
+import { StepMap } from '@tiptap/pm/transform'
+import {
+	comparisonRangeText,
+	createComparisonDocumentIndex,
+} from './comparisonDocumentIndex.ts'
+import {
+	classifyComparisonDescriptor,
+	classifyNodeMarkupDescriptor,
+	compareCodeUnits,
+	deepFreeze,
+	semanticTokenEncoder,
+	stableSerialize,
+} from './markdownComparisonClassification.ts'
+import { confirmReservedExactMoves } from './markdownComparisonMoves.ts'
+
+export const MAX_INLINE_ENVELOPE_SIZE = 4500
+export const MAX_ALIGNMENT_PRODUCT = 40_000
+export const MAX_RENDERED_COMPARISON_DESCRIPTORS = 10_000
+
+export interface ComparisonModelAudit extends ComparisonNodeSearchAudit {
+	fingerprintGroupAllocations: number
+}
+
+interface ComparisonModelOptions {
+	audit?: ComparisonModelAudit
+	maximumDescriptors?: number
+}
+
+export class ComparisonModelLimitError extends Error {
+	constructor() {
+		super('Rendered comparison change limit reached')
+		this.name = 'ComparisonModelLimitError'
+	}
+}
+
+const MAX_LINEAR_ALIGNMENT_LOOKAHEAD = 8
+
+const fingerprintCache = new WeakMap<Node, string>()
+
+type ExactPair = ReservedExactMovePair
+
+interface AlignmentStep {
+	before: LocatedComparisonNode | null
+	after: LocatedComparisonNode | null
+}
+
+interface AlignmentWindow {
+	before: readonly LocatedComparisonNode[]
+	after: readonly LocatedComparisonNode[]
+	beforeStart: number
+	beforeEnd: number
+	afterStart: number
+	afterEnd: number
+}
+
+interface InlineChangeRange {
+	fromA: number
+	toA: number
+	fromB: number
+	toB: number
+}
+
+interface ComparisonBuilder {
+	originalBefore: Node
+	originalAfter: Node
+	originalBeforeIndex: ComparisonDocumentIndex
+	originalAfterIndex: ComparisonDocumentIndex
+	comparisonBefore: Node
+	comparisonAfter: Node
+	comparisonBeforeIndex: ComparisonDocumentIndex
+	comparisonAfterIndex: ComparisonDocumentIndex
+	descriptors: ComparisonDescriptor[]
+	reservedMoves: ExactPair[]
+	audit?: ComparisonModelAudit
+	maximumDescriptors: number
+}
+
+/**
+ * Compare original documents by aligning bounded sibling windows recursively.
+ *
+ * @param originalBefore Earlier complete document and coordinate owner
+ * @param originalAfter Later complete document and coordinate owner
+ * @param options Comparison limits and optional structural-test counter
+ */
+export function createHierarchicalMarkdownComparisonModel(
+	originalBefore: Node,
+	originalAfter: Node,
+	options: ComparisonModelOptions = {},
+): MarkdownComparisonModel {
+	const { audit } = options
+	const normalized = normalizeSchemas(originalBefore, originalAfter)
+	const originalBeforeIndex = createComparisonDocumentIndex(originalBefore, audit)
+	const originalAfterIndex = createComparisonDocumentIndex(originalAfter, audit)
+	const comparisonBeforeIndex = normalized.before === originalBefore
+		? originalBeforeIndex
+		: createComparisonDocumentIndex(normalized.before, audit)
+	const comparisonAfterIndex = normalized.after === originalAfter
+		? originalAfterIndex
+		: createComparisonDocumentIndex(normalized.after, audit)
+	const builder: ComparisonBuilder = {
+		originalBefore,
+		originalAfter,
+		originalBeforeIndex,
+		originalAfterIndex,
+		comparisonBefore: normalized.before,
+		comparisonAfter: normalized.after,
+		comparisonBeforeIndex,
+		comparisonAfterIndex,
+		descriptors: [],
+		reservedMoves: [],
+		audit,
+		maximumDescriptors: options.maximumDescriptors ?? MAX_RENDERED_COMPARISON_DESCRIPTORS,
+	}
+
+	compareSiblingNodes(
+		builder,
+		comparisonBeforeIndex.children,
+		comparisonAfterIndex.children,
+		0,
+		normalized.before.content.size,
+		0,
+		normalized.after.content.size,
+		true,
+	)
+	emitReservedMoves(builder)
+
+	return deepFreeze({
+		descriptors: finalizeDescriptors(builder.descriptors),
+	})
+}
+
+/**
+ * Rebuild the earlier document with the later schema while preserving positions.
+ *
+ * @param before Earlier document
+ * @param after Later document
+ */
+function normalizeSchemas(before: Node, after: Node) {
+	if (before.type.schema === after.type.schema) {
+		return { before, after }
+	}
+	const rebuilt = after.type.schema.nodeFromJSON(before.toJSON())
+	if (rebuilt.nodeSize !== before.nodeSize) {
+		throw new Error('Markdown comparison schema normalization changed document positions')
+	}
+	if (rebuilt.textBetween(0, rebuilt.content.size, '\n', '\ufffc')
+		!== before.textBetween(0, before.content.size, '\n', '\ufffc')) {
+		throw new Error('Markdown comparison schema normalization changed document content')
+	}
+	return { before: rebuilt, after }
+}
+
+/**
+ * Align direct siblings around ordered exact anchors and recurse into pairs.
+ *
+ * @param builder Comparison state
+ * @param before Earlier direct children
+ * @param after Later direct children
+ * @param beforeStart Earlier parent content start
+ * @param beforeEnd Earlier parent content end
+ * @param afterStart Later parent content start
+ * @param afterEnd Later parent content end
+ * @param topLevel Whether these are root children
+ */
+function compareSiblingNodes(
+	builder: ComparisonBuilder,
+	before: readonly LocatedComparisonNode[],
+	after: readonly LocatedComparisonNode[],
+	beforeStart: number,
+	beforeEnd: number,
+	afterStart: number,
+	afterEnd: number,
+	topLevel: boolean,
+) {
+	const exactPairs = findUniqueExactPairs(before, after, builder.audit)
+	const anchors = longestIncreasingPairs(exactPairs)
+	const anchorKeys = new Set(anchors.map(pairKey))
+	const reserved = topLevel ? exactPairs.filter((pair) => !anchorKeys.has(pairKey(pair))) : []
+	const reservedBefore = new Set(reserved.map(({ before: node }) => node.index))
+	const reservedAfter = new Set(reserved.map(({ after: node }) => node.index))
+	builder.reservedMoves.push(...reserved)
+
+	let previousBeforeIndex = -1
+	let previousAfterIndex = -1
+	for (const anchor of [...anchors, null]) {
+		const nextBeforeIndex = anchor?.before.index ?? before.length
+		const nextAfterIndex = anchor?.after.index ?? after.length
+		const window: AlignmentWindow = {
+			before: before
+				.slice(previousBeforeIndex + 1, nextBeforeIndex)
+				.filter(({ index }) => !reservedBefore.has(index)),
+			after: after
+				.slice(previousAfterIndex + 1, nextAfterIndex)
+				.filter(({ index }) => !reservedAfter.has(index)),
+			beforeStart: positionAt(before, previousBeforeIndex + 1, beforeStart, beforeEnd),
+			beforeEnd: positionAt(before, nextBeforeIndex, beforeStart, beforeEnd),
+			afterStart: positionAt(after, previousAfterIndex + 1, afterStart, afterEnd),
+			afterEnd: positionAt(after, nextAfterIndex, afterStart, afterEnd),
+		}
+		compareAlignmentWindow(builder, window)
+		if (anchor) {
+			previousBeforeIndex = anchor.before.index
+			previousAfterIndex = anchor.after.index
+		}
+	}
+}
+
+/**
+ * Find exact sibling pairs whose canonical fingerprints are unique on both sides.
+ *
+ * @param before Earlier siblings
+ * @param after Later siblings
+ * @param audit Optional operation counter for structural regression tests
+ */
+function findUniqueExactPairs(
+	before: readonly LocatedComparisonNode[],
+	after: readonly LocatedComparisonNode[],
+	audit?: ComparisonModelAudit,
+) {
+	const beforeByFingerprint = groupByFingerprint(before, audit)
+	const afterByFingerprint = groupByFingerprint(after, audit)
+	const pairs: ExactPair[] = []
+	for (const afterNode of after) {
+		const fingerprint = fingerprintNode(afterNode.node)
+		const beforeMatches = beforeByFingerprint.get(fingerprint)
+		const afterMatches = afterByFingerprint.get(fingerprint)
+		if (beforeMatches?.length !== 1 || afterMatches?.length !== 1) {
+			continue
+		}
+		const beforeNode = beforeMatches[0]!
+		if (beforeNode.node.eq(afterNode.node)) {
+			pairs.push({ before: beforeNode, after: afterNode, fingerprint })
+		}
+	}
+	return pairs
+}
+
+/**
+ * @param nodes Siblings to index
+ * @param audit Optional operation counter for structural regression tests
+ */
+function groupByFingerprint(nodes: readonly LocatedComparisonNode[], audit?: ComparisonModelAudit) {
+	const grouped = new Map<string, LocatedComparisonNode[]>()
+	for (const node of nodes) {
+		const fingerprint = fingerprintNode(node.node)
+		const group = grouped.get(fingerprint)
+		if (group) {
+			group.push(node)
+		} else {
+			if (audit) {
+				audit.fingerprintGroupAllocations++
+			}
+			grouped.set(fingerprint, [node])
+		}
+	}
+	return grouped
+}
+
+/**
+ * Select deterministic order-preserving exact anchors in O(n log n).
+ *
+ * @param pairs Exact pairs in later-document order
+ */
+function longestIncreasingPairs(pairs: ExactPair[]) {
+	if (pairs.length === 0) {
+		return []
+	}
+	const tails: number[] = []
+	const previous = new Int32Array(pairs.length).fill(-1)
+	for (let candidateIndex = 0; candidateIndex < pairs.length; candidateIndex++) {
+		const beforeIndex = pairs[candidateIndex]!.before.index
+		let low = 0
+		let high = tails.length
+		while (low < high) {
+			const middle = (low + high) >>> 1
+			if (pairs[tails[middle]!]!.before.index < beforeIndex) {
+				low = middle + 1
+			} else {
+				high = middle
+			}
+		}
+		if (low > 0) {
+			previous[candidateIndex] = tails[low - 1]!
+		}
+		tails[low] = candidateIndex
+	}
+
+	const selected: ExactPair[] = []
+	let candidateIndex = tails.at(-1)!
+	while (candidateIndex >= 0) {
+		selected.push(pairs[candidateIndex]!)
+		candidateIndex = previous[candidateIndex]!
+	}
+	return selected.reverse()
+}
+
+/**
+ * @param pair Exact pair
+ */
+function pairKey(pair: ExactPair) {
+	return `${pair.before.index}:${pair.after.index}`
+}
+
+/**
+ * @param nodes Siblings
+ * @param index Child slot
+ * @param start Parent content start
+ * @param end Parent content end
+ */
+function positionAt(nodes: readonly LocatedComparisonNode[], index: number, start: number, end: number) {
+	return index < 0 ? start : nodes[index]?.from ?? end
+}
+
+/**
+ * Align one bounded window and compare every resulting pair or unmatched node.
+ *
+ * @param builder Comparison state
+ * @param window Unanchored sibling window
+ */
+function compareAlignmentWindow(builder: ComparisonBuilder, window: AlignmentWindow) {
+	const steps = alignWindow(window.before, window.after)
+	for (let index = 0; index < steps.length; index++) {
+		const step = steps[index]!
+		if (step.before && step.after) {
+			comparePairedNodes(builder, step.before, step.after)
+		} else if (step.before) {
+			const missing = missingLocation(steps, index, 'after', window.afterStart, window.afterEnd)
+			emitBlockChange(
+				builder,
+				step.before,
+				null,
+				missing.position,
+				missing.neighbors,
+			)
+		} else if (step.after) {
+			const missing = missingLocation(steps, index, 'before', window.beforeStart, window.beforeEnd)
+			emitBlockChange(
+				builder,
+				null,
+				step.after,
+				missing.position,
+				missing.neighbors,
+			)
+		}
+	}
+}
+
+/**
+ * Align a sibling window with bounded dynamic programming or a conservative fallback.
+ *
+ * @param before Earlier siblings
+ * @param after Later siblings
+ */
+function alignWindow(before: readonly LocatedComparisonNode[], after: readonly LocatedComparisonNode[]) {
+	if (before.length * after.length > MAX_ALIGNMENT_PRODUCT) {
+		return alignLargeWindow(before, after)
+	}
+
+	const columns = after.length + 1
+	const scores = new Float64Array((before.length + 1) * columns)
+	const pairScores = new Float64Array(before.length * after.length).fill(-1)
+	const scoreAt = (beforeIndex: number, afterIndex: number) => scores[beforeIndex * columns + afterIndex]!
+	for (let beforeIndex = 1; beforeIndex <= before.length; beforeIndex++) {
+		for (let afterIndex = 1; afterIndex <= after.length; afterIndex++) {
+			const pairScore = scoreCompatibleNodes(before[beforeIndex - 1]!.node, after[afterIndex - 1]!.node)
+			pairScores[(beforeIndex - 1) * after.length + afterIndex - 1] = pairScore
+			const pair = pairScore < 0 ? -1 : scoreAt(beforeIndex - 1, afterIndex - 1) + pairScore
+			scores[beforeIndex * columns + afterIndex] = Math.max(
+				pair,
+				scoreAt(beforeIndex - 1, afterIndex),
+				scoreAt(beforeIndex, afterIndex - 1),
+			)
+		}
+	}
+
+	const reversed: AlignmentStep[] = []
+	let beforeIndex = before.length
+	let afterIndex = after.length
+	while (beforeIndex > 0 || afterIndex > 0) {
+		const current = scoreAt(beforeIndex, afterIndex)
+		const pairScore = beforeIndex > 0 && afterIndex > 0
+			? pairScores[(beforeIndex - 1) * after.length + afterIndex - 1]!
+			: -1
+		if (pairScore >= 0 && current === scoreAt(beforeIndex - 1, afterIndex - 1) + pairScore) {
+			reversed.push({ before: before[--beforeIndex]!, after: after[--afterIndex]! })
+		} else if (beforeIndex > 0 && current === scoreAt(beforeIndex - 1, afterIndex)) {
+			reversed.push({ before: before[--beforeIndex]!, after: null })
+		} else {
+			reversed.push({ before: null, after: after[--afterIndex]! })
+		}
+	}
+	return reversed.reverse()
+}
+
+/**
+ * Preserve positional precision beyond the dynamic-programming ceiling.
+ * A bounded lookahead consumes small insert/delete runs without allowing
+ * alignment work to grow with the sibling product.
+ *
+ * @param before Earlier siblings
+ * @param after Later siblings
+ */
+function alignLargeWindow(before: readonly LocatedComparisonNode[], after: readonly LocatedComparisonNode[]) {
+	const steps: AlignmentStep[] = []
+	let beforeIndex = 0
+	let afterIndex = 0
+	while (beforeIndex < before.length || afterIndex < after.length) {
+		if (beforeIndex >= before.length) {
+			steps.push({ before: null, after: after[afterIndex++]! })
+			continue
+		}
+		if (afterIndex >= after.length) {
+			steps.push({ before: before[beforeIndex++]!, after: null })
+			continue
+		}
+
+		const beforeNode = before[beforeIndex]!
+		const afterNode = after[afterIndex]!
+		const directScore = scoreCompatibleNodes(beforeNode.node, afterNode.node)
+		const remainingBefore = before.length - beforeIndex
+		const remainingAfter = after.length - afterIndex
+		if (remainingAfter > remainingBefore) {
+			const skip = bestFollowingMatch(
+				beforeNode.node,
+				after,
+				afterIndex,
+				Math.min(remainingAfter - remainingBefore, MAX_LINEAR_ALIGNMENT_LOOKAHEAD),
+				directScore,
+			)
+			if (skip > 0) {
+				for (let offset = 0; offset < skip; offset++) {
+					steps.push({ before: null, after: after[afterIndex++]! })
+				}
+				continue
+			}
+		} else if (remainingBefore > remainingAfter) {
+			const skip = bestFollowingMatch(
+				afterNode.node,
+				before,
+				beforeIndex,
+				Math.min(remainingBefore - remainingAfter, MAX_LINEAR_ALIGNMENT_LOOKAHEAD),
+				directScore,
+			)
+			if (skip > 0) {
+				for (let offset = 0; offset < skip; offset++) {
+					steps.push({ before: before[beforeIndex++]!, after: null })
+				}
+				continue
+			}
+		}
+
+		if (directScore >= 0) {
+			steps.push({ before: beforeNode, after: afterNode })
+		} else {
+			steps.push({ before: beforeNode, after: null })
+			steps.push({ before: null, after: afterNode })
+		}
+		beforeIndex++
+		afterIndex++
+	}
+	return steps
+}
+
+/**
+ * Find a strictly better compatible node after a short unmatched run.
+ *
+ * @param target Node on the shorter side
+ * @param candidates Nodes on the longer side
+ * @param start Current longer-side index
+ * @param maximumSkip Maximum unmatched prefix to inspect
+ * @param directScore Current positional score
+ */
+function bestFollowingMatch(
+	target: Node,
+	candidates: readonly LocatedComparisonNode[],
+	start: number,
+	maximumSkip: number,
+	directScore: number,
+) {
+	let bestOffset = 0
+	let bestScore = directScore
+	for (let offset = 1; offset <= maximumSkip && start + offset < candidates.length; offset++) {
+		const score = scoreCompatibleNodes(target, candidates[start + offset]!.node)
+		if (score > bestScore) {
+			bestOffset = offset
+			bestScore = score
+		}
+	}
+	return bestOffset
+}
+
+/**
+ * @param before Earlier node
+ * @param after Later node
+ */
+function scoreCompatibleNodes(before: Node, after: Node) {
+	if (!compatibleNodes(before, after)) {
+		return -1
+	}
+	return before.eq(after) ? 3 : 1 + textSimilarity(before.textContent, after.textContent)
+}
+
+/**
+ * @param before Earlier node
+ * @param after Later node
+ */
+function compatibleNodes(before: Node, after: Node) {
+	return before.type === after.type
+}
+
+/**
+ * Compute the required prefix/non-overlapping-suffix Unicode similarity.
+ *
+ * @param before Earlier text
+ * @param after Later text
+ */
+function textSimilarity(before: string, after: string) {
+	const previous = [...normalizeAlignmentText(before)]
+	const next = [...normalizeAlignmentText(after)]
+	let prefix = 0
+	while (prefix < previous.length && prefix < next.length && previous[prefix] === next[prefix]) {
+		prefix++
+	}
+	let suffix = 0
+	const maximumSuffix = Math.min(previous.length, next.length) - prefix
+	while (suffix < maximumSuffix
+		&& previous[previous.length - suffix - 1] === next[next.length - suffix - 1]) {
+		suffix++
+	}
+	return (prefix + suffix) / Math.max(previous.length, next.length, 1)
+}
+
+/**
+ * @param value Text used only as an alignment hint
+ */
+function normalizeAlignmentText(value: string) {
+	return value.normalize('NFC').replace(/\s+/gu, ' ').trim()
+}
+
+/**
+ * Find the closest coordinate on an absent side of one alignment operation.
+ *
+ * @param steps Ordered alignment operations
+ * @param index Current operation
+ * @param side Missing side
+ * @param start Window start
+ * @param end Window end
+ */
+function missingLocation(
+	steps: AlignmentStep[],
+	index: number,
+	side: 'before' | 'after',
+	start: number,
+	end: number,
+) {
+	let previous: LocatedComparisonNode | null = null
+	for (let next = index + 1; next < steps.length; next++) {
+		const node = steps[next]![side]
+		if (node) {
+			for (let previousIndex = index - 1; previousIndex >= 0; previousIndex--) {
+				previous = steps[previousIndex]![side]
+				if (previous) {
+					break
+				}
+			}
+			return {
+				position: node.from,
+				neighbors: previous ? [previous, node] : [node],
+			}
+		}
+	}
+	for (let previousIndex = index - 1; previousIndex >= 0; previousIndex--) {
+		const node = steps[previousIndex]![side]
+		if (node) {
+			return { position: node.to, neighbors: [node] }
+		}
+	}
+	return { position: Math.min(Math.max(start, 0), end), neighbors: [] }
+}
+
+/**
+ * Compare one structurally compatible pair by category.
+ *
+ * @param builder Comparison state
+ * @param before Earlier node
+ * @param after Later node
+ */
+function comparePairedNodes(
+	builder: ComparisonBuilder,
+	before: LocatedComparisonNode,
+	after: LocatedComparisonNode,
+) {
+	if (before.node.eq(after.node)) {
+		return
+	}
+	if (before.node.isTextblock && after.node.isTextblock) {
+		compareTextblocks(builder, before, after)
+		return
+	}
+	if (before.node.isLeaf || after.node.isLeaf || before.node.isAtom || after.node.isAtom) {
+		emitBlockChange(builder, before, after)
+		return
+	}
+	if (!before.node.sameMarkup(after.node)) {
+		emitMarkupChange(builder, before, after)
+	}
+	compareSiblingNodes(
+		builder,
+		before.children,
+		after.children,
+		before.from + 1,
+		before.to - 1,
+		after.from + 1,
+		after.to - 1,
+		false,
+	)
+}
+
+/**
+ * Compare one textblock through a bounded bare-block ChangeSet.
+ *
+ * @param builder Comparison state
+ * @param before Earlier textblock
+ * @param after Later textblock
+ */
+function compareTextblocks(
+	builder: ComparisonBuilder,
+	before: LocatedComparisonNode,
+	after: LocatedComparisonNode,
+) {
+	const start = before.node.content.findDiffStart(after.node.content)
+	if (start === null) {
+		if (!before.node.sameMarkup(after.node)) {
+			emitMarkupChange(builder, before, after)
+		}
+		return
+	}
+	const diffEnd = before.node.content.findDiffEnd(after.node.content)
+	if (!diffEnd) {
+		emitBlockChange(builder, before, after)
+		return
+	}
+	let { a: endA, b: endB } = diffEnd
+	if (endA < start) {
+		endB += start - endA
+		endA = start
+	}
+	if (endB < start) {
+		endA += start - endB
+		endB = start
+	}
+	if ((endA - start) + (endB - start) > MAX_INLINE_ENVELOPE_SIZE) {
+		emitBlockChange(builder, before, after)
+		return
+	}
+
+	const map = new StepMap([0, before.node.content.size, after.node.content.size])
+	const changes = simplifyChanges(
+		ChangeSet.create(before.node, undefined, semanticTokenEncoder)
+			.addSteps(after.node, [map], null)
+			.changes,
+		after.node,
+	)
+	if (changes.length === 0 || !changes.every((change) => validInlineChange(builder, before, after, change))) {
+		emitBlockChange(builder, before, after)
+		return
+	}
+	if (!before.node.sameMarkup(after.node)) {
+		emitMarkupChange(builder, before, after)
+	}
+	const beforeRoots = originalLocations(builder, 'before', [before])
+	const afterRoots = originalLocations(builder, 'after', [after])
+	for (const change of changes) {
+		pushDescriptor(builder, (sourceOrder) => classifyComparisonDescriptor(
+			builder.originalBefore,
+			builder.originalAfter,
+			{
+				from: before.from + 1 + change.fromA,
+				to: before.from + 1 + change.toA,
+			},
+			{
+				from: after.from + 1 + change.fromB,
+				to: after.from + 1 + change.toB,
+			},
+			beforeRoots,
+			afterRoots,
+			sourceOrder,
+			'inline',
+			{ before: before.path, after: after.path },
+			builder.audit,
+		))
+	}
+}
+
+/**
+ * Validate a local ChangeSet range and its original-document round trip.
+ *
+ * @param builder Comparison state
+ * @param before Earlier textblock
+ * @param after Later textblock
+ * @param change Local ChangeSet range
+ */
+function validInlineChange(
+	builder: ComparisonBuilder,
+	before: LocatedComparisonNode,
+	after: LocatedComparisonNode,
+	change: InlineChangeRange,
+) {
+	if (!validLocalRange(change.fromA, change.toA, before.node.content.size)
+		|| !validLocalRange(change.fromB, change.toB, after.node.content.size)) {
+		return false
+	}
+	const beforeLocal = before.node.textBetween(change.fromA, change.toA, '\n', '\ufffc')
+	const afterLocal = after.node.textBetween(change.fromB, change.toB, '\n', '\ufffc')
+	const beforeAbsolute = comparisonRangeText({
+		from: before.from + 1 + change.fromA,
+		to: before.from + 1 + change.toA,
+	}, [originalLocation(builder, 'before', before)])
+	const afterAbsolute = comparisonRangeText({
+		from: after.from + 1 + change.fromB,
+		to: after.from + 1 + change.toB,
+	}, [originalLocation(builder, 'after', after)])
+	return beforeLocal === beforeAbsolute && afterLocal === afterAbsolute
+}
+
+/**
+ * @param from Range start
+ * @param to Range end
+ * @param maximum Content size
+ */
+function validLocalRange(from: number, to: number, maximum: number) {
+	return Number.isInteger(from) && Number.isInteger(to) && from >= 0 && to >= from && to <= maximum
+}
+
+/**
+ * Emit a direct node-markup descriptor.
+ *
+ * @param builder Comparison state
+ * @param before Earlier node
+ * @param after Later node
+ */
+function emitMarkupChange(
+	builder: ComparisonBuilder,
+	before: LocatedComparisonNode,
+	after: LocatedComparisonNode,
+) {
+	const beforeRoot = originalLocation(builder, 'before', before)
+	const afterRoot = originalLocation(builder, 'after', after)
+	pushDescriptor(builder, (sourceOrder) => classifyNodeMarkupDescriptor(
+		builder.originalBefore,
+		builder.originalAfter,
+		rangeFor(before),
+		rangeFor(after),
+		beforeRoot.node,
+		afterRoot.node,
+		[beforeRoot],
+		[afterRoot],
+		sourceOrder,
+		builder.audit,
+	))
+}
+
+/**
+ * Emit one conservative whole-node insert, delete, or replacement.
+ *
+ * @param builder Comparison state
+ * @param before Earlier node, if present
+ * @param after Later node, if present
+ * @param absentPosition Coordinate on the absent side
+ * @param absentNeighbors Adjacent nodes on the absent side
+ */
+function emitBlockChange(
+	builder: ComparisonBuilder,
+	before: LocatedComparisonNode | null,
+	after: LocatedComparisonNode | null,
+	absentPosition = 0,
+	absentNeighbors: readonly LocatedComparisonNode[] = [],
+) {
+	const beforeRange = before ? rangeFor(before) : emptyRange(absentPosition)
+	const afterRange = after ? rangeFor(after) : emptyRange(absentPosition)
+	const beforeRoots = originalLocations(builder, 'before', before ? [before] : absentNeighbors)
+	const afterRoots = originalLocations(builder, 'after', after ? [after] : absentNeighbors)
+	pushDescriptor(builder, (sourceOrder) => classifyComparisonDescriptor(
+		builder.originalBefore,
+		builder.originalAfter,
+		beforeRange,
+		afterRange,
+		beforeRoots,
+		afterRoots,
+		sourceOrder,
+		'block',
+		undefined,
+		builder.audit,
+	))
+}
+
+/**
+ * Convert reserved unique exact pairs into conservative grouped move descriptors.
+ *
+ * @param builder Comparison state
+ */
+function emitReservedMoves(builder: ComparisonBuilder) {
+	const { groups, rejected } = confirmReservedExactMoves(
+		builder.comparisonBefore,
+		builder.comparisonAfter,
+		builder.reservedMoves,
+	)
+	for (const pair of rejected) {
+		emitBlockChange(builder, pair.before, null, pair.after.from, [pair.after])
+		emitBlockChange(builder, null, pair.after, pair.before.from, [pair.before])
+	}
+
+	for (const group of groups) {
+		const first = group[0]!
+		const last = group.at(-1)!
+		const beforeRoots = originalLocations(builder, 'before', group.map(({ before }) => before))
+		const afterRoots = originalLocations(builder, 'after', group.map(({ after }) => after))
+		pushDescriptor(builder, (sourceOrder) => {
+			const descriptor = classifyComparisonDescriptor(
+				builder.originalBefore,
+				builder.originalAfter,
+				{ from: first.before.from, to: last.before.to },
+				{ from: first.after.from, to: last.after.to },
+				beforeRoots,
+				afterRoots,
+				sourceOrder,
+				'block',
+				undefined,
+				builder.audit,
+			)
+			return {
+				...descriptor,
+				operation: 'move',
+				detail: 'block',
+				facets: ['structure'],
+				signals: [{ type: 'node' }],
+			}
+		})
+	}
+}
+
+/**
+ * Emit one descriptor through the shared model limit.
+ *
+ * @param builder Mutable comparison state
+ * @param create Descriptor factory
+ */
+function pushDescriptor(
+	builder: ComparisonBuilder,
+	create: (sourceOrder: number) => ComparisonDescriptor | null,
+) {
+	if (builder.descriptors.length >= builder.maximumDescriptors) {
+		throw new ComparisonModelLimitError()
+	}
+	const descriptor = create(builder.descriptors.length)
+	if (descriptor) {
+		builder.descriptors.push(descriptor)
+	}
+}
+
+/**
+ * Assign stable source order and IDs after moves join recursively emitted changes.
+ *
+ * @param descriptors Provisional descriptors
+ */
+function finalizeDescriptors(descriptors: ComparisonDescriptor[]) {
+	return descriptors
+		.toSorted((a, b) => a.after.from - b.after.from
+			|| a.before.from - b.before.from
+			|| a.after.to - b.after.to
+			|| a.before.to - b.before.to
+			|| compareCodeUnits(a.operation, b.operation))
+		.map((descriptor, sourceOrder) => ({
+			...descriptor,
+			id: `${descriptor.operation === 'move' ? 'move' : 'change'}-${sourceOrder.toString(36)}`,
+			sourceOrder,
+		}))
+}
+
+/**
+ * Resolve located nodes against an original document.
+ *
+ * @param builder Mutable comparison state
+ * @param side Document side
+ * @param locations Located document nodes
+ */
+function originalLocations(
+	builder: ComparisonBuilder,
+	side: 'before' | 'after',
+	locations: readonly LocatedComparisonNode[],
+) {
+	return locations.map((location) => originalLocation(builder, side, location))
+}
+
+/**
+ * Resolve one located node against an original document.
+ *
+ * @param builder Mutable comparison state
+ * @param side Document side
+ * @param location Located document node
+ */
+function originalLocation(
+	builder: ComparisonBuilder,
+	side: 'before' | 'after',
+	location: LocatedComparisonNode,
+) {
+	return (side === 'before' ? builder.originalBeforeIndex : builder.originalAfterIndex)
+		.nodeAtPath(location.path)
+}
+
+/**
+ * @param node Located node
+ */
+function rangeFor(node: LocatedComparisonNode): ComparisonRange {
+	return { from: node.from, to: node.to }
+}
+
+/**
+ * @param position Empty-side coordinate
+ */
+function emptyRange(position: number): ComparisonRange {
+	return { from: position, to: position }
+}
+
+/**
+ * @param node Node to fingerprint
+ */
+function fingerprintNode(node: Node) {
+	const cached = fingerprintCache.get(node)
+	if (cached !== undefined) {
+		return cached
+	}
+	const fingerprint = stableSerialize(node.toJSON())
+	fingerprintCache.set(node, fingerprint)
+	return fingerprint
+}

--- a/src/comparison/markdownComparison.ts
+++ b/src/comparison/markdownComparison.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+
+import { createHierarchicalMarkdownComparisonModel } from './hierarchicalMarkdownComparisonModel.ts'
+
+export { ComparisonModelLimitError } from './hierarchicalMarkdownComparisonModel.ts'
+export type * from './markdownComparisonTypes.ts'
+
+/**
+ * Compare complete documents through the bounded hierarchical implementation.
+ *
+ * @param before Earlier document
+ * @param after Later document
+ */
+export function createMarkdownComparisonModel(before: Node, after: Node) {
+	return createHierarchicalMarkdownComparisonModel(before, after)
+}

--- a/src/comparison/markdownComparison.ts
+++ b/src/comparison/markdownComparison.ts
@@ -3,12 +3,46 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { Editor } from '@tiptap/core'
 import type { Node } from '@tiptap/pm/model'
+import type { PluginKey } from '@tiptap/pm/state'
+import type { ComparisonNodeSearchAudit } from './comparisonDocumentIndex.ts'
+import type {
+	ComparisonDescriptor,
+	ComparisonSide,
+} from './markdownComparisonTypes.ts'
 
+import { Plugin, PluginKey as ProseMirrorPluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+import {
+	createComparisonDocumentIndex,
+	findComparisonNodes,
+} from './comparisonDocumentIndex.ts'
 import { createHierarchicalMarkdownComparisonModel } from './hierarchicalMarkdownComparisonModel.ts'
 
 export { ComparisonModelLimitError } from './hierarchicalMarkdownComparisonModel.ts'
 export type * from './markdownComparisonTypes.ts'
+
+interface ComparisonDecorationState {
+	activeIds: readonly string[]
+	currentId: string | null
+}
+
+interface PreparedDecoration {
+	descriptor: ComparisonDescriptor
+	from: number
+	to: number
+	type: 'inline' | 'node' | 'widget'
+}
+
+interface ComparisonDecorationPluginState extends ComparisonDecorationState {
+	decorations: DecorationSet
+	prepared: readonly PreparedDecoration[]
+}
+
+type ComparisonDecorationKey = PluginKey<ComparisonDecorationPluginState>
+
+let pluginId = 0
 
 /**
  * Compare complete documents through the bounded hierarchical implementation.
@@ -18,4 +52,356 @@ export type * from './markdownComparisonTypes.ts'
  */
 export function createMarkdownComparisonModel(before: Node, after: Node) {
 	return createHierarchicalMarkdownComparisonModel(before, after)
+}
+
+/**
+ * Create stable-ID comparison decorations for registration after editor mount.
+ *
+ * @param descriptors Semantic descriptors
+ * @param side Document side
+ * @param markerLabel Accessible marker label
+ * @param emptyMarkerLabel Accessible empty-range label
+ * @param initialState Initial visible/current descriptor IDs
+ */
+export function createComparisonDecorationPlugin(
+	descriptors: readonly ComparisonDescriptor[],
+	side: ComparisonSide,
+	markerLabel: string,
+	emptyMarkerLabel = markerLabel,
+	initialState: ComparisonDecorationState = {
+		activeIds: descriptors.map(({ id }) => id),
+		currentId: descriptors[0]?.id ?? null,
+	},
+) {
+	const key = new ProseMirrorPluginKey<ComparisonDecorationPluginState>(`markdown-comparison-${side}-${pluginId++}`)
+	const plugin = new Plugin<ComparisonDecorationPluginState>({
+		key,
+		state: {
+			init: (_, state) => createPluginState(
+				state.doc,
+				descriptors,
+				side,
+				initialState,
+				markerLabel,
+				emptyMarkerLabel,
+			),
+			apply: (transaction, current) => {
+				const update = transaction.getMeta(key) as ComparisonDecorationState | undefined
+				if (transaction.docChanged) {
+					return {
+						activeIds: [],
+						currentId: null,
+						decorations: DecorationSet.empty,
+						prepared: [],
+					}
+				}
+				if (!update) {
+					return current
+				}
+				const selection = normalizeDecorationState(descriptors, update)
+				return {
+					...selection,
+					prepared: current.prepared,
+					decorations: buildDecorationSet(
+						transaction.doc,
+						current.prepared,
+						selection,
+						side,
+						markerLabel,
+						emptyMarkerLabel,
+					),
+				}
+			},
+		},
+		props: {
+			decorations(state) {
+				return key.getState(state)?.decorations ?? DecorationSet.empty
+			},
+		},
+	})
+	return { key, plugin }
+}
+
+/**
+ * Update visible/current IDs without traversing the document again.
+ *
+ * @param editor Comparison editor
+ * @param key Decoration plugin key
+ * @param state Decoration visibility and selection state
+ */
+export function setComparisonDecorationState(
+	editor: Editor,
+	key: ComparisonDecorationKey,
+	state: ComparisonDecorationState,
+) {
+	editor.view.dispatch(editor.state.tr.setMeta(key, state))
+}
+
+/**
+ * Create the initial comparison decoration state.
+ *
+ * @param doc Document to decorate
+ * @param descriptors Semantic comparison descriptors in source order
+ * @param side Document side to decorate
+ * @param selection Initial decoration visibility and selection state
+ * @param markerLabel Accessible change marker label
+ * @param emptyMarkerLabel Accessible empty-range marker label
+ */
+function createPluginState(
+	doc: Node,
+	descriptors: readonly ComparisonDescriptor[],
+	side: ComparisonSide,
+	selection: ComparisonDecorationState,
+	markerLabel: string,
+	emptyMarkerLabel: string,
+): ComparisonDecorationPluginState {
+	const prepared = prepareComparisonDecorations(doc, descriptors, side)
+	const normalized = normalizeDecorationState(descriptors, selection)
+	return {
+		...normalized,
+		prepared,
+		decorations: buildDecorationSet(
+			doc,
+			prepared,
+			normalized,
+			side,
+			markerLabel,
+			emptyMarkerLabel,
+		),
+	}
+}
+
+/**
+ * Limit visible and current IDs to known descriptors.
+ *
+ * @param descriptors Semantic comparison descriptors in source order
+ * @param state Decoration visibility and selection state
+ */
+function normalizeDecorationState(
+	descriptors: readonly ComparisonDescriptor[],
+	state: ComparisonDecorationState,
+): ComparisonDecorationState {
+	const known = new Set(descriptors.map(({ id }) => id))
+	const activeIds = [...new Set(state.activeIds)].filter((id) => known.has(id))
+	return {
+		activeIds,
+		currentId: state.currentId && activeIds.includes(state.currentId) ? state.currentId : null,
+	}
+}
+
+/**
+ * Prepare range templates once. Navigation only combines these templates.
+ *
+ * @param doc Document to decorate
+ * @param descriptors Semantic comparison descriptors in source order
+ * @param side Document side to decorate
+ * @param audit Optional operation counter for structural regression tests
+ */
+export function prepareComparisonDecorations(
+	doc: Node,
+	descriptors: readonly ComparisonDescriptor[],
+	side: ComparisonSide,
+	audit?: ComparisonNodeSearchAudit,
+) {
+	const index = createComparisonDocumentIndex(doc, audit)
+	const byId = new Map(descriptors.map((descriptor) => [descriptor.id, {
+		descriptor,
+		from: clamp(descriptor[side].from, 0, doc.content.size),
+		to: clamp(descriptor[side].to, 0, doc.content.size),
+		represented: false,
+		parts: [] as PreparedDecoration[],
+	}]))
+	const blockItems = [...byId.values()].filter((item) => item.descriptor.detail === 'block')
+	const topLevelNodes: Array<{ from: number, to: number }> = []
+	const nodeRanges = new Set<string>()
+	if (blockItems.some((item) => item.from !== item.to)) {
+		for (const location of index.nodes) {
+			const range = { from: location.from, to: location.to }
+			nodeRanges.add(`${range.from}:${range.to}`)
+			if (location.parent === null) {
+				topLevelNodes.push(range)
+			}
+		}
+	}
+	for (const item of blockItems) {
+		let lower = 0
+		let upper = topLevelNodes.length
+		while (lower < upper) {
+			const middle = Math.floor((lower + upper) / 2)
+			if (topLevelNodes[middle]!.to <= item.from) {
+				lower = middle + 1
+			} else {
+				upper = middle
+			}
+		}
+		for (let index = lower; index < topLevelNodes.length; index++) {
+			const range = topLevelNodes[index]!
+			if (range.from >= item.to) {
+				break
+			}
+			if (item.from <= range.from && item.to >= range.to) {
+				item.parts.push({ descriptor: item.descriptor, ...range, type: 'node' })
+				item.represented = true
+			}
+		}
+		if (!item.represented && item.from !== item.to) {
+			const context = item.descriptor.context[side]
+			if (context
+				&& context.from < context.to
+				&& nodeRanges.has(`${context.from}:${context.to}`)) {
+				item.parts.push({
+					descriptor: item.descriptor,
+					from: clamp(context.from, 0, doc.content.size),
+					to: clamp(context.to, 0, doc.content.size),
+					type: 'node',
+				})
+				item.represented = true
+			}
+		}
+	}
+
+	const inlineItems = [...byId.values()].filter((item) => item.descriptor.detail === 'inline')
+	for (const item of inlineItems) {
+		if (item.from === item.to) {
+			continue
+		}
+		for (const { node, from: pos, to: end } of findComparisonNodes(
+			{ from: item.from, to: item.to },
+			index.children,
+			audit,
+		)) {
+			if (node.isText) {
+				const from = Math.max(item.from, pos)
+				const to = Math.min(item.to, end)
+				if (from < to) {
+					item.parts.push({ descriptor: item.descriptor, from, to, type: 'inline' })
+					item.represented = true
+				}
+				continue
+			}
+			const fullyCovered = item.from <= pos && item.to >= end
+			const openingChanged = item.from <= pos && item.to > pos && item.to <= pos + 1
+			const closingChanged = item.from < end && item.to >= end && item.from >= end - 1
+			const nodeSemanticsChanged = item.descriptor.facets.some((facet) => facet !== 'text' && facet !== 'formatting')
+			if (node.isLeaf || (nodeSemanticsChanged && (fullyCovered || openingChanged || closingChanged))) {
+				item.parts.push({ descriptor: item.descriptor, from: pos, to: end, type: 'node' })
+				item.represented = true
+			}
+		}
+	}
+
+	return [...byId.values()].flatMap((item) => item.represented
+		? item.parts
+		: [{
+				descriptor: item.descriptor,
+				from: item.from,
+				to: item.from,
+				type: 'widget' as const,
+			}])
+}
+
+/**
+ * Build decorations from prepared templates and UI state.
+ *
+ * @param doc Document to decorate
+ * @param prepared Prepared decoration templates
+ * @param state Decoration visibility and selection state
+ * @param side Document side to decorate
+ * @param markerLabel Accessible change marker label
+ * @param emptyMarkerLabel Accessible empty-range marker label
+ */
+function buildDecorationSet(
+	doc: Node,
+	prepared: readonly PreparedDecoration[],
+	state: ComparisonDecorationState,
+	side: ComparisonSide,
+	markerLabel: string,
+	emptyMarkerLabel: string,
+) {
+	const active = new Set(state.activeIds)
+	const decorations = prepared.flatMap((item): Decoration[] => {
+		if (!active.has(item.descriptor.id)) {
+			return []
+		}
+		const label = item.type === 'widget' ? emptyMarkerLabel : markerLabel
+		const current = item.descriptor.id === state.currentId
+		const attributes = changeAttributes(
+			item.descriptor,
+			side,
+			current,
+			label,
+			item.type === 'widget',
+		)
+		if (item.type === 'inline') {
+			return [Decoration.inline(item.from, item.to, attributes)]
+		}
+		if (item.type === 'node') {
+			return [Decoration.node(item.from, item.to, attributes)]
+		}
+		return [Decoration.widget(item.from, () => {
+			const marker = document.createElement('span')
+			marker.className = attributes.class
+			marker.dataset.comparisonChange = item.descriptor.id
+			marker.setAttribute('role', 'note')
+			marker.setAttribute('aria-label', label)
+			if (current) {
+				marker.setAttribute('aria-current', 'true')
+			}
+			marker.textContent = '•'
+			return marker
+		}, { key: `${side}-${item.descriptor.id}-${current ? 'current' : 'idle'}`, side: -1 })]
+	})
+	return DecorationSet.create(doc, decorations)
+}
+
+/**
+ * Build accessible DOM attributes for one change marker.
+ *
+ * @param descriptor Semantic comparison descriptor
+ * @param side Document side to decorate
+ * @param current Whether the descriptor is selected
+ * @param label Accessible marker label
+ * @param empty Whether the descriptor range is empty
+ */
+function changeAttributes(
+	descriptor: ComparisonDescriptor,
+	side: ComparisonSide,
+	current: boolean,
+	label: string,
+	empty: boolean,
+) {
+	const pureFormatting = descriptor.facets.length === 1 && descriptor.facets[0] === 'formatting'
+	const coarseReplacement = descriptor.detail === 'block' && descriptor.operation === 'replace'
+	const classes = [
+		'text-comparison-change',
+		coarseReplacement
+			? 'text-comparison-change--block'
+			: pureFormatting
+				? 'text-comparison-change--formatting'
+				: descriptor.operation === 'move'
+					? 'text-comparison-change--move'
+					: descriptor.facets.includes('attribute') && !descriptor.facets.includes('text')
+						? 'text-comparison-change--attribute'
+						: `text-comparison-change--${side === 'before' ? 'removed' : 'added'}`,
+		descriptor.detail === 'block' && !coarseReplacement ? 'text-comparison-change--block' : '',
+		current ? 'text-comparison-change--current' : '',
+		empty ? 'text-comparison-change--empty' : '',
+	].filter(Boolean)
+	return {
+		class: classes.join(' '),
+		'data-comparison-change': descriptor.id,
+		'aria-label': label,
+		...(current ? { 'aria-current': 'true' } : {}),
+	}
+}
+
+/**
+ * Constrain a number to an inclusive range.
+ *
+ * @param value Input number
+ * @param minimum Inclusive lower bound
+ * @param maximum Inclusive upper bound
+ */
+function clamp(value: number, minimum: number, maximum: number) {
+	return Math.min(Math.max(value, minimum), maximum)
 }

--- a/src/comparison/markdownComparisonClassification.ts
+++ b/src/comparison/markdownComparisonClassification.ts
@@ -1,0 +1,866 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Mark, Node } from '@tiptap/pm/model'
+import type {
+	ComparisonNodeSearchAudit,
+	LocatedComparisonNode,
+} from './comparisonDocumentIndex.ts'
+import type {
+	ComparisonAttributeCode,
+	ComparisonContext,
+	ComparisonContextCode,
+	ComparisonContextLocation,
+	ComparisonDescriptor,
+	ComparisonFacet,
+	ComparisonMarkCode,
+	ComparisonOperation,
+	ComparisonPreviewAtom,
+	ComparisonRange,
+	ComparisonSignal,
+} from './markdownComparisonTypes.ts'
+
+import { getTextDirection } from '../extensions/TextDirection.ts'
+import {
+	comparisonRangeText,
+	findComparisonNodes,
+} from './comparisonDocumentIndex.ts'
+
+interface AttributeRecord {
+	key: string
+	nodeName: string
+	attribute: string
+	value: unknown
+	textContent: string
+}
+
+interface ExcludedAttributePaths {
+	before: readonly number[]
+	after: readonly number[]
+}
+
+const marksCache = new WeakMap<readonly Mark[], string>()
+const nodeShapeCache = new WeakMap<Node, string>()
+const graphemeSegmenter = typeof Intl.Segmenter === 'function'
+	? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+	: null
+
+const contextCodes: Record<string, ComparisonContextCode> = {
+	frontMatter: 'front-matter',
+	paragraph: 'paragraph',
+	heading: 'heading',
+	bulletList: 'list-item',
+	orderedList: 'list-item',
+	taskList: 'list-item',
+	listItem: 'list-item',
+	taskItem: 'task',
+	tableCell: 'table-cell',
+	tableHeader: 'table-cell',
+	codeBlock: 'code-block',
+	blockquote: 'quote',
+	callout: 'callout',
+	details: 'details',
+	detailsContent: 'details',
+	detailsSummary: 'details',
+	footnotes: 'footnote',
+	footnote: 'footnote',
+	footnoteReference: 'footnote-reference',
+	image: 'image',
+	imageInline: 'image',
+	mention: 'mention',
+	inlineMath: 'mathematics',
+	blockMath: 'mathematics',
+	preview: 'preview',
+}
+
+const contextPriority: Record<ComparisonContextCode, number> = {
+	'footnote-reference': 100,
+	image: 95,
+	mention: 95,
+	mathematics: 95,
+	preview: 95,
+	footnote: 90,
+	'table-cell': 85,
+	task: 80,
+	'list-item': 75,
+	'front-matter': 70,
+	'code-block': 70,
+	callout: 65,
+	details: 65,
+	quote: 60,
+	heading: 50,
+	paragraph: 40,
+	unknown: 0,
+}
+
+const markCodes: Record<string, ComparisonMarkCode> = {
+	strong: 'bold',
+	em: 'italic',
+	strike: 'strike',
+	highlight: 'highlight',
+	underline: 'underline',
+	code: 'inline-code',
+}
+
+const meaningfulAttributes: Record<string, Record<string, ComparisonAttributeCode>> = {
+	heading: { level: 'heading-level' },
+	orderedList: { start: 'list-start' },
+	taskItem: { checked: 'task-state' },
+	codeBlock: { language: 'code-language' },
+	image: { src: 'image-target', alt: 'image-alt' },
+	imageInline: { src: 'image-target', alt: 'image-alt' },
+	mention: { id: 'mention-identity', label: 'mention-identity' },
+	inlineMath: { latex: 'mathematics' },
+	blockMath: { latex: 'mathematics' },
+	preview: { href: 'preview-target' },
+	footnoteReference: { referenceId: 'footnote-reference' },
+	footnote: { referenceId: 'footnote-reference' },
+	callout: { type: 'callout-type' },
+	details: { openDetails: 'details-state' },
+	tableCell: { align: 'table-alignment', colspan: 'table-span', rowspan: 'table-span' },
+	tableHeader: { align: 'table-alignment', colspan: 'table-span', rowspan: 'table-span' },
+}
+
+/**
+ * Deterministically encode values found in ProseMirror attributes.
+ *
+ * @param value Attribute value
+ */
+export function stableSerialize(value: unknown): string {
+	if (value === null || typeof value !== 'object') {
+		return JSON.stringify(value) ?? String(value)
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map(stableSerialize).join(',')}]`
+	}
+	return `{${Object.entries(value)
+		.toSorted(([a], [b]) => compareCodeUnits(a, b))
+		.map(([key, child]) => `${JSON.stringify(key)}:${stableSerialize(child)}`)
+		.join(',')}}`
+}
+
+/**
+ * Compare strings by UTF-16 code units without locale-dependent collation.
+ *
+ * @param a Left value
+ * @param b Right value
+ */
+export function compareCodeUnits(a: string, b: string) {
+	return a < b ? -1 : a > b ? 1 : 0
+}
+
+/**
+ * Encode a mark set independent of mark order.
+ *
+ * @param marks ProseMirror marks
+ */
+function encodeMarks(marks: readonly Mark[]) {
+	const cached = marksCache.get(marks)
+	if (cached !== undefined) {
+		return cached
+	}
+	const encoded = marks
+		.map((mark) => `${mark.type.name}:${stableSerialize(mark.attrs)}`)
+		.toSorted()
+		.join('|')
+	marksCache.set(marks, encoded)
+	return encoded
+}
+
+/** Token encoder that treats formatting and all schema attributes as semantics. */
+export const semanticTokenEncoder = {
+	encodeCharacter(character: number, marks: readonly Mark[]) {
+		return `character:${character}:${encodeMarks(marks)}`
+	},
+	encodeNodeStart(node: Node) {
+		return `node-start:${node.type.name}:${stableSerialize(node.attrs)}:${encodeMarks(node.marks)}`
+	},
+	encodeNodeEnd(node: Node) {
+		return `node-end:${node.type.name}`
+	},
+	compareTokens(a: string, b: string) {
+		return a === b
+	},
+}
+
+/**
+ * Classify one existing ChangeSet range without recomputing it.
+ *
+ * @param beforeDoc Earlier complete document
+ * @param afterDoc Later complete document
+ * @param before Earlier range
+ * @param after Later range
+ * @param beforeRoots Known earlier range roots
+ * @param afterRoots Known later range roots
+ * @param sourceOrder Stable provisional order
+ * @param detail Inline or whole-block detail
+ * @param excludedAttributePaths Root paths whose attributes were classified separately
+ * @param audit Optional operation counter for structural regression tests
+ */
+export function classifyComparisonDescriptor(
+	beforeDoc: Node,
+	afterDoc: Node,
+	before: ComparisonRange,
+	after: ComparisonRange,
+	beforeRoots: readonly LocatedComparisonNode[],
+	afterRoots: readonly LocatedComparisonNode[],
+	sourceOrder: number,
+	detail: ComparisonDescriptor['detail'] = 'inline',
+	excludedAttributePaths?: ExcludedAttributePaths,
+	audit?: ComparisonNodeSearchAudit,
+): ComparisonDescriptor {
+	const boundedBefore = boundedRange(before, beforeDoc.content.size)
+	const boundedAfter = boundedRange(after, afterDoc.content.size)
+	const beforeNodes = findComparisonNodes(boundedBefore, beforeRoots, audit)
+	const afterNodes = findComparisonNodes(boundedAfter, afterRoots, audit)
+	const context: ComparisonContext = {
+		before: resolveContext(beforeNodes),
+		after: resolveContext(afterNodes),
+	}
+	const facets = new Set<ComparisonFacet>()
+	const signals: ComparisonSignal[] = []
+	const beforeText = comparisonRangeText(boundedBefore, beforeRoots)
+	const afterText = comparisonRangeText(boundedAfter, afterRoots)
+
+	if (beforeText !== afterText) {
+		facets.add('text')
+	}
+
+	classifyMarks(beforeDoc, afterDoc, boundedBefore, boundedAfter, beforeNodes, afterNodes, facets, signals)
+	classifyNodes(beforeNodes, afterNodes, boundedBefore, boundedAfter, facets, signals, audit)
+	classifyAttributes(
+		excludePath(beforeNodes, excludedAttributePaths?.before),
+		excludePath(afterNodes, excludedAttributePaths?.after),
+		facets,
+		signals,
+	)
+
+	if (facets.size === 0) {
+		facets.add('unknown')
+	}
+
+	return {
+		id: `change-${sourceOrder.toString(36)}`,
+		sourceOrder,
+		operation: operationFor(before, after),
+		detail,
+		facets: orderedFacets(facets),
+		before: boundedBefore,
+		after: boundedAfter,
+		context,
+		preview: {
+			before: previewAtom(boundedBefore, beforeText, beforeNodes),
+			after: previewAtom(boundedAfter, afterText, afterNodes),
+		},
+		signals: deduplicateSignals(signals),
+	}
+}
+
+/**
+ * Classify direct node markup without reclassifying changed descendant content.
+ *
+ * @param beforeDoc Earlier complete document
+ * @param afterDoc Later complete document
+ * @param before Earlier node range
+ * @param after Later node range
+ * @param beforeNode Earlier paired node
+ * @param afterNode Later paired node
+ * @param beforeRoots Known earlier range roots
+ * @param afterRoots Known later range roots
+ * @param sourceOrder Stable provisional order
+ * @param audit Optional operation counter for structural regression tests
+ */
+export function classifyNodeMarkupDescriptor(
+	beforeDoc: Node,
+	afterDoc: Node,
+	before: ComparisonRange,
+	after: ComparisonRange,
+	beforeNode: Node,
+	afterNode: Node,
+	beforeRoots: readonly LocatedComparisonNode[],
+	afterRoots: readonly LocatedComparisonNode[],
+	sourceOrder: number,
+	audit?: ComparisonNodeSearchAudit,
+): ComparisonDescriptor | null {
+	const boundedBefore = boundedRange(before, beforeDoc.content.size)
+	const boundedAfter = boundedRange(after, afterDoc.content.size)
+	const beforeNodes = findComparisonNodes(boundedBefore, beforeRoots, audit)
+	const afterNodes = findComparisonNodes(boundedAfter, afterRoots, audit)
+	const facets = new Set<ComparisonFacet>()
+	const signals: ComparisonSignal[] = []
+	classifyDirectAttributes(beforeNode, afterNode, facets, signals)
+	classifyDirectMarks(beforeNode, afterNode, facets, signals)
+	if (beforeNode.type.name !== afterNode.type.name) {
+		facets.add('structure')
+		signals.push({ type: 'node' })
+	}
+	if (facets.size === 0) {
+		return null
+	}
+	return {
+		id: `change-${sourceOrder.toString(36)}`,
+		sourceOrder,
+		operation: 'replace',
+		detail: 'block',
+		facets: orderedFacets(facets),
+		before: boundedBefore,
+		after: boundedAfter,
+		context: {
+			before: resolveContext(beforeNodes),
+			after: resolveContext(afterNodes),
+		},
+		preview: {
+			before: previewAtom(boundedBefore, comparisonRangeText(boundedBefore, beforeRoots), beforeNodes),
+			after: previewAtom(boundedAfter, comparisonRangeText(boundedAfter, afterRoots), afterNodes),
+		},
+		signals: deduplicateSignals(signals),
+	}
+}
+
+/**
+ * Resolve the comparison operation from both ranges.
+ *
+ * @param before Earlier comparison range
+ * @param after Later comparison range
+ */
+function operationFor(before: ComparisonRange, after: ComparisonRange): ComparisonOperation {
+	if (before.from === before.to && after.from !== after.to) {
+		return 'insert'
+	}
+	if (after.from === after.to && before.from !== before.to) {
+		return 'delete'
+	}
+	return 'replace'
+}
+
+/**
+ * Classify mark differences across touched nodes.
+ *
+ * @param beforeDoc Earlier complete document
+ * @param afterDoc Later complete document
+ * @param before Earlier range
+ * @param after Later range
+ * @param beforeNodes Earlier touched nodes
+ * @param afterNodes Later touched nodes
+ * @param facets Mutable descriptor facets
+ * @param signals Mutable descriptor signals
+ */
+function classifyMarks(
+	beforeDoc: Node,
+	afterDoc: Node,
+	before: ComparisonRange,
+	after: ComparisonRange,
+	beforeNodes: readonly LocatedComparisonNode[],
+	afterNodes: readonly LocatedComparisonNode[],
+	facets: Set<ComparisonFacet>,
+	signals: ComparisonSignal[],
+) {
+	const beforeMarks = collectMarks(beforeDoc, before, beforeNodes)
+	const afterMarks = collectMarks(afterDoc, after, afterNodes)
+	const names = new Set([...beforeMarks.keys(), ...afterMarks.keys()])
+	for (const name of [...names].toSorted()) {
+		const previous = beforeMarks.get(name)
+		const next = afterMarks.get(name)
+		if (stableSerialize(previous) === stableSerialize(next)) {
+			continue
+		}
+		const change = previous === undefined ? 'added' : next === undefined ? 'removed' : 'changed'
+		if (name === 'link') {
+			facets.add('attribute')
+			signals.push({
+				type: 'attribute',
+				attribute: previous === undefined || next === undefined ? 'link' : 'link-target',
+				change,
+			})
+		} else if (markCodes[name]) {
+			facets.add('formatting')
+			signals.push({ type: 'mark', mark: markCodes[name], change })
+		} else {
+			facets.add('unknown')
+		}
+	}
+}
+
+/**
+ * Classify structural differences across touched nodes.
+ *
+ * @param beforeNodes Earlier touched nodes
+ * @param afterNodes Later touched nodes
+ * @param before Earlier changed range
+ * @param after Later changed range
+ * @param facets Mutable descriptor facets
+ * @param signals Mutable descriptor signals
+ * @param audit Optional operation counter for structural regression tests
+ */
+function classifyNodes(
+	beforeNodes: readonly LocatedComparisonNode[],
+	afterNodes: readonly LocatedComparisonNode[],
+	before: ComparisonRange,
+	after: ComparisonRange,
+	facets: Set<ComparisonFacet>,
+	signals: ComparisonSignal[],
+	audit?: ComparisonNodeSearchAudit,
+) {
+	const beforeShape = structuralShape(beforeNodes, before, audit)
+	const afterShape = structuralShape(afterNodes, after, audit)
+	if (beforeShape === afterShape) {
+		return
+	}
+	// A text split caused only by marks is intentionally absent from structuralShape.
+	facets.add('structure')
+	signals.push({ type: 'node' })
+}
+
+/**
+ * Classify attribute differences across touched nodes.
+ *
+ * @param beforeNodes Earlier touched nodes
+ * @param afterNodes Later touched nodes
+ * @param facets Mutable descriptor facets
+ * @param signals Mutable descriptor signals
+ */
+function classifyAttributes(
+	beforeNodes: readonly LocatedComparisonNode[],
+	afterNodes: readonly LocatedComparisonNode[],
+	facets: Set<ComparisonFacet>,
+	signals: ComparisonSignal[],
+) {
+	const previous = collectAttributes(beforeNodes)
+	const next = collectAttributes(afterNodes)
+	const keys = new Set([...previous.keys()].filter((key) => next.has(key)))
+	for (const key of [...keys].toSorted()) {
+		const before = previous.get(key)!
+		const after = next.get(key)!
+		if (stableSerialize(before?.value) === stableSerialize(after?.value)) {
+			continue
+		}
+		// Do not turn a node replacement into an arbitrary attribute comparison.
+		if (before.nodeName !== after.nodeName) {
+			continue
+		}
+		const record = after
+		// Ignore a neutral transition when both values match content inference.
+		if (record.attribute === 'dir' && isInferredDirectionTransition(
+			before.value,
+			after.value,
+			before.textContent,
+			after.textContent,
+		)) {
+			continue
+		}
+		const code = record.attribute === 'dir'
+			? 'text-direction'
+			: meaningfulAttributes[record.nodeName]?.[record.attribute]
+		facets.add('attribute')
+		if (!code) {
+			facets.add('unknown')
+		}
+		signals.push({
+			type: 'attribute',
+			attribute: code ?? 'unknown-attribute',
+			change: 'changed',
+		})
+	}
+}
+
+/**
+ * @param before Earlier paired node
+ * @param after Later paired node
+ * @param facets Descriptor facets
+ * @param signals Descriptor signals
+ */
+function classifyDirectAttributes(
+	before: Node,
+	after: Node,
+	facets: Set<ComparisonFacet>,
+	signals: ComparisonSignal[],
+) {
+	const names = new Set([...Object.keys(before.attrs), ...Object.keys(after.attrs)])
+	for (const attribute of [...names].toSorted()) {
+		const previous = before.attrs[attribute]
+		const next = after.attrs[attribute]
+		if (stableSerialize(previous) === stableSerialize(next)) {
+			continue
+		}
+		if (attribute === 'dir' && isInferredDirectionTransition(
+			previous,
+			next,
+			before.textContent,
+			after.textContent,
+		)) {
+			continue
+		}
+		const code = attribute === 'dir'
+			? 'text-direction'
+			: meaningfulAttributes[after.type.name]?.[attribute]
+		facets.add('attribute')
+		if (!code) {
+			facets.add('unknown')
+		}
+		signals.push({
+			type: 'attribute',
+			attribute: code ?? 'unknown-attribute',
+			change: previous === undefined ? 'added' : next === undefined ? 'removed' : 'changed',
+		})
+	}
+}
+
+/**
+ * @param before Earlier paired node
+ * @param after Later paired node
+ * @param facets Descriptor facets
+ * @param signals Descriptor signals
+ */
+function classifyDirectMarks(
+	before: Node,
+	after: Node,
+	facets: Set<ComparisonFacet>,
+	signals: ComparisonSignal[],
+) {
+	const previous = new Map(before.marks.map((mark) => [mark.type.name, stableSerialize(mark.attrs)]))
+	const next = new Map(after.marks.map((mark) => [mark.type.name, stableSerialize(mark.attrs)]))
+	const names = new Set([...previous.keys(), ...next.keys()])
+	for (const name of [...names].toSorted()) {
+		if (previous.get(name) === next.get(name)) {
+			continue
+		}
+		const change = !previous.has(name) ? 'added' : !next.has(name) ? 'removed' : 'changed'
+		if (name === 'link') {
+			facets.add('attribute')
+			signals.push({ type: 'attribute', attribute: 'link-target', change })
+		} else if (markCodes[name]) {
+			facets.add('formatting')
+			signals.push({ type: 'mark', mark: markCodes[name], change })
+		} else {
+			facets.add('unknown')
+		}
+	}
+}
+
+/**
+ * Collect marks that intersect a changed range.
+ *
+ * @param doc Complete document
+ * @param range Changed range
+ * @param nodes Touched nodes
+ */
+function collectMarks(
+	doc: Node,
+	range: ComparisonRange,
+	nodes: readonly LocatedComparisonNode[],
+) {
+	const marks = new Map<string, string[]>()
+	const add = (mark: Mark) => {
+		const values = marks.get(mark.type.name) ?? []
+		const encoded = stableSerialize(mark.attrs)
+		if (!values.includes(encoded)) {
+			values.push(encoded)
+			values.sort()
+		}
+		marks.set(mark.type.name, values)
+	}
+	if (range.from === range.to) {
+		for (const mark of doc.resolve(range.from).marks()) {
+			add(mark)
+		}
+	} else {
+		for (const { node } of nodes) {
+			for (const mark of node.marks) {
+				add(mark)
+			}
+		}
+	}
+	return marks
+}
+
+/**
+ * @param nodes Located nodes
+ * @param path Exact path to exclude
+ */
+function excludePath(nodes: readonly LocatedComparisonNode[], path: readonly number[] | undefined) {
+	if (!path) {
+		return nodes
+	}
+	return nodes.filter((node) => node.path.length !== path.length
+		|| node.path.some((index, depth) => index !== path[depth]))
+}
+
+/**
+ * Resolve the strongest semantic context for touched nodes.
+ *
+ * @param nodes Located document nodes
+ */
+function resolveContext(nodes: readonly LocatedComparisonNode[]): ComparisonContextLocation | null {
+	const candidate = nodes
+		.filter(({ node }) => contextCodes[node.type.name] !== undefined)
+		.toSorted(compareContextCandidates)[0]
+	if (!candidate) {
+		return nodes[0]
+			? {
+					code: 'unknown',
+					path: nodes[0].path,
+					from: nodes[0].from,
+					to: nodes[0].to,
+				}
+			: null
+	}
+	return {
+		code: contextCodes[candidate.node.type.name],
+		path: candidate.path,
+		from: candidate.from,
+		to: candidate.to,
+	}
+}
+
+/**
+ * Encode the top-level structural shape of touched nodes.
+ *
+ * @param nodes Located document nodes
+ * @param range Changed range
+ * @param audit Optional operation counter for structural regression tests
+ */
+function structuralShape(
+	nodes: readonly LocatedComparisonNode[],
+	range: ComparisonRange,
+	audit?: ComparisonNodeSearchAudit,
+) {
+	const contained = nodes.filter(({ node, from, to }) => !node.isText
+		&& range.from <= from
+		&& range.to >= to)
+	const containedNodes = new Set(contained)
+	const roots = contained.filter(({ parent }) => !parent || !containedNodes.has(parent))
+	return roots.map(({ node }) => nodeShape(node, audit)).join('|')
+}
+
+/**
+ * Identify a direction transition consistent with parsed-content inference.
+ *
+ * @param before Earlier direction
+ * @param after Later direction
+ * @param beforeText Earlier node text
+ * @param afterText Later node text
+ */
+function isInferredDirectionTransition(
+	before: unknown,
+	after: unknown,
+	beforeText: string,
+	afterText: string,
+) {
+	return (!before || !after)
+		&& beforeText !== afterText
+		&& before === getTextDirection(beforeText)
+		&& after === getTextDirection(afterText)
+}
+
+/**
+ * Encode and cache one immutable node shape.
+ *
+ * @param node Immutable ProseMirror node
+ * @param audit Optional operation counter for structural regression tests
+ */
+function nodeShape(node: Node, audit?: ComparisonNodeSearchAudit): string {
+	const cached = nodeShapeCache.get(node)
+	if (cached !== undefined) {
+		return cached
+	}
+	if (node.isText) {
+		return ''
+	}
+	if (audit) {
+		audit.examinedNodes++
+	}
+	const children: string[] = []
+	node.forEach((child) => {
+		const shape = nodeShape(child, audit)
+		if (shape && children.at(-1) !== shape) {
+			children.push(shape)
+		}
+	})
+	const shape = `${node.type.name}(${children.join(',')})`
+	nodeShapeCache.set(node, shape)
+	return shape
+}
+
+/**
+ * Collect stable attribute records from touched nodes.
+ *
+ * @param nodes Located document nodes
+ */
+function collectAttributes(nodes: readonly LocatedComparisonNode[]) {
+	const records = new Map<string, AttributeRecord>()
+	const topLevelIndices = [...new Set(nodes.map(({ path }) => path[0]).filter((index): index is number => index !== undefined))]
+		.toSorted((a, b) => a - b)
+	const topLevelOrder = new Map(topLevelIndices.map((index, order) => [index, order]))
+	for (const { node, path } of nodes) {
+		if (node.isText) {
+			continue
+		}
+		const relativePath = path.length
+			? [topLevelOrder.get(path[0]!) ?? 0, ...path.slice(1)]
+			: []
+		for (const [attribute, value] of Object.entries(node.attrs)) {
+			const key = `${relativePath.join('.')}:${node.type.name}:${attribute}`
+			records.set(key, {
+				key,
+				nodeName: node.type.name,
+				attribute,
+				value,
+				textContent: node.textContent,
+			})
+		}
+	}
+	return records
+}
+
+/**
+ * Build a short preview for a changed range.
+ *
+ * @param range Changed document range
+ * @param rangeText Changed range text
+ * @param nodes Located document nodes
+ */
+function previewAtom(
+	range: ComparisonRange,
+	rangeText: string,
+	nodes: readonly LocatedComparisonNode[],
+): ComparisonPreviewAtom | null {
+	if (range.from === range.to) {
+		return null
+	}
+	const text = normalizePreview(rangeText.replaceAll('\ufffc', ''))
+	if (text) {
+		return { kind: 'text', text: truncateGraphemes(text, 96) }
+	}
+	const contextText = normalizePreview(resolveContextNode(nodes)?.node.textContent ?? '')
+	if (contextText) {
+		return { kind: 'text', text: truncateGraphemes(contextText, 96) }
+	}
+	const nodeName = resolveContextNode(nodes)?.node.type.name
+	const node = nodeName === 'frontMatter'
+		? 'front-matter'
+		: nodeName === 'image' || nodeName === 'imageInline'
+			? 'image'
+			: nodeName === 'mention'
+				? 'mention'
+				: nodeName === 'inlineMath' || nodeName === 'blockMath'
+					? 'mathematics'
+					: nodeName === 'footnoteReference'
+						? 'footnote-reference'
+						: nodeName === 'horizontalRule'
+							? 'horizontal-rule'
+							: 'changed-content'
+	return { kind: 'node', node }
+}
+
+/**
+ * Resolve the strongest context node.
+ *
+ * @param nodes Located document nodes
+ */
+function resolveContextNode(nodes: readonly LocatedComparisonNode[]) {
+	return nodes
+		.filter(({ node }) => contextCodes[node.type.name] !== undefined)
+		.toSorted(compareContextCandidates)[0]
+		?? nodes[0]
+}
+
+/**
+ * Order context nodes by semantic priority.
+ *
+ * @param a First context candidate
+ * @param b Second context candidate
+ */
+function compareContextCandidates(a: LocatedComparisonNode, b: LocatedComparisonNode) {
+	const aCode = contextCodes[a.node.type.name]
+	const bCode = contextCodes[b.node.type.name]
+	return contextPriority[bCode] - contextPriority[aCode]
+		|| b.path.length - a.path.length
+		|| a.from - b.from
+}
+
+/**
+ * Normalize whitespace in preview text.
+ *
+ * @param value Preview text
+ */
+function normalizePreview(value: string) {
+	return value.replace(/\s+/gu, ' ').trim()
+}
+
+/**
+ * Truncate text without splitting grapheme clusters.
+ *
+ * @param value Text to truncate
+ * @param maximum Maximum grapheme count
+ */
+export function truncateGraphemes(value: string, maximum: number) {
+	let count = 0
+	let truncated = ''
+	const segments = graphemeSegmenter?.segment(value) ?? value
+	for (const item of segments) {
+		if (count++ === maximum) {
+			return `${truncated}…`
+		}
+		truncated += typeof item === 'string' ? item : item.segment
+	}
+	return value
+}
+
+/**
+ * Return descriptor facets in presentation order.
+ *
+ * @param facets Mutable descriptor facets
+ */
+function orderedFacets(facets: Set<ComparisonFacet>) {
+	const order: ComparisonFacet[] = ['text', 'formatting', 'attribute', 'structure', 'unknown']
+	return order.filter((facet) => facets.has(facet))
+}
+
+/**
+ * Deduplicate and deterministically order signals.
+ *
+ * @param signals Mutable descriptor signals
+ */
+function deduplicateSignals(signals: ComparisonSignal[]) {
+	const byValue = new Map(signals.map((signal) => [stableSerialize(signal), signal]))
+	return [...byValue.values()].toSorted((a, b) => compareCodeUnits(stableSerialize(a), stableSerialize(b)))
+}
+
+/**
+ * Clamp a comparison range to a document size.
+ *
+ * @param range Changed document range
+ * @param maximum Document content size
+ */
+function boundedRange(range: ComparisonRange, maximum: number) {
+	const from = clamp(range.from, 0, maximum)
+	return { from, to: clamp(range.to, from, maximum) }
+}
+
+/**
+ * Constrain a number to an inclusive range.
+ *
+ * @param value Input number
+ * @param minimum Inclusive lower bound
+ * @param maximum Inclusive upper bound
+ */
+function clamp(value: number, minimum: number, maximum: number) {
+	return Math.min(Math.max(value, minimum), maximum)
+}
+
+/**
+ * Recursively freeze a comparison value.
+ *
+ * @param value Comparison value
+ */
+export function deepFreeze<T>(value: T): T {
+	if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+		Object.freeze(value)
+		for (const child of Object.values(value)) {
+			deepFreeze(child)
+		}
+	}
+	return value
+}

--- a/src/comparison/markdownComparisonMoves.ts
+++ b/src/comparison/markdownComparisonMoves.ts
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { LocatedComparisonNode } from './comparisonDocumentIndex.ts'
+
+import { stableSerialize } from './markdownComparisonClassification.ts'
+
+export type ReservedExactMoveNode = LocatedComparisonNode
+
+export interface ReservedExactMovePair {
+	before: ReservedExactMoveNode
+	after: ReservedExactMoveNode
+	fingerprint: string
+}
+
+interface TopLevelBlock {
+	index: number
+	node: Node
+	fingerprint: string
+}
+
+/**
+ * Reconfirm and group top-level exact pairs reserved by hierarchical alignment.
+ *
+ * @param before Earlier normalized document
+ * @param after Later normalized document
+ * @param candidates Reserved exact pairs
+ */
+export function confirmReservedExactMoves(
+	before: Node,
+	after: Node,
+	candidates: readonly ReservedExactMovePair[],
+) {
+	if (candidates.length === 0) {
+		return { groups: [], rejected: [] }
+	}
+	const beforeBlocks = topLevelBlocks(before)
+	const afterBlocks = topLevelBlocks(after)
+	const beforeCounts = documentFingerprintCounts(before)
+	const afterCounts = documentFingerprintCounts(after)
+	const confirmed: ReservedExactMovePair[] = []
+	const rejected: ReservedExactMovePair[] = []
+
+	for (const candidate of candidates) {
+		const beforeBlock = beforeBlocks[candidate.before.index]
+		const afterBlock = afterBlocks[candidate.after.index]
+		const valid = beforeBlock?.fingerprint === candidate.fingerprint
+			&& afterBlock?.fingerprint === candidate.fingerprint
+			&& beforeCounts.get(candidate.fingerprint) === 1
+			&& afterCounts.get(candidate.fingerprint) === 1
+			&& beforeBlock.node.eq(afterBlock.node)
+		if (valid) {
+			confirmed.push(candidate)
+		} else {
+			rejected.push(candidate)
+		}
+	}
+
+	const groups: ReservedExactMovePair[][] = []
+	for (const pair of confirmed.toSorted((a, b) => (
+		a.before.index - b.before.index || a.after.index - b.after.index
+	))) {
+		const group = groups.at(-1)
+		const previous = group?.at(-1)
+		if (group && previous
+			&& pair.before.index === previous.before.index + 1
+			&& pair.after.index === previous.after.index + 1) {
+			group.push(pair)
+		} else {
+			groups.push([pair])
+		}
+	}
+	return { groups, rejected }
+}
+
+/** @param doc Complete document */
+function topLevelBlocks(doc: Node) {
+	const blocks: TopLevelBlock[] = []
+	doc.forEach((node, _from, index) => {
+		blocks.push({
+			index,
+			node,
+			fingerprint: canonicalFingerprint(node),
+		})
+	})
+	return blocks
+}
+
+/** @param doc Complete document */
+function documentFingerprintCounts(doc: Node) {
+	const counts = new Map<string, number>()
+	doc.descendants((node) => {
+		const fingerprint = canonicalFingerprint(node)
+		counts.set(fingerprint, (counts.get(fingerprint) ?? 0) + 1)
+	})
+	return counts
+}
+
+/** @param node ProseMirror node */
+function canonicalFingerprint(node: Node) {
+	return stableSerialize(node.toJSON())
+}

--- a/src/comparison/markdownComparisonTypes.ts
+++ b/src/comparison/markdownComparisonTypes.ts
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export type ComparisonOperation = 'insert' | 'delete' | 'replace' | 'move'
+
+export type ComparisonDetail = 'inline' | 'block'
+
+export type ComparisonFacet
+	= | 'text'
+		| 'formatting'
+		| 'attribute'
+		| 'structure'
+		| 'unknown'
+
+export interface ComparisonRange {
+	from: number
+	to: number
+}
+
+export type ComparisonContextCode
+	= | 'front-matter'
+		| 'paragraph'
+		| 'heading'
+		| 'list-item'
+		| 'task'
+		| 'table-cell'
+		| 'code-block'
+		| 'quote'
+		| 'callout'
+		| 'details'
+		| 'footnote'
+		| 'footnote-reference'
+		| 'image'
+		| 'mention'
+		| 'mathematics'
+		| 'preview'
+		| 'unknown'
+
+export interface ComparisonContextLocation {
+	code: ComparisonContextCode
+	path: readonly number[]
+	from: number
+	to: number
+}
+
+export interface ComparisonContext {
+	before: ComparisonContextLocation | null
+	after: ComparisonContextLocation | null
+}
+
+export type ComparisonPreviewNode
+	= | 'front-matter'
+		| 'image'
+		| 'mention'
+		| 'mathematics'
+		| 'footnote-reference'
+		| 'horizontal-rule'
+		| 'changed-content'
+
+export type ComparisonPreviewAtom
+	= | { kind: 'text', text: string }
+		| { kind: 'node', node: ComparisonPreviewNode }
+
+export interface ComparisonPreview {
+	before: ComparisonPreviewAtom | null
+	after: ComparisonPreviewAtom | null
+}
+
+export type ComparisonMarkCode
+	= | 'bold'
+		| 'italic'
+		| 'strike'
+		| 'highlight'
+		| 'underline'
+		| 'inline-code'
+
+export type ComparisonAttributeCode
+	= | 'link'
+		| 'link-target'
+		| 'heading-level'
+		| 'list-start'
+		| 'task-state'
+		| 'code-language'
+		| 'text-direction'
+		| 'image-target'
+		| 'image-alt'
+		| 'mention-identity'
+		| 'mathematics'
+		| 'preview-target'
+		| 'footnote-reference'
+		| 'callout-type'
+		| 'details-state'
+		| 'table-alignment'
+		| 'table-span'
+		| 'unknown-attribute'
+
+export type ComparisonSignal
+	= | {
+		type: 'mark'
+		mark: ComparisonMarkCode
+		change: 'added' | 'removed' | 'changed'
+	}
+	| {
+		type: 'attribute'
+		attribute: ComparisonAttributeCode
+		change: 'added' | 'removed' | 'changed'
+	}
+	| {
+		type: 'node'
+	}
+
+export interface ComparisonDescriptor {
+	id: string
+	sourceOrder: number
+	operation: ComparisonOperation
+	detail: ComparisonDetail
+	facets: readonly ComparisonFacet[]
+	before: ComparisonRange
+	after: ComparisonRange
+	context: ComparisonContext
+	preview: ComparisonPreview
+	signals: readonly ComparisonSignal[]
+}
+
+export interface MarkdownComparisonModel {
+	descriptors: readonly ComparisonDescriptor[]
+}
+
+export type ComparisonSide = 'before' | 'after'

--- a/src/comparison/markdownSourceComparison.ts
+++ b/src/comparison/markdownSourceComparison.ts
@@ -1,0 +1,719 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Change } from 'diff'
+import type {
+	SourceComparisonWorkerRequest,
+	SourceComparisonWorkerResponse,
+} from './markdownSourceComparisonProtocol.ts'
+
+import { diffWordsWithSpace } from 'diff'
+import { compareMarkdownSourceLines } from './markdownSourceComparisonProtocol.ts'
+
+export type SourceEol = 'lf' | 'crlf' | 'cr' | 'none'
+export type SourceLineEnding = Exclude<SourceEol, 'none'> | 'mixed'
+
+export interface SourceDiffSegment {
+	text: string
+	changed: boolean
+}
+
+export interface SourceDiffLine {
+	number: number
+	text: string
+	eol: SourceEol
+	changed: boolean
+	eolChanged: boolean
+	segments: readonly SourceDiffSegment[]
+	hasTab: boolean
+	hasTrailingWhitespace: boolean
+	hasZeroWidth: boolean
+	missingFinalNewline: boolean
+}
+
+export interface SourceDiffHunk {
+	id: string
+	beforeStart: number
+	afterStart: number
+	before: readonly SourceDiffLine[]
+	after: readonly SourceDiffLine[]
+}
+
+export interface SourceLineEndingChange {
+	before: SourceLineEnding
+	after: SourceLineEnding
+}
+
+export interface SourceDiffGap {
+	id: string
+	slot: number
+	before: readonly SourceDiffLine[]
+	after: readonly SourceDiffLine[]
+	count: number
+}
+
+export interface SourceDiffReadyModel {
+	status: 'ready'
+	hunks: readonly SourceDiffHunk[]
+	gaps: readonly SourceDiffGap[]
+	lineEndingChange: SourceLineEndingChange | null
+}
+
+export interface SourceDiffLimitedModel {
+	status: 'limited'
+	reason: 'size' | 'complexity'
+}
+
+export type SourceDiffModel = SourceDiffReadyModel | SourceDiffLimitedModel
+
+interface SourceLine extends SourceDiffLine {
+	start: number
+	end: number
+}
+
+interface ChangedRun {
+	before: LineSpan | null
+	after: LineSpan | null
+	beforeAnchor: number
+	afterAnchor: number
+}
+
+interface LineSpan {
+	from: number
+	to: number
+}
+
+interface SourceCoreRun {
+	before: LineSpan | null
+	after: LineSpan | null
+}
+
+interface MutableHunkRange {
+	cores: SourceCoreRun[]
+	before: LineSpan | null
+	after: LineSpan | null
+}
+
+export const SOURCE_DIFF_LIMITS = Object.freeze({
+	maximumCharacters: 2_000_000,
+	maximumLines: 60_000,
+	maximumEditLength: 50_000,
+	timeoutMilliseconds: 2_000,
+	contextLines: 3,
+	maximumDisplayedRows: 5_000,
+	maximumWordDiffLines: 20,
+	maximumWordDiffPairs: 200,
+	maximumWordDiffCharacters: 2_000,
+	maximumWordDiffMilliseconds: 100,
+	maximumWordDiffPairMilliseconds: 10,
+})
+
+/**
+ * Build an asynchronous, bounded Markdown source diff.
+ *
+ * @param before Earlier stored Markdown
+ * @param after Later stored Markdown
+ * @param signal Optional caller cancellation signal
+ */
+export async function createMarkdownSourceComparison(
+	before: string,
+	after: string,
+	signal?: AbortSignal,
+): Promise<SourceDiffModel> {
+	if (before.length + after.length > SOURCE_DIFF_LIMITS.maximumCharacters
+		|| sourceLineCount(before) + sourceLineCount(after) > SOURCE_DIFF_LIMITS.maximumLines) {
+		return { status: 'limited', reason: 'size' }
+	}
+	if (signal?.aborted) {
+		throw abortError()
+	}
+
+	const comparisonBefore = normalizeLineEndings(before)
+	const comparisonAfter = normalizeLineEndings(after)
+	const changes = await computeLineChanges(comparisonBefore, comparisonAfter, signal)
+	if (!changes) {
+		return { status: 'limited', reason: 'complexity' }
+	}
+	return buildSourceModel(before, after, comparisonBefore, comparisonAfter, changes)
+}
+
+/**
+ * Keep the bounded Myers traversal off the UI thread. jsdiff's callback mode
+ * advances through zero-delay timers, which browsers throttle in background
+ * tabs and can therefore reject small documents at the wall-clock limit.
+ *
+ * @param before Earlier stored Markdown
+ * @param after Later stored Markdown
+ * @param signal Optional caller cancellation signal
+ */
+async function computeLineChanges(before: string, after: string, signal?: AbortSignal) {
+	if (typeof Worker === 'undefined') {
+		const result = compareMarkdownSourceLines({
+			before,
+			after,
+			maximumEditLength: SOURCE_DIFF_LIMITS.maximumEditLength,
+			timeoutMilliseconds: SOURCE_DIFF_LIMITS.timeoutMilliseconds,
+		})
+		if (signal?.aborted) {
+			throw abortError()
+		}
+		return result.status === 'ready' ? result.changes : undefined
+	}
+
+	const worker = new Worker(new URL('./markdownSourceComparison.worker.ts', import.meta.url), { type: 'module' })
+	return new Promise<Change[] | undefined>((resolve, reject) => {
+		const onAbort = () => {
+			signal?.removeEventListener('abort', onAbort)
+			worker.terminate()
+			reject(abortError())
+		}
+		const cleanup = () => {
+			signal?.removeEventListener('abort', onAbort)
+			worker.terminate()
+		}
+		worker.addEventListener('message', ({ data }: MessageEvent<SourceComparisonWorkerResponse>) => {
+			cleanup()
+			resolve(data.status === 'ready' ? data.changes : undefined)
+		}, { once: true })
+		worker.addEventListener('error', () => {
+			cleanup()
+			reject(new Error('Source comparison worker failed'))
+		}, { once: true })
+		signal?.addEventListener('abort', onAbort, { once: true })
+		if (signal?.aborted) {
+			onAbort()
+			return
+		}
+		worker.postMessage({
+			before,
+			after,
+			maximumEditLength: SOURCE_DIFF_LIMITS.maximumEditLength,
+			timeoutMilliseconds: SOURCE_DIFF_LIMITS.timeoutMilliseconds,
+		} satisfies SourceComparisonWorkerRequest)
+	})
+}
+
+/**
+ * Build the bounded source comparison model.
+ *
+ * @param before Earlier literal Markdown
+ * @param after Later literal Markdown
+ * @param comparisonBefore Earlier Markdown with normalized line endings
+ * @param comparisonAfter Later Markdown with normalized line endings
+ * @param changes Ordered line-diff changes
+ */
+function buildSourceModel(
+	before: string,
+	after: string,
+	comparisonBefore: string,
+	comparisonAfter: string,
+	changes: Change[],
+): SourceDiffModel {
+	const beforeLines = splitSourceLines(before)
+	const afterLines = splitSourceLines(after)
+	const runs = changedRuns(changes)
+	const ranges = mergeHunkRanges(runs.map((run) => hunkRange(
+		run,
+		beforeLines.length,
+		afterLines.length,
+	)))
+	const displayedRows = ranges.reduce((count, range) => count
+		+ (range.before ? range.before.to - range.before.from + 1 : 0)
+		+ (range.after ? range.after.to - range.after.from + 1 : 0), 0)
+	if (displayedRows > SOURCE_DIFF_LIMITS.maximumDisplayedRows) {
+		return { status: 'limited', reason: 'complexity' }
+	}
+	const wordDiffBudget = {
+		deadline: Date.now() + SOURCE_DIFF_LIMITS.maximumWordDiffMilliseconds,
+		remaining: SOURCE_DIFF_LIMITS.maximumWordDiffPairs,
+	}
+	const hunks = ranges.map((range, index) => createHunk(
+		`source-hunk-${index.toString(36)}`,
+		range,
+		beforeLines,
+		afterLines,
+		wordDiffBudget,
+	))
+	const gaps = createGaps(ranges, beforeLines, afterLines)
+	return {
+		status: 'ready',
+		hunks,
+		gaps,
+		lineEndingChange: summarizeLineEndingChange(
+			beforeLines,
+			afterLines,
+			comparisonBefore === comparisonAfter,
+		),
+	}
+}
+
+/**
+ * Compare line content independently from the file's newline convention.
+ *
+ * @param source Literal Markdown source
+ */
+function normalizeLineEndings(source: string) {
+	return source.replace(/\r\n?|\n/gu, '\n')
+}
+
+/**
+ * Report a newline convention change once instead of on every line.
+ *
+ * @param before Earlier source lines
+ * @param after Later source lines
+ * @param equalContent Whether normalized source content is equal
+ */
+function summarizeLineEndingChange(
+	before: readonly SourceLine[],
+	after: readonly SourceLine[],
+	equalContent: boolean,
+): SourceLineEndingChange | null {
+	const sameEndings = before.length === after.length
+		&& before.every(({ eol }, index) => eol === after[index]!.eol)
+	if (sameEndings) {
+		return null
+	}
+
+	const beforeEol = lineEndingConvention(before)
+	const afterEol = lineEndingConvention(after)
+	// ceiling: equal mixed conventions are attributed only for EOL-only edits;
+	// upgrade when source diffs must align EOL changes across content edits.
+	if (!beforeEol || !afterEol || (!equalContent && beforeEol === afterEol)) {
+		return null
+	}
+	return { before: beforeEol, after: afterEol }
+}
+
+/**
+ * Return the newline convention for terminated lines.
+ *
+ * @param lines Source lines
+ */
+function lineEndingConvention(lines: readonly SourceLine[]): SourceLineEnding | null {
+	const endings = new Set(lines
+		.map(({ eol }) => eol)
+		.filter((eol): eol is Exclude<SourceEol, 'none'> => eol !== 'none'))
+	if (endings.size === 0) {
+		return null
+	}
+	return endings.size === 1 ? [...endings][0]! : 'mixed'
+}
+
+/**
+ * Group adjacent line-diff changes into changed runs.
+ *
+ * @param changes Ordered line-diff changes
+ */
+function changedRuns(changes: Change[]) {
+	const runs: ChangedRun[] = []
+	let beforeLine = 0
+	let afterLine = 0
+	let current: ChangedRun | null = null
+	for (const change of changes) {
+		const count = change.count ?? sourceLineCount(change.value)
+		if (!change.added && !change.removed) {
+			if (current) {
+				runs.push(current)
+				current = null
+			}
+			beforeLine += count
+			afterLine += count
+			continue
+		}
+		current ??= {
+			before: null,
+			after: null,
+			beforeAnchor: beforeLine,
+			afterAnchor: afterLine,
+		}
+		if (change.removed) {
+			current.before = mergeSpans(current.before, {
+				from: beforeLine,
+				to: beforeLine + count - 1,
+			})
+			beforeLine += count
+		} else {
+			current.after = mergeSpans(current.after, {
+				from: afterLine,
+				to: afterLine + count - 1,
+			})
+			afterLine += count
+		}
+	}
+	if (current) {
+		runs.push(current)
+	}
+	return runs
+}
+
+/**
+ * Resolve source line spans for one changed run.
+ *
+ * @param run Adjacent changed run
+ * @param beforeLineCount Earlier line count
+ * @param afterLineCount Later line count
+ */
+function hunkRange(
+	run: ChangedRun,
+	beforeLineCount: number,
+	afterLineCount: number,
+): MutableHunkRange {
+	const beforeAnchor = run.before ?? anchorLine(beforeLineCount, run.beforeAnchor)
+	const afterAnchor = run.after ?? anchorLine(afterLineCount, run.afterAnchor)
+	return {
+		cores: [{ before: run.before, after: run.after }],
+		before: withContext(beforeAnchor, beforeLineCount),
+		after: withContext(afterAnchor, afterLineCount),
+	}
+}
+
+/**
+ * Merge overlapping source hunk ranges.
+ *
+ * @param ranges Ordered source hunk ranges
+ */
+function mergeHunkRanges(ranges: MutableHunkRange[]) {
+	const merged: MutableHunkRange[] = []
+	for (const range of ranges) {
+		const previous = merged.at(-1)
+		if (previous && (spansOverlap(previous.before, range.before) || spansOverlap(previous.after, range.after))) {
+			previous.cores.push(...range.cores)
+			previous.before = mergeSpans(previous.before, range.before)
+			previous.after = mergeSpans(previous.after, range.after)
+		} else {
+			merged.push({ ...range, cores: [...range.cores] })
+		}
+	}
+	return merged
+}
+
+/**
+ * Build one source comparison hunk.
+ *
+ * @param id Stable model ID
+ * @param range Source hunk range
+ * @param beforeLines Earlier source lines
+ * @param afterLines Later source lines
+ * @param wordDiffBudget Remaining line pairs eligible for word emphasis
+ * @param wordDiffBudget.deadline Time when word emphasis must stop
+ * @param wordDiffBudget.remaining Remaining line-pair count
+ */
+function createHunk(
+	id: string,
+	range: MutableHunkRange,
+	beforeLines: SourceLine[],
+	afterLines: SourceLine[],
+	wordDiffBudget: { deadline: number, remaining: number },
+): SourceDiffHunk {
+	const before = linesInSpan(beforeLines, range.before, range.cores.map(({ before }) => before))
+	const after = linesInSpan(afterLines, range.after, range.cores.map(({ after }) => after))
+	for (const core of range.cores) {
+		addWordEmphasis(before, after, core.before, core.after, range.before, range.after, wordDiffBudget)
+	}
+	return {
+		id,
+		beforeStart: before[0]?.number ?? 0,
+		afterStart: after[0]?.number ?? 0,
+		before,
+		after,
+	}
+}
+
+/**
+ * Build collapsible gaps around source hunks.
+ *
+ * @param ranges Ordered source hunk ranges
+ * @param beforeLines Earlier source lines
+ * @param afterLines Later source lines
+ */
+function createGaps(
+	ranges: MutableHunkRange[],
+	beforeLines: SourceLine[],
+	afterLines: SourceLine[],
+) {
+	if (ranges.length === 0) {
+		return []
+	}
+	const gaps: SourceDiffGap[] = []
+	for (let slot = 0; slot <= ranges.length; slot++) {
+		const before = gapLines(beforeLines, ranges, slot, 'before')
+		const after = gapLines(afterLines, ranges, slot, 'after')
+		if (before.length === 0 && after.length === 0) {
+			continue
+		}
+		gaps.push({
+			id: `source-gap-${slot.toString(36)}`,
+			slot,
+			before,
+			after,
+			count: Math.max(before.length, after.length),
+		})
+	}
+	return gaps
+}
+
+/**
+ * Select lines for one side of a collapsible gap.
+ *
+ * @param lines Source lines
+ * @param ranges Ordered source hunk ranges
+ * @param slot Gap boundary index
+ * @param side Source document side
+ */
+function gapLines(
+	lines: SourceLine[],
+	ranges: MutableHunkRange[],
+	slot: number,
+	side: 'before' | 'after',
+) {
+	if (slot === 0) {
+		const first = ranges[0]![side]
+		return first ? lines.slice(0, first.from) : []
+	}
+	if (slot === ranges.length) {
+		const last = ranges.at(-1)![side]
+		return last ? lines.slice(last.to + 1) : []
+	}
+	return betweenSpans(lines, ranges[slot - 1]![side], ranges[slot]![side])
+}
+
+/**
+ * Split literal source while preserving line endings.
+ *
+ * @param source Literal Markdown source
+ */
+function splitSourceLines(source: string) {
+	if (source.length === 0) {
+		return []
+	}
+	const lines: SourceLine[] = []
+	const pattern = /([^\r\n]*)(\r\n|\n|\r|$)/g
+	let match: RegExpExecArray | null
+	while ((match = pattern.exec(source)) !== null) {
+		const text = match[1]!
+		const rawEol = match[2]!
+		if (text === '' && rawEol === '' && match.index === source.length) {
+			break
+		}
+		const eol: SourceEol = rawEol === '\r\n' ? 'crlf' : rawEol === '\n' ? 'lf' : rawEol === '\r' ? 'cr' : 'none'
+		const start = match.index
+		const end = start + text.length + rawEol.length
+		lines.push({
+			number: lines.length + 1,
+			text,
+			eol,
+			changed: false,
+			eolChanged: false,
+			segments: [{ text, changed: false }],
+			hasTab: text.includes('\t'),
+			hasTrailingWhitespace: /[\t ]+$/u.test(text),
+			hasZeroWidth: /[\u200B-\u200D\u2060\uFEFF]/u.test(text),
+			missingFinalNewline: eol === 'none',
+			start,
+			end,
+		})
+		if (rawEol === '') {
+			break
+		}
+	}
+	return lines
+}
+
+/**
+ * Count display lines without materializing them.
+ *
+ * @param source Literal Markdown source
+ */
+function sourceLineCount(source: string) {
+	let count = 0
+	for (let index = 0; index < source.length; index++) {
+		if (source[index] === '\r') {
+			count++
+			if (source[index + 1] === '\n') {
+				index++
+			}
+		} else if (source[index] === '\n') {
+			count++
+		}
+	}
+	if (source.length && !source.endsWith('\n') && !source.endsWith('\r')) {
+		count++
+	}
+	return count
+}
+
+/**
+ * Resolve the nearest line for an empty source range.
+ *
+ * @param lineCount Source line count
+ * @param index Source line boundary
+ */
+function anchorLine(lineCount: number, index: number): LineSpan | null {
+	if (lineCount === 0) {
+		return null
+	}
+	const anchored = Math.min(index, lineCount - 1)
+	return { from: anchored, to: anchored }
+}
+
+/**
+ * Expand a line span with bounded context.
+ *
+ * @param span Changed line span
+ * @param lineCount Total source line count
+ */
+function withContext(span: LineSpan | null, lineCount: number) {
+	if (!span || lineCount === 0) {
+		return null
+	}
+	return {
+		from: Math.max(0, span.from - SOURCE_DIFF_LIMITS.contextLines),
+		to: Math.min(lineCount - 1, span.to + SOURCE_DIFF_LIMITS.contextLines),
+	}
+}
+
+/**
+ * Build display lines for a source span.
+ *
+ * @param lines Source lines
+ * @param span Display line span
+ * @param cores Changed core spans
+ */
+function linesInSpan(lines: SourceLine[], span: LineSpan | null, cores: readonly (LineSpan | null)[]) {
+	if (!span) {
+		return []
+	}
+	return lines.slice(span.from, span.to + 1).map((line) => ({
+		...line,
+		segments: [...line.segments],
+		changed: cores.some((core) => core !== null && line.number - 1 >= core.from && line.number - 1 <= core.to),
+	}))
+}
+
+/**
+ * Add word-level emphasis to aligned changed lines.
+ *
+ * @param before Earlier display lines
+ * @param after Later display lines
+ * @param coreBefore Earlier changed core span
+ * @param coreAfter Later changed core span
+ * @param spanBefore Earlier hunk span
+ * @param spanAfter Later hunk span
+ * @param wordDiffBudget Remaining line pairs eligible for word emphasis
+ * @param wordDiffBudget.deadline Time when word emphasis must stop
+ * @param wordDiffBudget.remaining Remaining line-pair count
+ */
+function addWordEmphasis(
+	before: SourceDiffLine[],
+	after: SourceDiffLine[],
+	coreBefore: LineSpan | null,
+	coreAfter: LineSpan | null,
+	spanBefore: LineSpan | null,
+	spanAfter: LineSpan | null,
+	wordDiffBudget: { deadline: number, remaining: number },
+) {
+	if (!coreBefore || !coreAfter || !spanBefore || !spanAfter) {
+		return
+	}
+	const removed = before.slice(coreBefore.from - spanBefore.from, coreBefore.to - spanBefore.from + 1)
+	const added = after.slice(coreAfter.from - spanAfter.from, coreAfter.to - spanAfter.from + 1)
+	markChangedEol(removed, added)
+	if (removed.length > SOURCE_DIFF_LIMITS.maximumWordDiffLines
+		|| added.length > SOURCE_DIFF_LIMITS.maximumWordDiffLines) {
+		return
+	}
+	const lineCount = Math.min(removed.length, added.length)
+	for (let index = 0; index < lineCount && wordDiffBudget.remaining > 0; index++) {
+		const beforeLine = removed[index]!
+		const afterLine = added[index]!
+		if (beforeLine.text.length > SOURCE_DIFF_LIMITS.maximumWordDiffCharacters
+			|| afterLine.text.length > SOURCE_DIFF_LIMITS.maximumWordDiffCharacters) {
+			continue
+		}
+		const remainingMilliseconds = wordDiffBudget.deadline - Date.now()
+		if (remainingMilliseconds <= 0) {
+			wordDiffBudget.remaining = 0
+			return
+		}
+		wordDiffBudget.remaining--
+		const words = diffWordsWithSpace(beforeLine.text, afterLine.text, {
+			timeout: Math.min(
+				remainingMilliseconds,
+				SOURCE_DIFF_LIMITS.maximumWordDiffPairMilliseconds,
+			),
+		})
+		if (!words) {
+			continue
+		}
+		beforeLine.segments = words
+			.filter(({ added }) => !added)
+			.map(({ value, removed }) => ({ text: value, changed: removed }))
+		afterLine.segments = words
+			.filter(({ removed }) => !removed)
+			.map(({ value, added }) => ({ text: value, changed: added }))
+	}
+}
+
+/**
+ * Mark paired lines with different line endings.
+ *
+ * @param before Earlier display lines
+ * @param after Later display lines
+ */
+function markChangedEol(before: SourceDiffLine[], after: SourceDiffLine[]) {
+	for (let index = 0; index < Math.min(before.length, after.length); index++) {
+		const left = before[index]!
+		const right = after[index]!
+		if (left.changed && right.changed && left.eol !== right.eol) {
+			left.eolChanged = true
+			right.eolChanged = true
+		}
+	}
+}
+
+/**
+ * Check whether two line spans overlap or touch.
+ *
+ * @param left First optional line span
+ * @param right Second optional line span
+ */
+function spansOverlap(left: LineSpan | null, right: LineSpan | null) {
+	return left !== null && right !== null && right.from <= left.to + 1
+}
+
+/**
+ * Merge two optional line spans.
+ *
+ * @param left First optional line span
+ * @param right Second optional line span
+ */
+function mergeSpans(left: LineSpan | null, right: LineSpan | null): LineSpan | null {
+	if (!left) {
+		return right ? { ...right } : null
+	}
+	if (!right) {
+		return { ...left }
+	}
+	return { from: Math.min(left.from, right.from), to: Math.max(left.to, right.to) }
+}
+
+/**
+ * Select unchanged lines between two spans.
+ *
+ * @param lines Source display lines
+ * @param left Earlier line span
+ * @param right Later line span
+ */
+function betweenSpans(lines: SourceLine[], left: LineSpan | null, right: LineSpan | null) {
+	if (!left || !right || right.from <= left.to + 1) {
+		return []
+	}
+	return lines.slice(left.to + 1, right.from)
+}
+
+/** Create the standard source comparison abort error. */
+function abortError() {
+	return new DOMException('Source comparison aborted', 'AbortError')
+}

--- a/src/comparison/markdownSourceComparison.worker.ts
+++ b/src/comparison/markdownSourceComparison.worker.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { SourceComparisonWorkerRequest, SourceComparisonWorkerResponse } from './markdownSourceComparisonProtocol.ts'
+
+import { compareMarkdownSourceLines } from './markdownSourceComparisonProtocol.ts'
+
+interface SourceComparisonWorkerScope {
+	addEventListener: (
+		type: 'message',
+		listener: (event: MessageEvent<SourceComparisonWorkerRequest>) => void,
+	) => void
+	postMessage: (message: SourceComparisonWorkerResponse) => void
+}
+
+const workerScope = globalThis as unknown as SourceComparisonWorkerScope
+
+workerScope.addEventListener('message', ({ data }) => {
+	workerScope.postMessage(compareMarkdownSourceLines(data))
+})

--- a/src/comparison/markdownSourceComparisonProtocol.ts
+++ b/src/comparison/markdownSourceComparisonProtocol.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Change } from 'diff'
+
+import { diffLines } from 'diff'
+
+export interface SourceComparisonWorkerRequest {
+	before: string
+	after: string
+	maximumEditLength: number
+	timeoutMilliseconds: number
+}
+
+export type SourceComparisonWorkerResponse
+	= | { status: 'ready', changes: Change[] }
+		| { status: 'limited' }
+
+/**
+ * Run the bounded line comparison used by both execution paths.
+ *
+ * @param request Worker protocol request
+ */
+export function compareMarkdownSourceLines(request: SourceComparisonWorkerRequest): SourceComparisonWorkerResponse {
+	const changes = diffLines(request.before, request.after, {
+		stripTrailingCr: false,
+		maxEditLength: request.maximumEditLength,
+		timeout: request.timeoutMilliseconds,
+	})
+	return changes ? { status: 'ready', changes } : { status: 'limited' }
+}

--- a/src/comparison/renderedComparisonLimit.ts
+++ b/src/comparison/renderedComparisonLimit.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * The first failing browser fixture measured 264,599/267,666 characters and
+ * 8,163/8,259 lines. These ceilings remain over 20% below the smaller failing
+ * dimension; recalibrate only with the same production-build browser gate.
+ */
+export const RENDERED_COMPARISON_LIMITS = Object.freeze({
+	maximumCharactersPerSnapshot: 210_000,
+	maximumLinesPerSnapshot: 6_500,
+})
+
+/**
+ * Determine whether rendered semantic comparison must be skipped before parsing.
+ *
+ * @param before Earlier raw Markdown
+ * @param after Later raw Markdown
+ */
+export function exceedsRenderedComparisonLimit(before: string, after: string): boolean {
+	return [before, after].some((content) => content.length > RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot
+		|| exceedsLineLimit(content))
+}
+
+/** @param content Raw Markdown */
+function exceedsLineLimit(content: string): boolean {
+	if (!content) {
+		return false
+	}
+	let lines = 1
+	for (let index = 0; index < content.length; index++) {
+		const character = content[index]
+		if (character === '\n' || (character === '\r' && content[index + 1] !== '\n')) {
+			lines++
+			if (lines > RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/src/components/ComparisonChangeList.vue
+++ b/src/components/ComparisonChangeList.vue
@@ -1,0 +1,814 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<ol class="text-comparison__change-list">
+		<li v-for="section in sections" :key="section.id" class="text-comparison__section">
+			<h3 :id="`${listId}-${section.id}-heading`" class="text-comparison__section-heading">
+				<button
+					type="button"
+					class="text-comparison__section-toggle"
+					:aria-controls="`${listId}-${section.id}-group`"
+					:aria-expanded="!collapsed.has(section.id)"
+					:aria-label="section.accessibleLabel"
+					:data-comparison-section="section.id"
+					@click="toggleSection(section.id)">
+					<span class="text-comparison__section-caret" aria-hidden="true">
+						{{ collapsed.has(section.id) ? '▸' : '▾' }}
+					</span>
+					<span class="text-comparison__section-title">
+						{{ section.title || t('text', 'Document start') }}
+					</span>
+					<span class="text-comparison__section-kinds" aria-hidden="true">
+						<span
+							v-for="kind in section.kinds"
+							:key="kind"
+							class="text-comparison__kind-dot"
+							:class="`text-comparison__kind-dot--${kind}`" />
+					</span>
+					<span class="text-comparison__section-count">
+						{{ n('text', '%n change', '%n changes', section.groups.length) }}
+					</span>
+				</button>
+			</h3>
+
+			<ul
+				v-show="!collapsed.has(section.id)"
+				:id="`${listId}-${section.id}-group`"
+				class="text-comparison__section-rows"
+				role="group"
+				:aria-labelledby="`${listId}-${section.id}-heading`">
+				<li v-for="record in section.records" :key="record.id">
+					<button
+						type="button"
+						class="text-comparison__change-item"
+						:aria-current="record.id === currentId ? 'true' : undefined"
+						:aria-label="record.accessibleLabel"
+						:data-comparison-select="record.id"
+						@click="emit('select', record.id)">
+						<span
+							class="text-comparison__operation"
+							:class="`text-comparison__operation--${record.operation}`"
+							aria-hidden="true">
+							{{ operationSymbol(record.operation) }}
+						</span>
+						<span
+							class="text-comparison__change-copy"
+							:class="{ 'text-comparison__change-copy--label-first': record.textUnchanged }">
+							<span class="text-comparison__preview" aria-hidden="true">
+								<template v-for="(preview, index) in record.previews" :key="preview.id">
+									<span v-if="index > 0" class="text-comparison__preview-separator">; </span>
+									<template v-if="preview.operation === 'insert'">
+										<ins class="text-comparison__preview-after"><bdi dir="auto">{{ preview.after || t('text', 'Content added') }}</bdi></ins>
+									</template>
+									<template v-else-if="preview.operation === 'delete'">
+										<del class="text-comparison__preview-before"><bdi dir="auto">{{ preview.before || t('text', 'Content removed') }}</bdi></del>
+									</template>
+									<template v-else-if="preview.textUnchanged">
+										<bdi dir="auto">{{ preview.before || preview.after || t('text', 'Content changed') }}</bdi>
+									</template>
+									<template v-else>
+										<del class="text-comparison__preview-before"><bdi dir="auto">{{ preview.before || t('text', 'No content') }}</bdi></del>
+										<span class="text-comparison__preview-arrow" aria-hidden="true"> → </span>
+										<ins class="text-comparison__preview-after"><bdi dir="auto">{{ preview.after || t('text', 'No content') }}</bdi></ins>
+									</template>
+								</template>
+							</span>
+							<span class="text-comparison__change-title">
+								<strong class="text-comparison__change-label">{{ record.label }}</strong>
+								<span class="text-comparison__change-context">{{ record.context }}</span>
+								<span
+									v-if="record.detail === 'block'"
+									class="text-comparison__detail-badge"
+									:aria-label="t('text', 'Block-level change; fine inline detail is unavailable')">
+									{{ t('text', 'Block-level') }}
+								</span>
+							</span>
+						</span>
+						<span class="text-comparison__change-open" aria-hidden="true">›</span>
+					</button>
+				</li>
+			</ul>
+		</li>
+	</ol>
+</template>
+
+<script setup lang="ts">
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonDescriptorGroup } from '../comparison/comparisonNavigation.ts'
+import type { ComparisonSection } from '../comparison/comparisonSections.ts'
+import type { ComparisonDescriptor } from '../comparison/markdownComparison.ts'
+
+import { n, t } from '@nextcloud/l10n'
+import { computed, ref, useId, watch } from 'vue'
+import { isPureFormatting } from '../comparison/comparisonNavigation.ts'
+import { selectComparisonSignal } from '../comparison/comparisonPresentation.ts'
+import { buildComparisonSections, headingLocations, nearestHeading } from '../comparison/comparisonSections.ts'
+
+const props = defineProps<{
+	groups: readonly ComparisonDescriptorGroup[]
+	currentId?: string
+	beforeDocument: Node
+	afterDocument: Node
+}>()
+
+const emit = defineEmits<{
+	select: [id: string]
+	currentLabel: [label: string]
+}>()
+
+const collapsed = ref(new Set<string>())
+const listId = useId()
+const beforeHeadings = headingLocations(props.beforeDocument)
+const afterHeadings = headingLocations(props.afterDocument)
+
+const sections = computed(() => {
+	const built = buildComparisonSections(props.groups, props.beforeDocument, props.afterDocument)
+	return built.map((section) => ({
+		...section,
+		accessibleLabel: sectionLabel(section),
+		records: section.groups.map((group) => buildRecord(group, section)),
+	}))
+})
+const records = computed(() => sections.value.flatMap(({ records }) => records))
+
+watch(
+	[records, () => props.currentId],
+	() => emit('currentLabel', records.value.find(({ id }) => id === props.currentId)?.label ?? ''),
+	{ immediate: true },
+)
+
+/**
+ * Keep a selected change reachable even when its section was collapsed.
+ */
+watch(() => props.currentId, (id) => {
+	if (!id) {
+		return
+	}
+	const section = sections.value.find(({ records }) => records.some((record) => record.id === id))
+	if (section && collapsed.value.has(section.id)) {
+		const next = new Set(collapsed.value)
+		next.delete(section.id)
+		collapsed.value = next
+	}
+})
+
+/**
+ * @param id Section ID
+ */
+function toggleSection(id: string) {
+	const next = new Set(collapsed.value)
+	if (next.has(id)) {
+		next.delete(id)
+	} else {
+		next.add(id)
+	}
+	collapsed.value = next
+}
+
+/**
+ * Name a section for assistive technology.
+ *
+ * The kind swatch beside the title is decorative, so the kinds it shows are
+ * spelled out here instead — otherwise that information exists only in colour.
+ *
+ * @param section Changed document section
+ */
+function sectionLabel(section: ComparisonSection) {
+	const kinds = ({
+		content: t('text', 'Content'),
+		formatting: t('text', 'Formatting'),
+		move: t('text', 'Moved content'),
+		other: t('text', 'Other changes'),
+	})
+	return [
+		section.title || t('text', 'Document start'),
+		n('text', '%n change', '%n changes', section.groups.length),
+		section.kinds.map((kind) => kinds[kind]).join(', '),
+	].filter(Boolean).join('. ')
+}
+
+/**
+ * @param group Changed semantic block
+ * @param section Section the group belongs to
+ */
+function buildRecord(group: ComparisonDescriptorGroup, section: ComparisonSection) {
+	const descriptor = group.descriptors[0]!
+	const editCount = group.descriptors.length
+	const detail = group.descriptors.some(({ detail }) => detail === 'block') ? 'block' : 'inline'
+	const operations = new Set(group.descriptors.map(({ operation }) => operation))
+	const operation = operations.size === 1 ? descriptor.operation : 'replace'
+	const formattingOnly = group.descriptors.every(isPureFormatting)
+	const label = editCount === 1 ? descriptorLabel(descriptor) : groupedDescriptorLabel(descriptor, editCount)
+	const context = descriptorContext(descriptor, section.title)
+	const previews = group.descriptors.map(descriptorPreview)
+	// A link target, a task state or a formatting mark can change without the
+	// words changing. Showing "Status dashboard → Status dashboard" would put
+	// the row's emptiest text in its most prominent place, so those rows lead
+	// with the label instead and keep the passage as context.
+	// A relocation reads the same on both sides by definition, so it belongs
+	// here too — only an insert or a delete genuinely has one side.
+	const textUnchanged = formattingOnly || previews.every(({ textUnchanged }) => textUnchanged)
+	const previewLabel = previews.map((preview) => previewText(
+		preview.operation,
+		preview.before,
+		preview.after,
+		preview.textUnchanged,
+	)).join('; ')
+	return {
+		context,
+		detail,
+		id: group.id,
+		label,
+		operation,
+		previews,
+		textUnchanged,
+		accessibleLabel: accessibleLabel(
+			operation,
+			detail,
+			label,
+			context,
+			previewLabel,
+		),
+	}
+}
+
+/**
+ * Preserve every exact descriptor preview represented by one grouped row.
+ *
+ * @param descriptor Semantic change
+ */
+function descriptorPreview(descriptor: ComparisonDescriptor) {
+	const before = previewSide(descriptor.preview.before)
+	const after = previewSide(descriptor.preview.after)
+	return {
+		after,
+		before,
+		id: descriptor.id,
+		operation: descriptor.operation,
+		textUnchanged: descriptor.operation !== 'insert'
+			&& descriptor.operation !== 'delete'
+			&& before === after,
+	}
+}
+
+/**
+ * @param descriptor Semantic change
+ */
+function descriptorLabel(descriptor: ComparisonDescriptor) {
+	const context = contextType(descriptor)
+	if (descriptor.operation === 'move') {
+		return t('text', 'Moved section')
+	}
+	const signal = selectComparisonSignal(descriptor.signals)
+	if (signal?.type === 'mark') {
+		const formatting = ({
+			bold: t('text', 'Bold'),
+			italic: t('text', 'Italic'),
+			strike: t('text', 'Strikethrough'),
+			highlight: t('text', 'Highlight'),
+			underline: t('text', 'Underline'),
+			'inline-code': t('text', 'Inline code'),
+		})[signal.mark]
+		return signal.change === 'added'
+			? t('text', '{formatting} added', { formatting })
+			: signal.change === 'removed'
+				? t('text', '{formatting} removed', { formatting })
+				: t('text', '{formatting} changed', { formatting })
+	}
+	if (signal?.type === 'attribute') {
+		return ({
+			link: signal.change === 'added' ? t('text', 'Link added') : t('text', 'Link removed'),
+			'link-target': t('text', 'Link target changed'),
+			'heading-level': t('text', 'Heading level changed'),
+			'list-start': t('text', 'List start changed'),
+			'task-state': t('text', 'Task state changed'),
+			'code-language': t('text', 'Code language changed'),
+			'text-direction': t('text', 'Text direction changed'),
+			'image-target': t('text', 'Image changed'),
+			'image-alt': t('text', 'Image description changed'),
+			'mention-identity': t('text', 'Mention changed'),
+			mathematics: t('text', 'Mathematics changed'),
+			'preview-target': t('text', 'Link preview changed'),
+			'footnote-reference': t('text', 'Footnote changed'),
+			'callout-type': t('text', 'Callout type changed'),
+			'details-state': t('text', 'Details state changed'),
+			'table-alignment': t('text', 'Table alignment changed'),
+			'table-span': t('text', 'Table structure changed'),
+			'unknown-attribute': t('text', 'Attribute changed'),
+		})[signal.attribute]
+	}
+	if (descriptor.facets.includes('unknown')) {
+		return t('text', 'Content changed')
+	}
+	if (descriptor.operation === 'insert') {
+		return context.code === 'unknown'
+			? t('text', 'Content added')
+			: t('text', '{context} added', { context: context.label })
+	}
+	if (descriptor.operation === 'delete') {
+		return context.code === 'unknown'
+			? t('text', 'Content removed')
+			: t('text', '{context} removed', { context: context.label })
+	}
+	if (descriptor.facets.includes('structure')) {
+		return t('text', 'Structure changed')
+	}
+	return context.code === 'unknown'
+		? t('text', 'Text changed')
+		: t('text', '{context} changed', { context: context.label })
+}
+
+/**
+ * @param descriptor First semantic range in one changed block
+ * @param count Algorithm ranges represented by the row
+ */
+function groupedDescriptorLabel(descriptor: ComparisonDescriptor, count: number) {
+	const context = contextType(descriptor)
+	const label = context.code === 'unknown'
+		? t('text', 'Content changed')
+		: t('text', '{context} changed', { context: context.label })
+	return `${label} — ${n('text', '%n edit', '%n edits', count)}`
+}
+
+/**
+ * Describe where a change sits, without repeating its section heading.
+ *
+ * A heading rename still shows both names, because the old name is the only
+ * place the reader can see what the section used to be called.
+ *
+ * @param descriptor Semantic change
+ * @param sectionTitle Heading already shown above the row
+ */
+function descriptorContext(descriptor: ComparisonDescriptor, sectionTitle: string) {
+	const before = nearestHeadingText(descriptor, 'before')
+	const after = nearestHeadingText(descriptor, 'after')
+	// A delete has no place in the After document — its After position is only
+	// where the content collapsed to, which is the following section. Reading
+	// that as a rename would claim a change that never happened.
+	if (descriptor.operation === 'delete') {
+		return before && before !== sectionTitle
+			? t('text', 'Section: {section}', { section: before })
+			: contextType(descriptor).label
+	}
+	const headingChanged = descriptor.operation === 'replace'
+		&& (descriptor.context.before?.code === 'heading'
+			|| descriptor.context.after?.code === 'heading')
+	if (headingChanged && before && after && before !== after) {
+		return t('text', '{before} → {after}', { before, after })
+	}
+	const section = after || before
+	if (section && section !== sectionTitle) {
+		return t('text', 'Section: {section}', { section })
+	}
+	return contextType(descriptor).label
+}
+
+/**
+ * @param descriptor Semantic change
+ * @param side Document side
+ */
+function nearestHeadingText(descriptor: ComparisonDescriptor, side: 'before' | 'after') {
+	const headings = side === 'before' ? beforeHeadings : afterHeadings
+	const position = descriptor.context[side]?.from ?? descriptor[side].from
+	return nearestHeading(headings, position)
+}
+
+/**
+ * @param descriptor Semantic change
+ */
+function contextType(descriptor: ComparisonDescriptor) {
+	// A delete's After context is only the position its content collapsed to,
+	// which is usually the enclosing heading. Reading it would report a deleted
+	// paragraph as "Heading removed".
+	const code = descriptor.operation === 'delete'
+		? descriptor.context.before?.code ?? descriptor.context.after?.code ?? 'unknown'
+		: descriptor.context.after?.code ?? descriptor.context.before?.code ?? 'unknown'
+	return {
+		code,
+		label: ({
+			'front-matter': t('text', 'Front matter'),
+			paragraph: t('text', 'Paragraph'),
+			heading: t('text', 'Heading'),
+			'list-item': t('text', 'List item'),
+			task: t('text', 'Task'),
+			'table-cell': t('text', 'Table cell'),
+			'code-block': t('text', 'Code block'),
+			quote: t('text', 'Quote'),
+			callout: t('text', 'Callout'),
+			details: t('text', 'Details'),
+			footnote: t('text', 'Footnote'),
+			'footnote-reference': t('text', 'Footnote reference'),
+			image: t('text', 'Image'),
+			mention: t('text', 'Mention'),
+			mathematics: t('text', 'Mathematics'),
+			preview: t('text', 'Link preview'),
+			unknown: t('text', 'Changed content'),
+		})[code],
+	}
+}
+
+/**
+ * @param operation Display operation
+ * @param detail Finest detail represented by the group
+ * @param label Primary semantic label
+ * @param context Nearest useful context
+ * @param previewLabel Safe descriptor previews
+ */
+function accessibleLabel(
+	operation: ComparisonDescriptor['operation'],
+	detail: ComparisonDescriptor['detail'],
+	label: string,
+	context: string,
+	previewLabel: string,
+) {
+	// The section heading above the row already names the section, once, for
+	// assistive technology as much as for sight. Repeating it on every row
+	// would restore the redundancy the grouping removed.
+	return [
+		operationLabel(operation),
+		label,
+		context,
+		previewLabel,
+		detail === 'block' ? t('text', 'Block-level; fine inline detail is unavailable') : '',
+	].filter(Boolean).join('. ')
+}
+
+/**
+ * @param operation Display operation
+ * @param before Safe Before preview
+ * @param after Safe After preview
+ * @param textUnchanged Whether the passage reads the same on both sides
+ */
+function previewText(operation: ComparisonDescriptor['operation'], before: string, after: string, textUnchanged: boolean) {
+	if (operation === 'insert') {
+		return after || t('text', 'Content added')
+	}
+	if (operation === 'delete') {
+		return before || t('text', 'Content removed')
+	}
+	if (textUnchanged) {
+		return before || after || t('text', 'Content changed')
+	}
+	return `${before || t('text', 'No content')} → ${after || t('text', 'No content')}`
+}
+
+/**
+ * @param atom Safe descriptor preview
+ */
+function previewSide(atom: ComparisonDescriptor['preview']['before']) {
+	if (!atom) {
+		return ''
+	}
+	if (atom.kind === 'text') {
+		return atom.text
+	}
+	return ({
+		'front-matter': t('text', 'Front matter changed'),
+		image: t('text', 'Image changed'),
+		mention: t('text', 'Mention changed'),
+		mathematics: t('text', 'Mathematics changed'),
+		'footnote-reference': t('text', 'Footnote reference changed'),
+		'horizontal-rule': t('text', 'Divider changed'),
+		'changed-content': t('text', 'Changed content'),
+	})[atom.node]
+}
+
+/**
+ * @param operation Display operation
+ */
+function operationLabel(operation: ComparisonDescriptor['operation']) {
+	return ({
+		insert: t('text', 'Added'),
+		delete: t('text', 'Removed'),
+		replace: t('text', 'Changed'),
+		move: t('text', 'Moved'),
+	})[operation]
+}
+
+/**
+ * @param operation Display operation
+ */
+function operationSymbol(operation: ComparisonDescriptor['operation']) {
+	return ({ insert: '+', delete: '−', replace: '↔', move: '↳' })[operation]
+}
+</script>
+
+<style lang="scss">
+.text-comparison {
+	&__change-list {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	&__section-rows {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	// The section is the sticky header's containing block, so a header travels
+	// only as far as its own rows and never over the next section's.
+	&__section {
+		position: relative;
+	}
+
+	&__section-heading {
+		position: sticky;
+		top: 0;
+		z-index: 1;
+		margin: 0;
+		background: var(--color-main-background);
+		font-size: inherit;
+		font-weight: inherit;
+	}
+
+	// core/css/inputs.scss styles every bare <button> at (0,1,1): width 130px,
+	// its own border and padding, an opaque background and a text cursor. Both
+	// controls below are written as descendants of .text-comparison so they
+	// carry (0,2,0) and win on specificity rather than on !important.
+	.text-comparison__section-toggle {
+		display: flex;
+		align-items: center;
+		gap: calc(2 * var(--default-grid-baseline));
+		inline-size: 100%;
+		min-block-size: var(--default-clickable-area);
+		// The global rule sets `margin: 3px; margin-inline-start: 0` at (0,2,1),
+		// which a two-class selector cannot reach.
+		margin: 0 !important;
+		padding: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
+		border: 0;
+		border-block-end: 1px solid var(--color-border);
+		border-radius: 0;
+		background: transparent;
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+		text-align: start;
+		cursor: pointer;
+
+		&:hover {
+			background: var(--color-background-hover);
+			// …and `border-color: var(--color-main-text)` on hover at (0,4,1),
+			// which would turn this divider black under the pointer.
+			border-block-end-color: var(--color-border) !important;
+		}
+	}
+
+	// Matches the row's operation column so section titles and change previews
+	// share one left edge.
+	&__section-caret {
+		inline-size: calc(6 * var(--default-grid-baseline));
+		font-size: var(--font-size-small);
+		text-align: center;
+	}
+
+	&__section-title {
+		min-inline-size: 0;
+		overflow: hidden;
+		color: var(--color-main-text);
+		font-weight: var(--font-weight-heading);
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__section-kinds {
+		display: inline-flex;
+		flex: 0 0 auto;
+		gap: var(--default-grid-baseline);
+	}
+
+	// Nextcloud offers no fifth semantic hue, and primary and info sit about one
+	// step apart, so shape carries the distinction alongside colour rather than
+	// leaving two of the four swatches effectively identical.
+	&__kind-dot {
+		inline-size: calc(2 * var(--default-grid-baseline));
+		block-size: calc(2 * var(--default-grid-baseline));
+		border-radius: 50%;
+
+		&--content {
+			background: var(--color-element-warning);
+		}
+
+		&--formatting {
+			border: 2px solid var(--color-primary-element);
+			background: transparent;
+		}
+
+		&--move {
+			border-radius: 0;
+			background: var(--color-element-info);
+			transform: rotate(45deg);
+		}
+
+		// --color-text-maxcontrast rather than --color-border-maxcontrast: both
+		// are themed, but this one holds more contrast on either ground.
+		&--other {
+			background: var(--color-text-maxcontrast);
+		}
+	}
+
+	&__section-count {
+		flex: 0 0 auto;
+		margin-inline-start: auto;
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+
+	.text-comparison__change-item {
+		display: grid;
+		grid-template-columns: calc(6 * var(--default-grid-baseline)) minmax(0, 1fr) calc(3 * var(--default-grid-baseline));
+		align-items: center;
+		gap: calc(2 * var(--default-grid-baseline));
+		inline-size: 100%;
+		min-block-size: calc(14 * var(--default-grid-baseline));
+		margin: 0 !important;
+		padding: calc(2 * var(--default-grid-baseline)) calc(2 * var(--default-grid-baseline));
+		border: 0;
+		border-block-end: 1px solid var(--color-border);
+		border-radius: 0;
+		background: transparent;
+		color: var(--color-main-text);
+		text-align: start;
+		cursor: pointer;
+
+		&:hover {
+			background: var(--color-background-hover);
+			border-block-end-color: var(--color-border) !important;
+		}
+
+		// After :hover, so pointing at the current change cannot make it look
+		// unselected.
+		&[aria-current='true'] {
+			background: var(--color-primary-element-light);
+			box-shadow: inset calc(0.75 * var(--default-grid-baseline)) 0 0 var(--color-primary-element);
+		}
+	}
+
+	// The global focus ring is declared !important at (0,3,1): a black outline
+	// plus a white box-shadow that would erase the selection bar. Beating it
+	// needs both !important and more classes, hence the extra level of nesting.
+	.text-comparison__change-list {
+		.text-comparison__section-toggle:focus-visible,
+		.text-comparison__change-item:focus-visible {
+			position: relative;
+			z-index: 2;
+			outline: 2px solid var(--color-primary-element) !important;
+			outline-offset: -2px;
+			box-shadow: none !important;
+		}
+
+		.text-comparison__change-item[aria-current='true']:focus-visible {
+			box-shadow: inset calc(0.75 * var(--default-grid-baseline)) 0 0 var(--color-primary-element) !important;
+		}
+	}
+
+	&__operation {
+		display: grid;
+		place-items: center;
+		inline-size: calc(6 * var(--default-grid-baseline));
+		block-size: calc(6 * var(--default-grid-baseline));
+		border: 1px solid currentColor;
+		border-radius: 50%;
+		font-size: var(--font-size-small);
+		font-weight: var(--font-weight-heading);
+
+		&--insert { color: var(--color-success-text); }
+		&--delete { color: var(--color-error-text); }
+		&--replace { color: var(--color-warning-text); }
+		// Info, matching both the section swatch and the document mark.
+		&--move { color: var(--color-element-info); }
+	}
+
+	&__change-copy {
+		display: grid;
+		gap: var(--default-grid-baseline);
+		min-inline-size: 0;
+		line-height: var(--default-line-height);
+	}
+
+	// When only an attribute or a mark changed, the passage reads the same on
+	// both sides, so the label is the informative half and leads instead.
+	&__change-copy--label-first {
+		.text-comparison__preview {
+			order: 2;
+			color: var(--color-text-maxcontrast);
+			font-size: var(--font-size-small);
+		}
+
+		.text-comparison__change-title {
+			order: 1;
+			color: var(--color-main-text);
+			font-size: var(--default-font-size);
+		}
+
+		.text-comparison__change-label {
+			font-weight: var(--font-weight-heading);
+		}
+	}
+
+	/* The changed content itself leads the row. */
+	&__preview {
+		min-inline-size: 0;
+		overflow: hidden;
+		color: var(--color-main-text);
+		font-size: var(--default-font-size);
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__preview-before {
+		padding-inline: calc(0.5 * var(--default-grid-baseline));
+		border-radius: var(--border-radius-small);
+		background: var(--color-error);
+		box-shadow: inset 0 -2px 0 var(--color-border-error);
+		text-decoration: line-through;
+		text-decoration-thickness: 1px;
+	}
+
+	&__preview-after {
+		padding-inline: calc(0.5 * var(--default-grid-baseline));
+		border-radius: var(--border-radius-small);
+		background: var(--color-success);
+		box-shadow: inset 0 -2px 0 var(--color-border-success);
+		text-decoration: none;
+	}
+
+	&__preview-arrow {
+		color: var(--color-text-maxcontrast);
+	}
+
+	&__preview-separator {
+		color: var(--color-text-maxcontrast);
+	}
+
+	&__change-title {
+		display: flex;
+		align-items: center;
+		gap: calc(1.5 * var(--default-grid-baseline));
+		min-inline-size: 0;
+		overflow: hidden;
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+		white-space: nowrap;
+	}
+
+	&__change-label {
+		flex: 0 0 auto;
+		font-weight: var(--font-weight-element);
+	}
+
+	&__change-context {
+		min-inline-size: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+
+		&::before {
+			content: '· ';
+		}
+	}
+
+	&__change-open {
+		color: var(--color-text-maxcontrast);
+		font-size: var(--default-font-size);
+	}
+
+	// On one column the two pills cannot share a line: the Before half eats the
+	// width and the After half is clipped away entirely, silently turning a
+	// before-and-after row into a before-only one. Stack them instead.
+	.text-comparison--single & {
+		&__preview {
+			white-space: normal;
+		}
+
+		&__preview-before,
+		&__preview-after {
+			display: block;
+			inline-size: fit-content;
+			max-inline-size: 100%;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		&__preview-arrow {
+			display: none;
+		}
+	}
+
+	&__detail-badge {
+		flex: 0 0 auto;
+		padding-inline: calc(1.5 * var(--default-grid-baseline));
+		border: 1px solid var(--color-border-maxcontrast);
+		border-radius: var(--border-radius-pill);
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+		font-weight: var(--font-weight-element);
+		// Capped so the badge's border cannot make its row taller than its
+		// neighbours and stutter the divider rhythm.
+		line-height: calc(4 * var(--default-grid-baseline));
+	}
+}
+</style>

--- a/src/components/ComparisonEditorContent.vue
+++ b/src/components/ComparisonEditorContent.vue
@@ -1,0 +1,99 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div ref="host" />
+</template>
+
+<script setup lang="ts">
+import type { Plugin } from '@tiptap/pm/state'
+import type { Editor } from '@tiptap/vue-3'
+import type { AppContext } from 'vue'
+
+import { getCurrentInstance, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+	consumeStateOnlyComparisonEditor,
+	registerMountedPlugin,
+} from '../comparison/comparisonEditorLifecycle.ts'
+
+type ContentComponent = NonNullable<Editor['contentComponent']>
+
+interface ComparisonComponentInternals {
+	ctx: { _: ContentComponent }
+	provides: AppContext['provides']
+}
+
+const { editor, plugins } = defineProps<{
+	editor: Editor
+	plugins: readonly Plugin[]
+}>()
+const emit = defineEmits<{ ready: [] }>()
+const INITIALIZATION_ERROR = 'Comparison editor plugin initialization failed'
+const host = ref<HTMLElement | null>(null)
+const instance = getCurrentInstance()
+
+onMounted(() => {
+	if (!instance || !host.value) {
+		throw new Error(INITIALIZATION_ERROR)
+	}
+	const internals = instance as unknown as ComparisonComponentInternals
+	const owner = internals.ctx._
+	if (owner !== instance
+		|| editor.options.element !== null
+		|| editor.contentComponent !== null
+		|| editor.appContext !== null) {
+		throw new Error(INITIALIZATION_ERROR)
+	}
+	consumeStateOnlyComparisonEditor(editor)
+
+	const appContext: AppContext = {
+		...instance.appContext,
+		provides: internals.provides,
+	}
+	setEditorContext(editor, owner, appContext)
+
+	try {
+		editor.setOptions({ element: host.value })
+		editor.mount(host.value)
+		if (editor.view.dom.parentElement !== host.value
+			|| editor.contentComponent !== owner
+			|| editorAppContext(editor) !== appContext) {
+			throw new Error(INITIALIZATION_ERROR)
+		}
+		for (const plugin of plugins) {
+			registerMountedPlugin(editor, plugin)
+		}
+		emit('ready')
+	} catch (error) {
+		setEditorContext(editor, null, null)
+		throw error
+	}
+})
+
+onBeforeUnmount(() => {
+	setEditorContext(editor, null, null)
+})
+
+/**
+ * Update Tiptap's public Vue rendering context as one lifecycle operation.
+ *
+ * @param editorInstance Comparison editor
+ * @param contentComponent Owning Vue component instance
+ * @param appContext Owning Vue application context
+ */
+function setEditorContext(
+	editorInstance: Editor,
+	contentComponent: ContentComponent | null,
+	appContext: AppContext | null,
+) {
+	editorInstance.contentComponent = contentComponent
+	editorInstance.appContext = appContext
+}
+
+/** @param editorInstance Comparison editor */
+function editorAppContext(editorInstance: Editor): AppContext | null {
+	return editorInstance.appContext
+}
+</script>

--- a/src/components/MarkdownContentComparison.vue
+++ b/src/components/MarkdownContentComparison.vue
@@ -45,6 +45,18 @@
 						@keydown="onViewTabKeydown($event, 'documents')">
 						{{ t('text', 'Full documents') }}
 					</button>
+					<button
+						:id="sourceTabId"
+						ref="sourceTab"
+						type="button"
+						role="tab"
+						:aria-controls="sourcePanelId"
+						:aria-selected="view === 'source'"
+						:tabindex="view === 'source' ? 0 : -1"
+						@click="setView('source')"
+						@keydown="onViewTabKeydown($event, 'source')">
+						{{ t('text', 'Markdown source') }}
+					</button>
 				</div>
 
 				<div
@@ -99,8 +111,8 @@
 			data-comparison-rendered-limit
 			role="status">
 			{{ renderedLimitReason === 'size'
-				? t('text', 'This comparison is too large for rendered views.')
-				: t('text', 'This comparison has too many changes for rendered views.') }}
+				? t('text', 'This comparison is too large for rendered views. Markdown source is shown instead.')
+				: t('text', 'This comparison has too many changes for rendered views. Markdown source is shown instead.') }}
 		</div>
 
 		<div
@@ -132,6 +144,9 @@
 					data-comparison-empty="syntax"
 					role="status">
 					<p>{{ t('text', 'No rendered differences — Markdown syntax differs.') }}</p>
+					<NcButton data-comparison-empty-action @click="setView('source')">
+						{{ t('text', 'Open Markdown source') }}
+					</NcButton>
 				</div>
 				<div
 					v-else
@@ -242,17 +257,45 @@
 				</article>
 			</div>
 		</div>
+
+		<div
+			v-show="view === 'source'"
+			:id="sourcePanelId"
+			class="text-comparison__source"
+			role="tabpanel"
+			:aria-labelledby="sourceTabId">
+			<p class="text-comparison__source-explanation">
+				{{ t('text', 'Source compares literal Markdown, so its change groups and count can differ from rendered changes.') }}
+			</p>
+			<div v-if="sourceComponentLoading" class="text-comparison__source-message" role="status">
+				{{ t('text', 'Loading Markdown source view…') }}
+			</div>
+			<div v-else-if="sourceComponentError" class="text-comparison__source-message" role="alert">
+				<p>{{ t('text', 'Could not load the Markdown source view.') }}</p>
+				<NcButton @click="loadSourceComponent">
+					{{ t('text', 'Retry') }}
+				</NcButton>
+			</div>
+			<component
+				:is="SourceComparison"
+				v-else-if="SourceComparison"
+				:afterContent="afterContent"
+				:beforeContent="beforeContent"
+				:layoutMode="layoutMode" />
+		</div>
 	</section>
 </template>
 
 <script setup lang="ts">
 import type { Editor } from '@tiptap/core'
+import type { Component, ShallowRef } from 'vue'
 import type { ComparisonSide } from '../comparison/markdownComparison.ts'
 
 import { getCurrentUser } from '@nextcloud/auth'
 import { n, t } from '@nextcloud/l10n'
 import {
 	computed,
+	markRaw,
 	nextTick,
 	onBeforeUnmount,
 	onMounted,
@@ -285,7 +328,7 @@ import AttachmentResolver from '../services/AttachmentResolver.js'
 import { ATTACHMENT_RESOLVER, EDITOR_UPLOAD } from './Editor.provider.ts'
 
 type LayoutMode = 'paired' | 'single'
-type ComparisonView = 'changes' | 'documents'
+type ComparisonView = 'changes' | 'documents' | 'source'
 
 const props = defineProps<{
 	beforeContent: string
@@ -306,17 +349,24 @@ const beforeScroller = ref<HTMLElement | null>(null)
 const afterScroller = ref<HTMLElement | null>(null)
 const changesTab = ref<HTMLButtonElement | null>(null)
 const documentsTab = ref<HTMLButtonElement | null>(null)
+const sourceTab = ref<HTMLButtonElement | null>(null)
 const beforeSideTab = ref<HTMLButtonElement | null>(null)
 const afterSideTab = ref<HTMLButtonElement | null>(null)
 const layoutMode = ref<LayoutMode>('paired')
-const view = ref<ComparisonView>('changes')
+const view = ref<ComparisonView>(renderedLimitReason ? 'source' : 'changes')
 const activeSide = ref<ComparisonSide>('before')
 const hidePureFormatting = ref(false)
+const SourceComparison: ShallowRef<Component | null> = shallowRef(null)
+const sourceComponentLoading = ref(false)
+const sourceComponentError = ref<unknown>(null)
+let destroyed = false
 const comparisonId = useId()
 const changesPanelId = `${comparisonId}-changes-panel`
 const documentsPanelId = `${comparisonId}-documents-panel`
+const sourcePanelId = `${comparisonId}-source-panel`
 const changesTabId = `${comparisonId}-changes-tab`
 const documentsTabId = `${comparisonId}-documents-tab`
+const sourceTabId = `${comparisonId}-source-tab`
 const beforePanelId = `${comparisonId}-before-panel`
 const afterPanelId = `${comparisonId}-after-panel`
 const beforeTabId = `${comparisonId}-before-tab`
@@ -419,6 +469,7 @@ function createComparisonRuntime() {
 		}
 		if (error instanceof ComparisonModelLimitError) {
 			renderedLimitReason = 'complexity'
+			view.value = 'source'
 			return null
 		}
 		throw error
@@ -472,8 +523,35 @@ function onEditorReady(side: ComparisonSide) {
  * @param nextView Selected peer view
  */
 function setView(nextView: ComparisonView) {
-	if (!renderedLimitReason) {
-		view.value = nextView
+	if (renderedLimitReason && nextView !== 'source') {
+		return
+	}
+	view.value = nextView
+	if (nextView === 'source') {
+		loadSourceComponent()
+	}
+}
+
+/** Load the source view only after its peer tab is selected. */
+async function loadSourceComponent() {
+	if (SourceComparison.value || sourceComponentLoading.value) {
+		return
+	}
+	sourceComponentLoading.value = true
+	sourceComponentError.value = null
+	try {
+		const component = await import('./MarkdownSourceComparison.vue')
+		if (!destroyed) {
+			SourceComparison.value = markRaw(component.default)
+		}
+	} catch (error) {
+		if (!destroyed) {
+			sourceComponentError.value = error
+		}
+	} finally {
+		if (!destroyed) {
+			sourceComponentLoading.value = false
+		}
 	}
 }
 
@@ -565,7 +643,7 @@ function setActiveSide(side: ComparisonSide, focus = false) {
  * @param current Current peer view
  */
 function onViewTabKeydown(event: KeyboardEvent, current: ComparisonView) {
-	const views: ComparisonView[] = ['changes', 'documents']
+	const views: ComparisonView[] = renderedLimitReason ? ['source'] : ['changes', 'documents', 'source']
 	let target: ComparisonView | undefined
 	if (event.key === 'Home') {
 		target = views[0]
@@ -584,6 +662,7 @@ function onViewTabKeydown(event: KeyboardEvent, current: ComparisonView) {
 	nextTick(() => ({
 		changes: changesTab.value,
 		documents: documentsTab.value,
+		source: sourceTab.value,
 	})[target]?.focus())
 }
 
@@ -647,6 +726,9 @@ onMounted(async () => {
 			rootObserver.observe(root.value)
 		}
 	}
+	if (renderedLimitReason) {
+		await loadSourceComponent()
+	}
 	await nextTick()
 	if (!renderedLimitReason && readyEditors.size !== 2) {
 		throw new Error('Comparison editor plugin initialization failed')
@@ -655,6 +737,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+	destroyed = true
 	rootObserver?.disconnect()
 	comparisonRuntime?.destroy()
 })
@@ -768,6 +851,8 @@ $content-inset: 16px;
 	&__status,
 	&__changes-count,
 	&__empty p,
+	&__source-message p,
+	&__source-explanation {
 		margin: 0;
 	}
 
@@ -983,7 +1068,30 @@ $content-inset: 16px;
 
 			img { max-inline-size: 100%; }
 		}
-		}
+	}
+
+	&__source {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	&__source-explanation {
+		flex: 0 0 auto;
+		padding: calc(2 * var(--default-grid-baseline)) calc(3 * var(--default-grid-baseline));
+		border-block-end: 1px solid var(--color-border);
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+		text-align: center;
+	}
+
+	&__source-message {
+		padding: calc(6 * var(--default-grid-baseline));
+		text-align: center;
+	}
 
 	&__sr-only {
 		position: absolute;

--- a/src/components/MarkdownContentComparison.vue
+++ b/src/components/MarkdownContentComparison.vue
@@ -4,10 +4,74 @@
 -->
 
 <template>
-	<section class="text-comparison" :aria-label="t('text', 'Version comparison')">
+	<section
+		ref="root"
+		class="text-comparison"
+		:class="`text-comparison--${layoutMode}`"
+		:aria-label="t('text', 'Version comparison')">
 		<header class="text-comparison__header">
-			<h2>{{ t('text', 'Changes') }}</h2>
-			<div v-if="!renderedLimitReason" class="text-comparison__changes-controls">
+			<p
+				class="text-comparison__sr-only"
+				data-comparison-announcement
+				aria-live="polite"
+				aria-atomic="true">
+				{{ navigationAnnouncement }}
+			</p>
+			<div class="text-comparison__toolbar">
+				<div class="text-comparison__view-tabs" role="tablist" :aria-label="t('text', 'Comparison view')">
+					<button
+						:id="changesTabId"
+						ref="changesTab"
+						type="button"
+						role="tab"
+						:aria-controls="changesPanelId"
+						:aria-selected="view === 'changes'"
+						:disabled="!!renderedLimitReason"
+						:tabindex="view === 'changes' ? 0 : -1"
+						@click="setView('changes')"
+						@keydown="onViewTabKeydown($event, 'changes')">
+						{{ t('text', 'Changes') }}
+					</button>
+					<button
+						:id="documentsTabId"
+						ref="documentsTab"
+						type="button"
+						role="tab"
+						:aria-controls="documentsPanelId"
+						:aria-selected="view === 'documents'"
+						:disabled="!!renderedLimitReason"
+						:tabindex="view === 'documents' ? 0 : -1"
+						@click="setView('documents')"
+						@keydown="onViewTabKeydown($event, 'documents')">
+						{{ t('text', 'Full documents') }}
+					</button>
+				</div>
+
+				<div
+					v-if="view === 'documents' && activeIds.length"
+					class="text-comparison__navigation"
+					:aria-label="t('text', 'Change navigation')">
+					<NcButton
+						variant="tertiary"
+						:aria-label="t('text', 'Previous change')"
+						:disabled="activeIds.length <= 1"
+						@click="move(-1)">
+						{{ t('text', 'Previous') }}
+					</NcButton>
+					<p class="text-comparison__status" aria-hidden="true">
+						{{ currentAnnouncement }}
+					</p>
+					<NcButton
+						variant="tertiary"
+						:aria-label="t('text', 'Next change')"
+						:disabled="activeIds.length <= 1"
+						@click="move(1)">
+						{{ t('text', 'Next') }}
+					</NcButton>
+				</div>
+			</div>
+
+			<div v-if="view === 'changes' && !renderedLimitReason" class="text-comparison__changes-controls">
 				<p class="text-comparison__changes-count">
 					{{ n('text', '%n change', '%n changes', activeGroups.length) }}
 				</p>
@@ -17,66 +81,211 @@
 					<small v-if="hidePureFormatting">{{ t('text', '{count} hidden', { count: formattingCount }) }}</small>
 				</label>
 			</div>
-		</header>
 
+			<div
+				v-if="view === 'documents' && hidePureFormatting && formattingCount"
+				class="text-comparison__hidden-formatting"
+				data-comparison-hidden-formatting
+				role="status">
+				<span>{{ n('text', '%n formatting change hidden', '%n formatting changes hidden', formattingCount) }}</span>
+				<NcButton variant="tertiary" @click="hidePureFormatting = false">
+					{{ t('text', 'Show') }}
+				</NcButton>
+			</div>
+		</header>
 		<div
 			v-if="renderedLimitReason"
 			class="text-comparison__rendered-limit"
 			data-comparison-rendered-limit
 			role="status">
 			{{ renderedLimitReason === 'size'
-				? t('text', 'This comparison is too large for a rendered view.')
-				: t('text', 'This comparison has too many changes for a rendered view.') }}
+				? t('text', 'This comparison is too large for rendered views.')
+				: t('text', 'This comparison has too many changes for rendered views.') }}
 		</div>
-		<div v-else-if="activeGroups.length" class="text-comparison__changes-content">
-			<ComparisonChangeList
-				:afterDocument="originalAfter!"
-				:beforeDocument="originalBefore!"
-				:currentId="currentId || undefined"
-				:groups="activeGroups"
-				@select="currentId = $event" />
-		</div>
+
 		<div
-			v-else-if="model.descriptors.length"
-			class="text-comparison__empty"
-			data-comparison-empty="filtered"
-			role="status">
-			{{ t('text', 'All rendered changes are formatting-only and hidden by the current filter.') }}
+			v-show="view === 'changes'"
+			:id="changesPanelId"
+			class="text-comparison__changes"
+			role="tabpanel"
+			:aria-labelledby="changesTabId">
+			<template v-if="!renderedLimitReason">
+				<div v-if="activeGroups.length && originalAfter && originalBefore" class="text-comparison__changes-content">
+					<ComparisonChangeList
+						:afterDocument="originalAfter"
+						:beforeDocument="originalBefore"
+						:currentId="currentId || undefined"
+						:groups="activeGroups"
+						@currentLabel="currentLabel = $event"
+						@select="selectDescriptor" />
+				</div>
+				<div
+					v-else-if="model.descriptors.length"
+					class="text-comparison__empty"
+					data-comparison-empty="filtered"
+					role="status">
+					<p>{{ t('text', 'All rendered changes are formatting-only and hidden by the current filter.') }}</p>
+				</div>
+				<div
+					v-else-if="rawDifferent"
+					class="text-comparison__empty"
+					data-comparison-empty="syntax"
+					role="status">
+					<p>{{ t('text', 'No rendered differences — Markdown syntax differs.') }}</p>
+				</div>
+				<div
+					v-else
+					class="text-comparison__empty"
+					data-comparison-empty="identical"
+					role="status">
+					<p>{{ t('text', 'No differences.') }}</p>
+				</div>
+			</template>
 		</div>
+
 		<div
-			v-else-if="rawDifferent"
-			class="text-comparison__empty"
-			data-comparison-empty="syntax"
-			role="status">
-			{{ t('text', 'No rendered differences — Markdown syntax differs.') }}
-		</div>
-		<div
-			v-else
-			class="text-comparison__empty"
-			data-comparison-empty="identical"
-			role="status">
-			{{ t('text', 'No differences.') }}
+			v-show="view === 'documents'"
+			:id="documentsPanelId"
+			class="text-comparison__documents"
+			role="tabpanel"
+			:aria-labelledby="documentsTabId">
+			<div
+				v-if="layoutMode === 'single'"
+				class="text-comparison__side-tabs"
+				role="tablist"
+				:aria-label="t('text', 'Version to display')">
+				<button
+					:id="beforeTabId"
+					ref="beforeSideTab"
+					type="button"
+					role="tab"
+					:aria-selected="activeSide === 'before'"
+					:aria-controls="beforePanelId"
+					:tabindex="activeSide === 'before' ? 0 : -1"
+					@click="setActiveSide('before')"
+					@keydown="onSideTabKeydown($event, 'before')">
+					{{ t('text', 'Before') }}
+				</button>
+				<button
+					:id="afterTabId"
+					ref="afterSideTab"
+					type="button"
+					role="tab"
+					:aria-selected="activeSide === 'after'"
+					:aria-controls="afterPanelId"
+					:tabindex="activeSide === 'after' ? 0 : -1"
+					@click="setActiveSide('after')"
+					@keydown="onSideTabKeydown($event, 'after')">
+					{{ t('text', 'After') }}
+				</button>
+			</div>
+
+			<div v-if="beforeEditor && afterEditor" class="text-comparison__document-grid">
+				<article
+					v-show="layoutMode !== 'single' || activeSide === 'before'"
+					:id="beforePanelId"
+					ref="beforePane"
+					class="text-comparison__document text-comparison__document--before"
+					:role="layoutMode === 'single' ? 'tabpanel' : 'region'"
+					:aria-label="layoutMode !== 'single' ? t('text', 'Before') : undefined"
+					:aria-labelledby="layoutMode === 'single' ? beforeTabId : undefined">
+					<header>
+						<div class="text-comparison__document-heading">
+							<span aria-hidden="true">−</span>
+							<h2>{{ t('text', 'Before') }}</h2>
+						</div>
+						<span class="text-comparison__document-legend" aria-hidden="true">
+							{{ t('text', 'Removed') }}
+							<span v-if="layoutMode !== 'single'" data-comparison-independent-scrolling> · {{ t('text', 'Independent scroll') }}</span>
+						</span>
+						<p class="text-comparison__sr-only">
+							{{ t('text', 'The Before pane scrolls independently. Removed content uses a minus sign, border, highlight, and line-through.') }}
+						</p>
+					</header>
+					<div ref="beforeScroller" class="text-comparison__document-scroller">
+						<ComparisonEditorContent
+							class="text-comparison__content"
+							:editor="beforeEditor"
+							:plugins="beforePlugins"
+							@ready="onEditorReady('before')" />
+					</div>
+				</article>
+
+				<article
+					v-show="layoutMode !== 'single' || activeSide === 'after'"
+					:id="afterPanelId"
+					ref="afterPane"
+					class="text-comparison__document text-comparison__document--after"
+					:role="layoutMode === 'single' ? 'tabpanel' : 'region'"
+					:aria-label="layoutMode !== 'single' ? t('text', 'After') : undefined"
+					:aria-labelledby="layoutMode === 'single' ? afterTabId : undefined">
+					<header>
+						<div class="text-comparison__document-heading">
+							<span aria-hidden="true">+</span>
+							<h2>{{ t('text', 'After') }}</h2>
+						</div>
+						<span class="text-comparison__document-legend" aria-hidden="true">
+							{{ t('text', 'Added') }}
+							<span v-if="layoutMode !== 'single'" data-comparison-independent-scrolling> · {{ t('text', 'Independent scroll') }}</span>
+						</span>
+						<p class="text-comparison__sr-only">
+							{{ t('text', 'The After pane scrolls independently. Added content uses a plus sign, border, highlight, and underline.') }}
+						</p>
+					</header>
+					<div ref="afterScroller" class="text-comparison__document-scroller">
+						<ComparisonEditorContent
+							class="text-comparison__content"
+							:editor="afterEditor"
+							:plugins="afterPlugins"
+							@ready="onEditorReady('after')" />
+					</div>
+				</article>
+			</div>
 		</div>
 	</section>
 </template>
 
 <script setup lang="ts">
 import type { Editor } from '@tiptap/core'
+import type { ComparisonSide } from '../comparison/markdownComparison.ts'
 
+import { getCurrentUser } from '@nextcloud/auth'
 import { n, t } from '@nextcloud/l10n'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import {
+	computed,
+	nextTick,
+	onBeforeUnmount,
+	onMounted,
+	provide,
+	ref,
+	shallowRef,
+	useId,
+	watch,
+} from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import ComparisonChangeList from './ComparisonChangeList.vue'
+import ComparisonEditorContent from './ComparisonEditorContent.vue'
+import { locateComparisonTarget } from '../comparison/comparisonDocumentLocation.ts'
 import {
 	currentIdAfterFilter,
+	currentOrdinal,
 	groupComparisonDescriptors,
+	moveCurrentId,
 	visibleDescriptorIds,
 } from '../comparison/comparisonNavigation.ts'
 import { createComparisonEditor } from '../comparison/createComparisonEditor.ts'
 import {
 	ComparisonModelLimitError,
+	createComparisonDecorationPlugin,
 	createMarkdownComparisonModel,
+	setComparisonDecorationState,
 } from '../comparison/markdownComparison.ts'
 import { exceedsRenderedComparisonLimit } from '../comparison/renderedComparisonLimit.ts'
+import AttachmentResolver from '../services/AttachmentResolver.js'
+import { ATTACHMENT_RESOLVER, EDITOR_UPLOAD } from './Editor.provider.ts'
+
+type LayoutMode = 'paired' | 'single'
+type ComparisonView = 'changes' | 'documents'
 
 const props = defineProps<{
 	beforeContent: string
@@ -90,16 +299,59 @@ const props = defineProps<{
 const emit = defineEmits<{ ready: [] }>()
 let renderedLimitReason: 'size' | 'complexity' | null
 	= exceedsRenderedComparisonLimit(props.beforeContent, props.afterContent) ? 'size' : null
-
-const runtime = renderedLimitReason ? null : createRuntime()
-const model = runtime?.model ?? { descriptors: [] }
-const originalAfter = runtime?.afterEditor.state.doc
-const originalBefore = runtime?.beforeEditor.state.doc
-const rawDifferent = props.beforeContent !== props.afterContent
+const root = ref<HTMLElement | null>(null)
+const beforePane = ref<HTMLElement | null>(null)
+const afterPane = ref<HTMLElement | null>(null)
+const beforeScroller = ref<HTMLElement | null>(null)
+const afterScroller = ref<HTMLElement | null>(null)
+const changesTab = ref<HTMLButtonElement | null>(null)
+const documentsTab = ref<HTMLButtonElement | null>(null)
+const beforeSideTab = ref<HTMLButtonElement | null>(null)
+const afterSideTab = ref<HTMLButtonElement | null>(null)
+const layoutMode = ref<LayoutMode>('paired')
+const view = ref<ComparisonView>('changes')
+const activeSide = ref<ComparisonSide>('before')
 const hidePureFormatting = ref(false)
-const formattingCount = model.descriptors
-	.filter(({ facets }) => facets.length === 1 && facets[0] === 'formatting')
-	.length
+const comparisonId = useId()
+const changesPanelId = `${comparisonId}-changes-panel`
+const documentsPanelId = `${comparisonId}-documents-panel`
+const changesTabId = `${comparisonId}-changes-tab`
+const documentsTabId = `${comparisonId}-documents-tab`
+const beforePanelId = `${comparisonId}-before-panel`
+const afterPanelId = `${comparisonId}-after-panel`
+const beforeTabId = `${comparisonId}-before-tab`
+const afterTabId = `${comparisonId}-after-tab`
+
+const attachmentResolver = props.fileId
+	? new AttachmentResolver({
+			currentDirectory: props.filePath?.split('/').slice(0, -1).join('/') ?? '/',
+			fileId: props.fileId,
+			session: undefined,
+			shareToken: props.shareToken,
+			user: getCurrentUser(),
+		})
+	: {
+			async resolve(src: string) {
+				return {
+					fullUrl: src,
+					isImage: true,
+					name: src.split('/').pop(),
+					previewUrl: src,
+				}
+			},
+		}
+provide(ATTACHMENT_RESOLVER, shallowRef(attachmentResolver))
+provide(EDITOR_UPLOAD, false)
+
+const comparisonRuntime = renderedLimitReason ? null : createComparisonRuntime()
+const afterEditor = comparisonRuntime?.afterEditor
+const beforeEditor = comparisonRuntime?.beforeEditor
+const model = comparisonRuntime?.model ?? { descriptors: [] }
+const originalAfter = comparisonRuntime?.originalAfter
+const originalBefore = comparisonRuntime?.originalBefore
+const currentId = ref<string | null>(model.descriptors[0]?.id ?? null)
+const rawDifferent = props.beforeContent !== props.afterContent
+const formattingCount = model.descriptors.filter(({ facets }) => facets.length === 1 && facets[0] === 'formatting').length
 const visibleIds = computed(() => visibleDescriptorIds(model.descriptors, hidePureFormatting.value))
 const activeDescriptors = computed(() => {
 	const active = new Set(visibleIds.value)
@@ -107,28 +359,59 @@ const activeDescriptors = computed(() => {
 })
 const activeGroups = computed(() => groupComparisonDescriptors(activeDescriptors.value))
 const activeIds = computed(() => activeGroups.value.map(({ id }) => id))
-const currentId = ref<string | null>(activeIds.value[0] ?? null)
+const currentLabel = ref(t('text', 'change'))
+const currentAnnouncement = computed(() => {
+	return t('text', 'Change {current} of {total}: {label}', {
+		current: currentOrdinal(activeIds.value, currentId.value),
+		total: activeIds.value.length,
+		label: currentLabel.value,
+	})
+})
+const navigationAnnouncement = computed(() => view.value === 'documents' && activeIds.value.length
+	? currentAnnouncement.value
+	: '')
+const pluginRuntime = initializeComparisonPlugins()
+const afterPluginKey = pluginRuntime?.afterPluginKey
+const afterPlugins = pluginRuntime?.afterPlugins ?? []
+const beforePluginKey = pluginRuntime?.beforePluginKey
+const beforePlugins = pluginRuntime?.beforePlugins ?? []
+const readyEditors = new Set<ComparisonSide>()
+const pendingTargets: Record<ComparisonSide, string | null> = { before: null, after: null }
 
-/** Create both immutable documents atomically with one shared schema. */
-function createRuntime() {
+/** Create both state-only editors atomically so partial initialization cannot leak. */
+function createComparisonRuntime() {
 	const editors: Editor[] = []
 	try {
-		const options = {
+		const editorOptions = {
 			filePath: props.filePath,
 			noLazyImages: props.noLazyImages,
 			openLink: props.openLinkHandler,
 		}
-		const beforeEditor = createComparisonEditor(props.beforeContent, options)
+		const beforeEditor = createComparisonEditor(props.beforeContent, editorOptions)
 		editors.push(beforeEditor)
 		const afterEditor = createComparisonEditor(props.afterContent, {
-			...options,
+			...editorOptions,
 			schema: beforeEditor.schema,
 		})
 		editors.push(afterEditor)
+		const originalBefore = beforeEditor.state.doc
+		const originalAfter = afterEditor.state.doc
+		const model = createMarkdownComparisonModel(originalBefore, originalAfter)
+		let runtimeDestroyed = false
 		return {
 			afterEditor,
 			beforeEditor,
-			model: createMarkdownComparisonModel(beforeEditor.state.doc, afterEditor.state.doc),
+			destroy() {
+				if (runtimeDestroyed) {
+					return
+				}
+				runtimeDestroyed = true
+				beforeEditor.destroy()
+				afterEditor.destroy()
+			},
+			model,
+			originalAfter,
+			originalBefore,
 		}
 	} catch (error) {
 		for (const editor of editors) {
@@ -142,53 +425,676 @@ function createRuntime() {
 	}
 }
 
+/** Prepare decorations against the original documents before their visible mount. */
+function initializeComparisonPlugins() {
+	if (!comparisonRuntime) {
+		return null
+	}
+	try {
+		const selection = { activeIds: visibleIds.value, currentId: currentId.value }
+		const beforeDecoration = createComparisonDecorationPlugin(
+			model.descriptors,
+			'before',
+			t('text', 'Removed content'),
+			t('text', 'Content exists only in After'),
+			selection,
+		)
+		const afterDecoration = createComparisonDecorationPlugin(
+			model.descriptors,
+			'after',
+			t('text', 'Added content'),
+			t('text', 'Content exists only in Before'),
+			selection,
+		)
+		return {
+			afterPluginKey: afterDecoration.key,
+			afterPlugins: [afterDecoration.plugin],
+			beforePluginKey: beforeDecoration.key,
+			beforePlugins: [beforeDecoration.plugin],
+		}
+	} catch (error) {
+		comparisonRuntime?.destroy()
+		throw error
+	}
+}
+
+/**
+ * @param side Mounted comparison side
+ */
+function onEditorReady(side: ComparisonSide) {
+	if (readyEditors.has(side)) {
+		throw new Error('Comparison editor plugin initialization failed')
+	}
+	readyEditors.add(side)
+}
+
+/**
+ * @param nextView Selected peer view
+ */
+function setView(nextView: ComparisonView) {
+	if (!renderedLimitReason) {
+		view.value = nextView
+	}
+}
+
+/**
+ * Select a changelog record and locate both original document sides.
+ *
+ * @param id Opaque descriptor ID
+ */
+function selectDescriptor(id: string) {
+	if (!activeIds.value.includes(id)) {
+		return
+	}
+	currentId.value = id
+	updateSelection()
+	pendingTargets.before = id
+	pendingTargets.after = id
+	setView('documents')
+	nextTick(locatePendingTargets)
+}
+
+/**
+ * @param offset Navigation offset
+ */
+function move(offset: number) {
+	const next = moveCurrentId(activeIds.value, currentId.value, offset)
+	if (next) {
+		selectDescriptor(next)
+	}
+}
+
+/** Update decoration visibility and current state without replacing either document. */
+function updateSelection() {
+	if (!beforeEditor || !afterEditor || !beforePluginKey || !afterPluginKey) {
+		return
+	}
+	const state = { activeIds: visibleIds.value, currentId: currentId.value }
+	setComparisonDecorationState(beforeEditor, beforePluginKey, state)
+	setComparisonDecorationState(afterEditor, afterPluginKey, state)
+}
+
+/** Locate every currently visible side with independent pane-local math. */
+function locatePendingTargets() {
+	if (view.value !== 'documents') {
+		return
+	}
+	if (layoutMode.value === 'paired') {
+		locatePendingSide('before')
+		locatePendingSide('after')
+	} else {
+		locatePendingSide(activeSide.value)
+	}
+}
+
+/**
+ * @param side Visible document side
+ */
+function locatePendingSide(side: ComparisonSide) {
+	const id = pendingTargets[side]
+	if (!id) {
+		return
+	}
+	const located = locateComparisonTarget(
+		side === 'before' ? beforePane.value : afterPane.value,
+		side === 'before' ? beforeScroller.value : afterScroller.value,
+		id,
+		reducedMotion() ? 'auto' : 'smooth',
+	)
+	if (located) {
+		pendingTargets[side] = null
+	}
+}
+
+/**
+ * @param side Side selected in single mode
+ * @param focus Whether keyboard navigation should move tab focus
+ */
+function setActiveSide(side: ComparisonSide, focus = false) {
+	activeSide.value = side
+	nextTick(() => {
+		if (focus) {
+			(side === 'before' ? beforeSideTab.value : afterSideTab.value)?.focus()
+		}
+		locatePendingSide(side)
+	})
+}
+
+/**
+ * @param event Tab keyboard event
+ * @param current Current peer view
+ */
+function onViewTabKeydown(event: KeyboardEvent, current: ComparisonView) {
+	const views: ComparisonView[] = ['changes', 'documents']
+	let target: ComparisonView | undefined
+	if (event.key === 'Home') {
+		target = views[0]
+	} else if (event.key === 'End') {
+		target = views.at(-1)
+	} else if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+		const offset = event.key === 'ArrowRight' ? 1 : -1
+		const index = views.indexOf(current)
+		target = views[(index + offset + views.length) % views.length]
+	}
+	if (!target) {
+		return
+	}
+	event.preventDefault()
+	setView(target)
+	nextTick(() => ({
+		changes: changesTab.value,
+		documents: documentsTab.value,
+	})[target]?.focus())
+}
+
+/**
+ * @param event Side-tab keyboard event
+ * @param current Current document side
+ */
+function onSideTabKeydown(event: KeyboardEvent, current: ComparisonSide) {
+	let target: ComparisonSide | null = null
+	if (event.key === 'Home') {
+		target = 'before'
+	} else if (event.key === 'End') {
+		target = 'after'
+	} else if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+		target = current === 'before' ? 'after' : 'before'
+	}
+	if (!target) {
+		return
+	}
+	event.preventDefault()
+	setActiveSide(target, true)
+}
+
+/** @param width Comparison container width */
+function updateLayout(width: number) {
+	if (!width) {
+		return
+	}
+	layoutMode.value = width >= 760 ? 'paired' : 'single'
+}
+
+/** Return the user's motion-safe scrolling behavior. */
+function reducedMotion() {
+	return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+}
+
+let rootObserver: ResizeObserver | null = null
+
 watch(hidePureFormatting, () => {
 	currentId.value = currentIdAfterFilter(model.descriptors, activeIds.value, currentId.value)
+	for (const side of ['before', 'after'] as const) {
+		if (pendingTargets[side] && !activeIds.value.includes(pendingTargets[side])) {
+			pendingTargets[side] = currentId.value
+		}
+	}
+	updateSelection()
 })
+watch(layoutMode, () => nextTick(locatePendingTargets))
 
 onMounted(async () => {
+	if (!renderedLimitReason && readyEditors.size !== 2) {
+		throw new Error('Comparison editor plugin initialization failed')
+	}
+	if (root.value) {
+		const initialWidth = root.value.getBoundingClientRect().width || root.value.clientWidth
+		if (initialWidth) {
+			updateLayout(initialWidth)
+		}
+		if (typeof ResizeObserver !== 'undefined') {
+			rootObserver = new ResizeObserver(([entry]) => updateLayout(entry?.contentRect.width ?? 0))
+			rootObserver.observe(root.value)
+		}
+	}
 	await nextTick()
+	if (!renderedLimitReason && readyEditors.size !== 2) {
+		throw new Error('Comparison editor plugin initialization failed')
+	}
 	emit('ready')
 })
 
 onBeforeUnmount(() => {
-	runtime?.beforeEditor.destroy()
-	runtime?.afterEditor.destroy()
+	rootObserver?.disconnect()
+	comparisonRuntime?.destroy()
 })
 </script>
 
 <style lang="scss">
-.text-comparison-root,
-.text-comparison {
+@use './../css/prosemirror.scss';
+
+// Widest the change list is allowed to grow. Its rows are single-line
+// previews rather than prose, so they earn width well past a reading measure,
+// but past this the longest preview still ends far short of the right edge and
+// the row reads as two fragments with a gap between them.
+$content-measure: 1040px;
+// Gutter either side of the change list, matched by the controls above it.
+$content-inset: 16px;
+
+.text-comparison-root {
+	display: flex;
+	flex: 1 1 auto;
 	inline-size: 100%;
+	min-width: 0;
+	min-height: 0;
+	block-size: 100%;
+	overflow: hidden;
 }
 
 .text-comparison {
-	&__header,
-	&__changes-content,
-	&__empty,
-	&__rendered-limit {
-		max-inline-size: 1040px;
-		margin-inline: auto;
-		padding: 16px;
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	min-width: 0;
+	min-height: 0;
+	block-size: 100%;
+	overflow: hidden;
+	color: var(--color-main-text);
+
+	// No inline padding here: __changes-controls measures itself against this
+	// box and must resolve to the same width as the list in the panel below.
+	// The rows that are not on that measure carry their own inset instead.
+	&__header {
+		position: relative;
+		z-index: 5;
+		flex: 0 0 auto;
+		padding-block: calc(2 * var(--default-grid-baseline));
+		border-block-end: 1px solid var(--color-border);
+		background: var(--color-main-background);
 	}
 
-	&__header,
+	&__toolbar,
+	&__hidden-formatting {
+		padding-inline: calc(3 * var(--default-grid-baseline));
+	}
+
+	&__toolbar,
 	&__changes-controls,
-	&__filter {
+	&__hidden-formatting,
+	&__navigation {
 		display: flex;
+		flex-wrap: wrap;
 		align-items: center;
-		gap: 12px;
+		gap: calc(2 * var(--default-grid-baseline));
+		min-width: 0;
 	}
 
-	&__header,
-	&__changes-controls {
+	&__toolbar {
 		justify-content: space-between;
 	}
 
-	&__header h2,
-	&__changes-count {
+	&__view-tabs,
+	&__side-tabs {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 1px;
+		padding: calc(0.5 * var(--default-grid-baseline));
+		border-radius: var(--border-radius-element);
+		background: var(--color-background-dark);
+
+		button {
+			min-block-size: var(--default-clickable-area);
+			padding-inline: calc(3 * var(--default-grid-baseline));
+			border: 0;
+			border-radius: var(--border-radius-small);
+			background: transparent;
+			font-size: var(--default-font-size);
+			font-weight: var(--font-weight-element);
+
+			&[aria-selected='true'] {
+				background: var(--color-main-background);
+				box-shadow: 0 1px 3px var(--color-box-shadow);
+				color: var(--color-primary-element);
+				font-weight: var(--font-weight-heading);
+			}
+
+			&:focus-visible {
+				outline: 2px solid var(--color-primary-element);
+				outline-offset: 1px;
+			}
+		}
+	}
+
+	&__navigation {
+		flex: 0 0 auto;
+		gap: calc(0.5 * var(--default-grid-baseline));
+
+		button {
+			min-block-size: var(--default-clickable-area);
+		}
+	}
+
+	&__status,
+	&__changes-count,
+	&__empty p,
 		margin: 0;
+	}
+
+	&__status {
+		min-inline-size: 10rem;
+		font-size: var(--font-size-small);
+		text-align: center;
+	}
+
+	/* The controls and the list share one measure so their rules line up at every width. */
+	&__changes-controls,
+	&__changes-content {
+		box-sizing: border-box;
+		inline-size: min(calc(100% - #{$content-inset}), #{$content-measure});
+		margin-inline: auto;
+	}
+
+	&__changes-controls {
+		justify-content: space-between;
+		margin-block-start: calc(2 * var(--default-grid-baseline));
+		padding-block-start: calc(2 * var(--default-grid-baseline));
+		border-block-start: 1px solid var(--color-border);
+	}
+
+	&__changes-count {
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+	}
+
+	&__filter {
+		display: flex;
+		align-items: center;
+		gap: calc(1.5 * var(--default-grid-baseline));
+		min-block-size: var(--default-clickable-area);
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+		white-space: nowrap;
+
+		input {
+			inline-size: calc(4 * var(--default-grid-baseline));
+			block-size: calc(4 * var(--default-grid-baseline));
+		}
+	}
+
+	&__hidden-formatting {
+		justify-content: flex-end;
+		margin-block-start: var(--default-grid-baseline);
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+	}
+
+	&__rendered-limit {
+		flex: 0 0 auto;
+		padding: calc(2.5 * var(--default-grid-baseline)) calc(4 * var(--default-grid-baseline));
+		border-block-end: 1px solid var(--color-border);
+		background: var(--color-warning);
+		color: var(--color-warning-text);
+		text-align: center;
+	}
+
+	&__changes {
+		flex: 1 1 auto;
+		min-width: 0;
+		min-height: 0;
+		overflow-y: auto;
+		overscroll-behavior: contain;
+		// Keeps a row the browser scrolls to clear of the sticky section header
+		// it would otherwise be parked underneath.
+		scroll-padding-block-start: var(--default-clickable-area);
+	}
+
+	&__changes-content {
+		padding-block: calc(3 * var(--default-grid-baseline)) calc(8 * var(--default-grid-baseline));
+	}
+
+	&__empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: calc(3.5 * var(--default-grid-baseline));
+		min-block-size: calc(45 * var(--default-grid-baseline));
+		padding: calc(6 * var(--default-grid-baseline));
+		text-align: center;
+	}
+
+	&__documents {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	&__side-tabs {
+		flex: 0 0 auto;
+		inline-size: fit-content;
+		margin: calc(2 * var(--default-grid-baseline)) auto;
+	}
+
+	&__document-grid {
+		display: grid;
+		flex: 1 1 auto;
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	&--single &__document-grid {
+		display: block;
+	}
+
+	&--single &__document {
+		block-size: 100%;
+	}
+
+	&__document {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+
+		& + & {
+			border-inline-start: 1px solid var(--color-border);
+		}
+
+		> header {
+			display: flex;
+			flex: 0 0 auto;
+			align-items: center;
+			justify-content: space-between;
+			gap: calc(3 * var(--default-grid-baseline));
+			padding: calc(2 * var(--default-grid-baseline)) calc(4 * var(--default-grid-baseline));
+			border-block-end: 1px solid var(--color-border);
+			background: var(--color-main-background);
+
+			h2 {
+				margin: 0;
+				font-size: var(--default-font-size);
+				font-weight: var(--font-weight-heading);
+			}
+		}
+	}
+
+	&__document-heading {
+		display: flex;
+		align-items: center;
+		gap: calc(1.5 * var(--default-grid-baseline));
+
+		span {
+			inline-size: calc(4 * var(--default-grid-baseline));
+			font-size: var(--default-font-size);
+			font-weight: var(--font-weight-heading);
+			line-height: 1;
+			text-align: center;
+		}
+	}
+
+	&__document--before > header &__document-heading span { color: var(--color-error-text); }
+	&__document--after > header &__document-heading span { color: var(--color-success-text); }
+
+	&__document-legend {
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+		font-weight: var(--font-weight-element);
+	}
+
+	&__document-scroller {
+		flex: 1 1 auto;
+		min-width: 0;
+		min-height: 0;
+		padding-inline: calc(4 * var(--default-grid-baseline));
+		overflow: auto;
+		overscroll-behavior: contain;
+	}
+
+	&--single &__document + &__document {
+		border-inline-start: 0;
+	}
+
+	&__content {
+		min-width: 0;
+
+		// The rendered document keeps its own heading scale: these sizes belong
+		// to the content being compared, not to the comparison chrome.
+		.ProseMirror {
+			min-width: 0;
+			padding: calc(3 * var(--default-grid-baseline)) calc(1.5 * var(--default-grid-baseline)) calc(9 * var(--default-grid-baseline));
+			font-size: var(--default-font-size);
+
+			p { margin-block-end: 0.75em; }
+
+			h1,
+			h2,
+			h3,
+			h4,
+			h5,
+			h6 { margin-block: calc(4.5 * var(--default-grid-baseline)) calc(2 * var(--default-grid-baseline)); }
+
+			h1 { font-size: 24px; }
+			h2 { font-size: 20px; }
+			h3 { font-size: 18px; }
+			h4 { font-size: 17px; }
+
+			pre {
+				padding: calc(2.5 * var(--default-grid-baseline)) calc(3 * var(--default-grid-baseline));
+				margin-block-end: 0.75em;
+				font-size: var(--font-size-small);
+			}
+
+			img { max-inline-size: 100%; }
+		}
+		}
+
+	&__sr-only {
+		position: absolute;
+		inline-size: 1px;
+		block-size: 1px;
+		padding: 0;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+		border: 0;
+	}
+}
+
+.text-comparison-change {
+	border-radius: var(--border-radius-small);
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+
+	&--removed {
+		border-block-end: 1px solid var(--color-border-error);
+		background-color: var(--color-error);
+		text-decoration: line-through;
+		text-decoration-thickness: 1px;
+	}
+
+	&--added {
+		border-block-end: 1px solid var(--color-border-success);
+		background-color: var(--color-success);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+	}
+
+	&--formatting {
+		border-block-end: 3px double var(--color-primary-element);
+		background: var(--color-primary-element-light);
+		text-decoration: none;
+	}
+
+	&--attribute {
+		border: 2px dashed var(--color-element-warning);
+		background: var(--color-warning);
+		text-decoration: none;
+	}
+
+	// Relocation reads as info, not primary: primary already marks the current
+	// change and the selected changelog row, and a formatting change below.
+	&--move {
+		border-inline-start: 4px solid var(--color-element-info);
+		background: var(--color-info);
+		text-decoration: none;
+	}
+
+	// Excludes --move: a moved block carries both classes, and this rule is both
+	// later and more specific, so it would repaint relocation as a warning.
+	&--block:not(&--removed, &--added, &--move) {
+		border: 2px solid var(--color-element-warning);
+		background: var(--color-warning);
+		text-decoration: none;
+	}
+
+	&--current {
+		outline: 2px solid var(--color-primary-element);
+		outline-offset: 2px;
+	}
+
+	&:not([data-node-view-wrapper], &--empty) {
+		padding-inline: calc(0.5 * var(--default-grid-baseline));
+	}
+
+	&--empty {
+		display: inline-grid;
+		place-items: center;
+		inline-size: 1.2em;
+		block-size: 1.2em;
+		margin-inline: var(--default-grid-baseline);
+		border: 2px solid currentColor;
+		border-radius: 50%;
+		background: var(--color-main-background);
+		color: var(--color-text-maxcontrast);
+		font-size: 0.75em;
+		line-height: 1;
+		text-decoration: none;
+	}
+}
+
+.text-comparison .text-comparison__content .ProseMirror .text-comparison-change--empty {
+	width: 1.2em;
+	border: 2px solid currentColor !important;
+}
+
+.text-comparison--single {
+	.text-comparison__toolbar,
+	.text-comparison__hidden-formatting { padding-inline: calc(2 * var(--default-grid-baseline)); }
+	.text-comparison__toolbar { align-items: stretch; }
+	.text-comparison__view-tabs { flex: 1 1 100%; }
+	.text-comparison__view-tabs button { flex: 1 1 0; padding-inline: calc(1.5 * var(--default-grid-baseline)); }
+	.text-comparison__navigation {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr) auto;
+		inline-size: 100%;
+	}
+	.text-comparison__status { min-inline-size: 0; }
+	.text-comparison__changes-controls { align-items: flex-start; }
+	.text-comparison__filter { white-space: normal; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.text-comparison * {
+		scroll-behavior: auto !important;
+		transition: none !important;
 	}
 }
 </style>

--- a/src/components/MarkdownContentComparison.vue
+++ b/src/components/MarkdownContentComparison.vue
@@ -1,0 +1,194 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<section class="text-comparison" :aria-label="t('text', 'Version comparison')">
+		<header class="text-comparison__header">
+			<h2>{{ t('text', 'Changes') }}</h2>
+			<div v-if="!renderedLimitReason" class="text-comparison__changes-controls">
+				<p class="text-comparison__changes-count">
+					{{ n('text', '%n change', '%n changes', activeGroups.length) }}
+				</p>
+				<label v-if="formattingCount" class="text-comparison__filter">
+					<input v-model="hidePureFormatting" type="checkbox">
+					<span>{{ t('text', 'Hide formatting-only changes') }}</span>
+					<small v-if="hidePureFormatting">{{ t('text', '{count} hidden', { count: formattingCount }) }}</small>
+				</label>
+			</div>
+		</header>
+
+		<div
+			v-if="renderedLimitReason"
+			class="text-comparison__rendered-limit"
+			data-comparison-rendered-limit
+			role="status">
+			{{ renderedLimitReason === 'size'
+				? t('text', 'This comparison is too large for a rendered view.')
+				: t('text', 'This comparison has too many changes for a rendered view.') }}
+		</div>
+		<div v-else-if="activeGroups.length" class="text-comparison__changes-content">
+			<ComparisonChangeList
+				:afterDocument="originalAfter!"
+				:beforeDocument="originalBefore!"
+				:currentId="currentId || undefined"
+				:groups="activeGroups"
+				@select="currentId = $event" />
+		</div>
+		<div
+			v-else-if="model.descriptors.length"
+			class="text-comparison__empty"
+			data-comparison-empty="filtered"
+			role="status">
+			{{ t('text', 'All rendered changes are formatting-only and hidden by the current filter.') }}
+		</div>
+		<div
+			v-else-if="rawDifferent"
+			class="text-comparison__empty"
+			data-comparison-empty="syntax"
+			role="status">
+			{{ t('text', 'No rendered differences — Markdown syntax differs.') }}
+		</div>
+		<div
+			v-else
+			class="text-comparison__empty"
+			data-comparison-empty="identical"
+			role="status">
+			{{ t('text', 'No differences.') }}
+		</div>
+	</section>
+</template>
+
+<script setup lang="ts">
+import type { Editor } from '@tiptap/core'
+
+import { n, t } from '@nextcloud/l10n'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import ComparisonChangeList from './ComparisonChangeList.vue'
+import {
+	currentIdAfterFilter,
+	groupComparisonDescriptors,
+	visibleDescriptorIds,
+} from '../comparison/comparisonNavigation.ts'
+import { createComparisonEditor } from '../comparison/createComparisonEditor.ts'
+import {
+	ComparisonModelLimitError,
+	createMarkdownComparisonModel,
+} from '../comparison/markdownComparison.ts'
+import { exceedsRenderedComparisonLimit } from '../comparison/renderedComparisonLimit.ts'
+
+const props = defineProps<{
+	beforeContent: string
+	afterContent: string
+	fileId?: number
+	filePath?: string
+	shareToken?: string
+	noLazyImages?: boolean
+	openLinkHandler?: (href: string) => void
+}>()
+const emit = defineEmits<{ ready: [] }>()
+let renderedLimitReason: 'size' | 'complexity' | null
+	= exceedsRenderedComparisonLimit(props.beforeContent, props.afterContent) ? 'size' : null
+
+const runtime = renderedLimitReason ? null : createRuntime()
+const model = runtime?.model ?? { descriptors: [] }
+const originalAfter = runtime?.afterEditor.state.doc
+const originalBefore = runtime?.beforeEditor.state.doc
+const rawDifferent = props.beforeContent !== props.afterContent
+const hidePureFormatting = ref(false)
+const formattingCount = model.descriptors
+	.filter(({ facets }) => facets.length === 1 && facets[0] === 'formatting')
+	.length
+const visibleIds = computed(() => visibleDescriptorIds(model.descriptors, hidePureFormatting.value))
+const activeDescriptors = computed(() => {
+	const active = new Set(visibleIds.value)
+	return model.descriptors.filter(({ id }) => active.has(id))
+})
+const activeGroups = computed(() => groupComparisonDescriptors(activeDescriptors.value))
+const activeIds = computed(() => activeGroups.value.map(({ id }) => id))
+const currentId = ref<string | null>(activeIds.value[0] ?? null)
+
+/** Create both immutable documents atomically with one shared schema. */
+function createRuntime() {
+	const editors: Editor[] = []
+	try {
+		const options = {
+			filePath: props.filePath,
+			noLazyImages: props.noLazyImages,
+			openLink: props.openLinkHandler,
+		}
+		const beforeEditor = createComparisonEditor(props.beforeContent, options)
+		editors.push(beforeEditor)
+		const afterEditor = createComparisonEditor(props.afterContent, {
+			...options,
+			schema: beforeEditor.schema,
+		})
+		editors.push(afterEditor)
+		return {
+			afterEditor,
+			beforeEditor,
+			model: createMarkdownComparisonModel(beforeEditor.state.doc, afterEditor.state.doc),
+		}
+	} catch (error) {
+		for (const editor of editors) {
+			editor.destroy()
+		}
+		if (error instanceof ComparisonModelLimitError) {
+			renderedLimitReason = 'complexity'
+			return null
+		}
+		throw error
+	}
+}
+
+watch(hidePureFormatting, () => {
+	currentId.value = currentIdAfterFilter(model.descriptors, activeIds.value, currentId.value)
+})
+
+onMounted(async () => {
+	await nextTick()
+	emit('ready')
+})
+
+onBeforeUnmount(() => {
+	runtime?.beforeEditor.destroy()
+	runtime?.afterEditor.destroy()
+})
+</script>
+
+<style lang="scss">
+.text-comparison-root,
+.text-comparison {
+	inline-size: 100%;
+}
+
+.text-comparison {
+	&__header,
+	&__changes-content,
+	&__empty,
+	&__rendered-limit {
+		max-inline-size: 1040px;
+		margin-inline: auto;
+		padding: 16px;
+	}
+
+	&__header,
+	&__changes-controls,
+	&__filter {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+	}
+
+	&__header,
+	&__changes-controls {
+		justify-content: space-between;
+	}
+
+	&__header h2,
+	&__changes-count {
+		margin: 0;
+	}
+}
+</style>

--- a/src/components/MarkdownSourceComparison.vue
+++ b/src/components/MarkdownSourceComparison.vue
@@ -1,0 +1,636 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<section ref="root" class="text-source-comparison" :aria-label="t('text', 'Markdown source comparison')">
+		<div v-if="loading" class="text-source-comparison__message" role="status">
+			{{ t('text', 'Loading Markdown source differences…') }}
+		</div>
+		<div v-else-if="error" class="text-source-comparison__message" role="alert">
+			<p>{{ t('text', 'Could not load Markdown source differences.') }}</p>
+			<NcButton @click="load">
+				{{ t('text', 'Retry') }}
+			</NcButton>
+		</div>
+		<div v-else-if="model?.status === 'limited'" class="text-source-comparison__message" role="status">
+			{{ model.reason === 'size'
+				? t('text', 'This source comparison is too large to display safely.')
+				: t('text', 'This source comparison exceeded the safe processing limit.') }}
+		</div>
+		<template v-else-if="model?.status === 'ready'">
+			<header class="text-source-comparison__toolbar">
+				<p
+					v-if="model.lineEndingChange"
+					class="text-source-comparison__line-ending-change"
+					data-source-line-ending-change>
+					{{ t('text', 'Line endings changed: {before} → {after}', {
+						before: lineEndingLabel(model.lineEndingChange.before),
+						after: lineEndingLabel(model.lineEndingChange.after),
+					}) }}
+				</p>
+				<div v-if="model.hunks.length" class="text-source-comparison__navigation" :aria-label="t('text', 'Source change navigation')">
+					<NcButton :aria-label="t('text', 'Previous source change')" :disabled="model.hunks.length <= 1" @click="move(-1)">
+						{{ t('text', 'Previous') }}
+					</NcButton>
+					<p aria-live="polite" aria-atomic="true">
+						{{ t('text', 'Source change {current} of {total}', {
+							current: currentIndex + 1,
+							total: model.hunks.length,
+						}) }}
+					</p>
+					<NcButton :aria-label="t('text', 'Next source change')" :disabled="model.hunks.length <= 1" @click="move(1)">
+						{{ t('text', 'Next') }}
+					</NcButton>
+				</div>
+				<p v-else-if="!model.lineEndingChange" class="text-source-comparison__message">
+					{{ t('text', 'No Markdown source differences') }}
+				</p>
+
+				<div
+					v-if="layoutMode === 'single'"
+					class="text-source-comparison__tabs"
+					role="tablist"
+					:aria-label="t('text', 'Source version to display')">
+					<button
+						:id="beforeTabId"
+						ref="beforeTab"
+						type="button"
+						role="tab"
+						:aria-selected="activeSide === 'before'"
+						:aria-controls="sourcePanelId"
+						:tabindex="activeSide === 'before' ? 0 : -1"
+						@click="activeSide = 'before'"
+						@keydown="onSideTabKeydown($event, 'before')">
+						{{ t('text', 'Before') }}
+					</button>
+					<button
+						:id="afterTabId"
+						ref="afterTab"
+						type="button"
+						role="tab"
+						:aria-selected="activeSide === 'after'"
+						:aria-controls="sourcePanelId"
+						:tabindex="activeSide === 'after' ? 0 : -1"
+						@click="activeSide = 'after'"
+						@keydown="onSideTabKeydown($event, 'after')">
+						{{ t('text', 'After') }}
+					</button>
+				</div>
+			</header>
+
+			<div class="text-source-comparison__column-headings" :class="{ 'text-source-comparison__column-headings--single': layoutMode === 'single' }">
+				<strong v-show="layoutMode !== 'single' || activeSide === 'before'">{{ t('text', 'Before') }}</strong>
+				<strong v-show="layoutMode !== 'single' || activeSide === 'after'">{{ t('text', 'After') }}</strong>
+			</div>
+
+			<div
+				:id="sourcePanelId"
+				class="text-source-comparison__hunks"
+				:role="layoutMode === 'single' ? 'tabpanel' : undefined"
+				:aria-labelledby="layoutMode === 'single' ? activeSide === 'before' ? beforeTabId : afterTabId : undefined">
+				<template v-for="(hunk, hunkIndex) in [...model.hunks, null]" :key="`source-slot-${hunkIndex}`">
+					<div v-if="gapAt(hunkIndex)" class="text-source-comparison__gap">
+						<NcButton
+							v-if="canExpandGap(gapAt(hunkIndex)!)"
+							:aria-expanded="expandedGaps.has(gapAt(hunkIndex)!.id)"
+							:data-source-gap="gapAt(hunkIndex)!.id"
+							@click="toggleGap(gapAt(hunkIndex)!.id)">
+							{{ expandedGaps.has(gapAt(hunkIndex)!.id)
+								? t('text', 'Hide unchanged lines')
+								: t('text', 'Show {count} unchanged lines', { count: gapAt(hunkIndex)!.count }) }}
+						</NcButton>
+						<p v-else>
+							{{ t('text', '{count} unchanged lines hidden', { count: gapAt(hunkIndex)!.count }) }}
+						</p>
+						<div v-if="expandedGaps.has(gapAt(hunkIndex)!.id)">
+							<div
+								v-for="(row, rowIndex) in gapRows(gapAt(hunkIndex)!)"
+								:key="`${gapAt(hunkIndex)!.id}-${rowIndex}`"
+								class="text-source-comparison__row"
+								:class="{ 'text-source-comparison__row--single': layoutMode === 'single' }">
+								<SourceLine v-show="layoutMode !== 'single' || activeSide === 'before'" :line="row.before" side="before" />
+								<SourceLine v-show="layoutMode !== 'single' || activeSide === 'after'" :line="row.after" side="after" />
+							</div>
+						</div>
+					</div>
+
+					<section
+						v-if="hunk"
+						class="text-source-comparison__hunk"
+						:class="{ 'text-source-comparison__hunk--current': hunkIndex === currentIndex }"
+						:data-source-hunk="hunk.id">
+						<h3 class="text-source-comparison__hunk-title">
+							<button
+								type="button"
+								:aria-label="t('text', 'Source change at lines {before} / {after}', { before: hunk.beforeStart, after: hunk.afterStart })"
+								:aria-current="hunkIndex === currentIndex ? 'true' : undefined"
+								@click="currentId = hunk.id">
+								{{ t('text', 'Lines {before} / {after}', { before: hunk.beforeStart, after: hunk.afterStart }) }}
+							</button>
+						</h3>
+						<div
+							v-for="(row, rowIndex) in hunkRows(hunk)"
+							:key="`${hunk.id}-${rowIndex}`"
+							class="text-source-comparison__row"
+							:class="{ 'text-source-comparison__row--single': layoutMode === 'single' }">
+							<SourceLine
+								v-show="layoutMode !== 'single' || activeSide === 'before'"
+								:line="row.before"
+								side="before" />
+							<SourceLine
+								v-show="layoutMode !== 'single' || activeSide === 'after'"
+								:line="row.after"
+								side="after" />
+						</div>
+					</section>
+				</template>
+			</div>
+		</template>
+	</section>
+</template>
+
+<script setup lang="ts">
+import type {
+	SourceDiffGap,
+	SourceDiffHunk,
+	SourceDiffLine,
+	SourceDiffModel,
+	SourceLineEnding,
+} from '../comparison/markdownSourceComparison.ts'
+
+import { t } from '@nextcloud/l10n'
+import { computed, defineComponent, h, nextTick, onBeforeUnmount, onMounted, ref, useId } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+
+const props = defineProps<{
+	beforeContent: string
+	afterContent: string
+	layoutMode: 'paired' | 'single'
+}>()
+
+const MAXIMUM_WRAPPED_SOURCE_LINE_LENGTH = 2000
+// ceiling: large gaps stay collapsed; upgrade when the source view virtualizes rows.
+const MAXIMUM_EXPANDABLE_GAP_LINES = 2000
+
+const SourceLine = defineComponent({
+	props: {
+		line: { type: Object as () => SourceDiffLine | undefined, default: undefined },
+		side: { type: String as () => 'before' | 'after', required: true },
+	},
+
+	setup(lineProps) {
+		return () => {
+			const line = lineProps.line
+			if (!line) {
+				return h('div', { class: 'text-source-comparison__line text-source-comparison__line--empty', 'aria-hidden': 'true' })
+			}
+			const signals = [
+				line.hasTab ? t('text', 'Tab') : '',
+				line.hasTrailingWhitespace ? t('text', 'Trailing whitespace') : '',
+				line.hasZeroWidth ? t('text', 'Zero-width character') : '',
+				line.eolChanged ? line.eol.toUpperCase() : '',
+			].filter(Boolean)
+			return h('div', {
+				class: [
+					'text-source-comparison__line',
+					line.changed ? `text-source-comparison__line--${lineProps.side === 'before' ? 'removed' : 'added'}` : '',
+				],
+			}, [
+				line.changed
+					? h('span', { class: 'text-source-comparison__sr-only' }, lineProps.side === 'before'
+							? t('text', 'Removed line {line}', { line: line.number })
+							: t('text', 'Added line {line}', { line: line.number }))
+					: null,
+				h('span', { class: 'text-source-comparison__line-number', 'aria-hidden': 'true' }, String(line.number)),
+				h('span', { class: 'text-source-comparison__line-prefix', 'aria-hidden': 'true' }, line.changed ? (lineProps.side === 'before' ? '−' : '+') : ' '),
+				h('code', {
+					class: [
+						'text-source-comparison__line-code',
+						{ 'text-source-comparison__line-code--long': line.text.length > MAXIMUM_WRAPPED_SOURCE_LINE_LENGTH },
+					],
+					dir: 'auto',
+				}, line.segments.map((segment) => h('bdi', {
+					class: segment.changed ? 'text-source-comparison__segment--changed' : undefined,
+				}, segment.text))),
+				...signals.map((signal) => h('span', { class: 'text-source-comparison__whitespace-signal' }, signal)),
+				line.missingFinalNewline
+					? h('span', { class: 'text-source-comparison__newline-marker' }, t('text', 'No newline at end of file'))
+					: null,
+			])
+		}
+	},
+})
+
+const loading = ref(true)
+const error = ref<unknown>(null)
+const model = ref<SourceDiffModel | null>(null)
+const currentId = ref<string | null>(null)
+const activeSide = ref<'before' | 'after'>('before')
+const expandedGaps = ref(new Set<string>())
+const root = ref<HTMLElement | null>(null)
+const beforeTab = ref<HTMLButtonElement | null>(null)
+const afterTab = ref<HTMLButtonElement | null>(null)
+const comparisonId = useId()
+const beforeTabId = `${comparisonId}-before-tab`
+const afterTabId = `${comparisonId}-after-tab`
+const sourcePanelId = `${comparisonId}-source-panel`
+let controller: AbortController | null = null
+let generation = 0
+
+const currentIndex = computed(() => {
+	if (model.value?.status !== 'ready') {
+		return 0
+	}
+	return Math.max(0, model.value.hunks.findIndex(({ id }) => id === currentId.value))
+})
+const gapsBySlot = computed(() => model.value?.status === 'ready'
+	? new Map(model.value.gaps.map((gap) => [gap.slot, gap]))
+	: new Map<number, SourceDiffGap>())
+const hunkRowsById = computed(() => model.value?.status === 'ready'
+	? new Map(model.value.hunks.map((hunk) => [hunk.id, pairedRows(hunk.before, hunk.after)]))
+	: new Map<string, ReturnType<typeof pairedRows>>())
+
+/** Load the source comparison for the current content. */
+async function load() {
+	const request = ++generation
+	controller?.abort()
+	controller = new AbortController()
+	loading.value = true
+	error.value = null
+	try {
+		const { createMarkdownSourceComparison } = await import('../comparison/markdownSourceComparison.ts')
+		const result = await createMarkdownSourceComparison(props.beforeContent, props.afterContent, controller.signal)
+		if (request !== generation) {
+			return
+		}
+		model.value = result
+		currentId.value = result.status === 'ready' ? result.hunks[0]?.id ?? null : null
+	} catch (exception) {
+		if (request !== generation || (exception instanceof DOMException && exception.name === 'AbortError')) {
+			return
+		}
+		error.value = exception
+	} finally {
+		if (request === generation) {
+			loading.value = false
+		}
+	}
+}
+
+/**
+ * Move the current source hunk selection.
+ *
+ * @param offset Signed hunk navigation offset
+ */
+function move(offset: number) {
+	if (model.value?.status !== 'ready' || model.value.hunks.length === 0) {
+		return
+	}
+	const index = (currentIndex.value + offset + model.value.hunks.length) % model.value.hunks.length
+	currentId.value = model.value.hunks[index]!.id
+	nextTick(() => {
+		const target = [...root.value?.querySelectorAll<HTMLElement>('[data-source-hunk]') ?? []]
+			.find((candidate) => candidate.dataset.sourceHunk === currentId.value)
+		if (target && typeof target.scrollIntoView === 'function') {
+			target.scrollIntoView({ block: 'center', behavior: reducedMotion() ? 'auto' : 'smooth' })
+		}
+	})
+}
+
+/**
+ * Read paired display rows for one hunk.
+ *
+ * @param hunk Source comparison hunk
+ */
+function hunkRows(hunk: SourceDiffHunk) {
+	return hunkRowsById.value.get(hunk.id) ?? []
+}
+
+/**
+ * Read paired display rows for one gap.
+ *
+ * @param gap Source comparison gap
+ */
+function gapRows(gap: SourceDiffGap) {
+	return pairedRows(gap.before, gap.after)
+}
+
+/**
+ * Pair source lines by display row.
+ *
+ * @param before Earlier source lines
+ * @param after Later source lines
+ */
+function pairedRows(before: readonly SourceDiffLine[], after: readonly SourceDiffLine[]) {
+	const rows: Array<{ before?: SourceDiffLine, after?: SourceDiffLine }> = []
+	let beforeIndex = 0
+	let afterIndex = 0
+	while (beforeIndex < before.length || afterIndex < after.length) {
+		const beforeLine = before[beforeIndex]
+		const afterLine = after[afterIndex]
+		if (beforeLine?.changed || afterLine?.changed) {
+			const removed: SourceDiffLine[] = []
+			const added: SourceDiffLine[] = []
+			while (before[beforeIndex]?.changed) {
+				removed.push(before[beforeIndex++]!)
+			}
+			while (after[afterIndex]?.changed) {
+				added.push(after[afterIndex++]!)
+			}
+			for (let index = 0; index < Math.max(removed.length, added.length); index++) {
+				rows.push({ before: removed[index], after: added[index] })
+			}
+			continue
+		}
+
+		rows.push({ before: beforeLine, after: afterLine })
+		beforeIndex += beforeLine ? 1 : 0
+		afterIndex += afterLine ? 1 : 0
+	}
+	return rows
+}
+
+/**
+ * Read the gap at a hunk boundary.
+ *
+ * @param slot Gap boundary index
+ */
+function gapAt(slot: number) {
+	return gapsBySlot.value.get(slot)
+}
+
+/** @param gap Source gap */
+function canExpandGap(gap: SourceDiffGap) {
+	return gap.count <= MAXIMUM_EXPANDABLE_GAP_LINES
+}
+
+/**
+ * Toggle one source gap.
+ *
+ * @param id Source gap ID
+ */
+function toggleGap(id: string) {
+	expandedGaps.value = expandedGaps.value.has(id) ? new Set() : new Set([id])
+}
+
+/**
+ * Handle keyboard navigation between source side tabs.
+ *
+ * @param event Keyboard event
+ * @param side Current source side
+ */
+function onSideTabKeydown(event: KeyboardEvent, side: 'before' | 'after') {
+	let target: 'before' | 'after' | null = null
+	if (event.key === 'Home') {
+		target = 'before'
+	} else if (event.key === 'End') {
+		target = 'after'
+	} else if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+		target = side === 'before' ? 'after' : 'before'
+	}
+	if (!target) {
+		return
+	}
+	event.preventDefault()
+	activeSide.value = target
+	nextTick(() => (target === 'before' ? beforeTab.value : afterTab.value)?.focus())
+}
+
+/** @param lineEnding Source line-ending convention */
+function lineEndingLabel(lineEnding: SourceLineEnding) {
+	return lineEnding === 'mixed' ? t('text', 'Mixed') : lineEnding.toUpperCase()
+}
+
+/** Check the user motion preference. */
+function reducedMotion() {
+	return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+}
+
+onMounted(load)
+onBeforeUnmount(() => {
+	generation++
+	controller?.abort()
+})
+</script>
+
+<style lang="scss">
+.text-source-comparison {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
+
+	&__toolbar,
+	&__navigation,
+	&__tabs {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: calc(2 * var(--default-grid-baseline));
+	}
+
+	&__toolbar {
+		flex-direction: column;
+		padding: calc(2 * var(--default-grid-baseline));
+	}
+
+	&__navigation p,
+	&__line-ending-change,
+	&__message p {
+		margin: 0;
+	}
+
+	&__tabs button {
+		min-height: var(--default-clickable-area);
+		padding-inline: calc(4 * var(--default-grid-baseline));
+		border: 2px solid transparent;
+		border-radius: var(--border-radius-pill);
+		background: var(--color-background-hover);
+		font-size: var(--default-font-size);
+
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-element);
+			outline-offset: 2px;
+		}
+
+		&[aria-selected='true'] {
+			border-color: var(--color-primary-element);
+			font-weight: var(--font-weight-heading);
+		}
+	}
+
+	&__message {
+		padding: calc(6 * var(--default-grid-baseline));
+		text-align: center;
+	}
+
+	&__column-headings,
+	&__row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	}
+
+	&__column-headings {
+		position: sticky;
+		top: 0;
+		z-index: 2;
+		background: var(--color-main-background);
+
+		strong {
+			padding: calc(2 * var(--default-grid-baseline)) calc(3 * var(--default-grid-baseline));
+			border-block: 1px solid var(--color-border);
+		}
+
+		strong + strong {
+			border-inline-start: 1px solid var(--color-border);
+		}
+
+		&--single {
+			display: block;
+		}
+	}
+
+	&__hunk {
+		border-block-end: 1px solid var(--color-border);
+
+		&--current {
+			box-shadow: inset 3px 0 0 var(--color-primary-element);
+		}
+	}
+
+	&__hunk-title {
+		margin: 0;
+		background: var(--color-background-dark);
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+
+		button {
+			display: block;
+			inline-size: 100%;
+			min-height: var(--default-clickable-area);
+			padding: calc(2 * var(--default-grid-baseline)) calc(3 * var(--default-grid-baseline));
+			border: 0;
+			background: transparent;
+			color: inherit;
+			font: inherit;
+			font-weight: var(--font-weight-heading);
+			text-align: start;
+
+			&:focus-visible {
+				outline: 2px solid var(--color-primary-element);
+				outline-offset: -2px;
+			}
+		}
+	}
+
+	&__row--single {
+		display: block;
+	}
+
+	&__line {
+		display: grid;
+		grid-template-columns: 4ch 2ch minmax(0, 1fr) auto;
+		min-width: 0;
+		border-inline-start: 3px solid transparent;
+		font-family: var(--font-face-monospace);
+		font-size: var(--font-size-small);
+
+		&:nth-child(2) {
+			border-inline-start-color: var(--color-border);
+		}
+
+		&--removed {
+			border-inline-start-color: var(--color-border-error);
+			background: var(--color-error);
+		}
+
+		&--added {
+			border-inline-start-color: var(--color-border-success);
+			background: var(--color-success);
+		}
+
+		&--empty {
+			min-height: calc(6 * var(--default-grid-baseline));
+			background: repeating-linear-gradient(-45deg, transparent, transparent 6px, var(--color-background-dark) 6px, var(--color-background-dark) 7px);
+		}
+	}
+
+	&__line-number,
+	&__line-prefix {
+		padding-inline: var(--default-grid-baseline);
+		color: var(--color-text-maxcontrast);
+		text-align: end;
+		user-select: none;
+	}
+
+	&__line-code {
+		min-width: 0;
+		padding-inline: calc(2 * var(--default-grid-baseline));
+		overflow-wrap: anywhere;
+		white-space: break-spaces;
+
+		&--long {
+			overflow-x: auto;
+			overflow-wrap: normal;
+			white-space: pre;
+		}
+	}
+
+	&__hunks {
+		flex: 1 1 auto;
+		min-width: 0;
+		min-height: 0;
+		overflow: auto;
+	}
+
+	&__segment--changed {
+		font-weight: var(--font-weight-heading);
+		text-decoration: underline 2px;
+		text-underline-offset: 2px;
+	}
+
+	&__whitespace-signal,
+	&__newline-marker {
+		align-self: center;
+		margin: var(--default-grid-baseline);
+		padding-inline: var(--default-grid-baseline);
+		border: 1px dashed var(--color-border-maxcontrast);
+		border-radius: var(--border-radius-pill);
+		color: var(--color-text-maxcontrast);
+		font-family: var(--font-face);
+		font-size: var(--font-size-small);
+		white-space: nowrap;
+	}
+
+	&__newline-marker {
+		grid-column: 3 / -1;
+		justify-self: start;
+	}
+
+	&__gap {
+		padding: calc(2 * var(--default-grid-baseline));
+		border-block-end: 1px solid var(--color-border);
+		text-align: center;
+
+		p {
+			margin: 0;
+			color: var(--color-text-maxcontrast);
+		}
+	}
+
+	&__sr-only {
+		position: absolute;
+		inline-size: 1px;
+		block-size: 1px;
+		padding: 0;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+		border: 0;
+	}
+}
+</style>

--- a/src/components/Menu/ActionList.vue
+++ b/src/components/Menu/ActionList.vue
@@ -134,14 +134,15 @@ export default {
 	},
 
 	mounted() {
-		this.$_updateState = debounce(this.checkStateOfChildren.bind(this), 50)
-		this.editor?.on('update', this.$_updateState)
-		this.editor?.on('selectionUpdate', this.$_updateState)
+		this.$_updateChildrenState = debounce(this.checkStateOfChildren.bind(this), 50)
+		this.editor?.on('update', this.$_updateChildrenState)
+		this.editor?.on('selectionUpdate', this.$_updateChildrenState)
 	},
 
 	beforeUnmount() {
-		this.editor?.off('update', this.$_updateState)
-		this.editor?.off('selectionUpdate', this.$_updateState)
+		this.editor?.off('update', this.$_updateChildrenState)
+		this.editor?.off('selectionUpdate', this.$_updateChildrenState)
+		this.$_updateChildrenState.clear()
 	},
 
 	methods: {

--- a/src/components/Menu/BaseActionEntry.js
+++ b/src/components/Menu/BaseActionEntry.js
@@ -79,6 +79,7 @@ const BaseActionEntry = {
 	beforeUnmount() {
 		this.editor.off('update', this.$_updateState)
 		this.editor.off('selectionUpdate', this.$_updateState)
+		this.$_updateState.clear()
 	},
 	methods: {
 		updateState() {

--- a/src/composables/useEditorMethods.ts
+++ b/src/composables/useEditorMethods.ts
@@ -13,6 +13,18 @@ import markdownit from '../markdownit/index.js'
 import { isUser } from '../services/SyncService.ts'
 
 /**
+ * Convert editor source content to the HTML consumed by Tiptap's parser.
+ *
+ * @param content Editor source content
+ * @param markdown Whether the editor supports Markdown content
+ */
+export function renderEditorContent(content: string, markdown: boolean) {
+	return markdown
+		? markdownit.render(content) + '<p/>'
+		: `<pre>\n${escapeHtml(content)}</pre>`
+}
+
+/**
  *
  * @param editor to apply methods to
  */
@@ -29,12 +41,9 @@ export function useEditorMethods(editor: Editor) {
 	) => void = (content, { addToHistory = true } = {}) => {
 		const hasMarkdownContent
 			= editor.extensionManager.extensions.includes(Markdown)
-		const html = hasMarkdownContent
-			? markdownit.render(content) + '<p/>'
-			: `<pre>\n${escapeHtml(content)}</pre>`
 		editor
 			.chain()
-			.setContent(html, { emitUpdate: addToHistory })
+			.setContent(renderEditorContent(content, hasMarkdownContent), { emitUpdate: addToHistory })
 			.command(({ tr }) => {
 				tr.setMeta('addToHistory', addToHistory)
 				return true

--- a/src/createMarkdownContentComparison.ts
+++ b/src/createMarkdownContentComparison.ts
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createApp } from 'vue'
+import { OPEN_LINK_HANDLER } from './composables/useOpenLinkHandler.ts'
+import { openLink } from './helpers/links.js'
+
+export interface MarkdownContentComparisonOptions {
+	el: HTMLElement
+	beforeContent: string
+	afterContent: string
+	fileId?: number
+	filePath?: string
+	shareToken?: string
+	noLazyImages?: boolean
+	openLinkHandler?: (href: string) => void
+	onLoaded?: () => void
+}
+
+export interface MarkdownContentComparisonInstance {
+	destroy: () => void
+}
+
+/**
+ * Create and mount an immutable semantic Markdown comparison.
+ *
+ * @param options Comparison options
+ */
+export async function createMarkdownContentComparison(options: MarkdownContentComparisonOptions): Promise<MarkdownContentComparisonInstance> {
+	if (!(options?.el instanceof HTMLElement)) {
+		throw new TypeError('Comparison el must be an HTMLElement')
+	}
+	if (typeof options.beforeContent !== 'string' || typeof options.afterContent !== 'string') {
+		throw new TypeError('beforeContent and afterContent must be strings')
+	}
+
+	const { default: MarkdownContentComparison } = await import('./components/MarkdownContentComparison.vue')
+	let resolveLoaded: () => void
+	let rejectLoaded: (error: unknown) => void
+	let loaded = false
+	const loadedPromise = new Promise<void>((resolve, reject) => {
+		resolveLoaded = resolve
+		rejectLoaded = reject
+	})
+	const onReady = () => {
+		if (loaded) {
+			return
+		}
+		loaded = true
+		try {
+			options.onLoaded?.()
+			resolveLoaded()
+		} catch (error) {
+			rejectLoaded(error)
+		}
+	}
+	const app = createApp(MarkdownContentComparison, {
+		afterContent: options.afterContent,
+		beforeContent: options.beforeContent,
+		fileId: options.fileId,
+		filePath: options.filePath,
+		noLazyImages: options.noLazyImages ?? false,
+		onReady,
+		openLinkHandler: options.openLinkHandler ?? openLink,
+		shareToken: options.shareToken,
+	})
+	app.config.errorHandler = (error) => {
+		if (!loaded) {
+			rejectLoaded(error)
+			return
+		}
+		throw error
+	}
+	app.provide(OPEN_LINK_HANDLER, {
+		openLink: options.openLinkHandler ?? openLink,
+	})
+
+	options.el.replaceChildren()
+	const root = document.createElement('div')
+	root.className = 'text-comparison-root'
+	options.el.appendChild(root)
+	let destroyed = false
+
+	try {
+		app.mount(root)
+		await loadedPromise
+	} catch (error) {
+		try {
+			app.unmount()
+		} catch {
+			// Preserve the comparison initialization error.
+		}
+		root.remove()
+		throw error
+	}
+
+	return {
+		destroy() {
+			if (destroyed) {
+				return
+			}
+			destroyed = true
+			app.unmount()
+			root.remove()
+		},
+	}
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4,11 +4,12 @@
  */
 
 import { createCollaborativeEditor, createEditor, createMarkdownContentEditor } from './createEditor.ts'
+import { createMarkdownContentComparison } from './createMarkdownContentComparison.ts'
 import { createTable } from './createTable.ts'
 
 import 'vite/modulepreload-polyfill'
 
-const apiVersion = '1.4'
+const apiVersion = '1.5'
 
 window.OCA.Text = {
 	...window.OCA.Text,
@@ -18,4 +19,5 @@ window.OCA.Text.apiVersion = apiVersion
 window.OCA.Text.createEditor = createEditor
 window.OCA.Text.createCollaborativeEditor = createCollaborativeEditor
 window.OCA.Text.createMarkdownContentEditor = createMarkdownContentEditor
+window.OCA.Text.createMarkdownContentComparison = createMarkdownContentComparison
 window.OCA.Text.createTable = createTable

--- a/src/extensions/RichText.ts
+++ b/src/extensions/RichText.ts
@@ -66,12 +66,16 @@ lowlight.registerAlias('plaintext', 'mermaid')
 interface RichTextOptions {
 	connection?: Connection
 	editing: boolean
+	emitAttachmentEvents: boolean
 	extensions: Extensions
+	inferTextDirectionOnParse: boolean
+	keymap: boolean
 	relativePath?: string
 	isEmbedded: boolean
 	mentionSearch?: (query: string) => Promise<Record<string, string>>
 	openLink?: (href: string) => void
 	noLazyImages: boolean
+	search: boolean
 }
 
 export default Extension.create<RichTextOptions>({
@@ -80,9 +84,13 @@ export default Extension.create<RichTextOptions>({
 	addOptions() {
 		return {
 			editing: true,
+			emitAttachmentEvents: true,
 			extensions: [],
+			inferTextDirectionOnParse: false,
 			isEmbedded: false,
+			keymap: true,
 			noLazyImages: false,
+			search: true,
 		}
 	},
 
@@ -123,7 +131,10 @@ export default Extension.create<RichTextOptions>({
 				isEmbedded: this.options.isEmbedded,
 			}),
 			Underline,
-			Image.configure({ noLazyImages: this.options.noLazyImages }),
+			Image.configure({
+				emitAttachmentEvents: this.options.emitAttachmentEvents,
+				noLazyImages: this.options.noLazyImages,
+			}),
 			ImageInline.configure({ noLazyImages: this.options.noLazyImages }),
 			Dropcursor.configure({
 				color: 'var(--color-primary-element)',
@@ -131,7 +142,7 @@ export default Extension.create<RichTextOptions>({
 			}),
 			Gapcursor,
 			KeepSyntax,
-			Keymap,
+			...(this.options.keymap ? [Keymap] : []),
 			FrontMatter,
 			Mention.configure({
 				suggestion: MentionSuggestion({
@@ -141,7 +152,9 @@ export default Extension.create<RichTextOptions>({
 					},
 				}),
 			}),
-			Search,
+			...(this.options.search
+				? [Search]
+				: []),
 			Emoji.configure({
 				suggestion: EmojiSuggestion(),
 			}),
@@ -163,6 +176,7 @@ export default Extension.create<RichTextOptions>({
 				notAfter: ['paragraph', 'comments', 'footnotes'],
 			}),
 			TextDirection.configure({
+				inferTextDirectionOnParse: this.options.inferTextDirectionOnParse,
 				types: [
 					'blockquote',
 					'callout',

--- a/src/extensions/TextDirection.ts
+++ b/src/extensions/TextDirection.ts
@@ -119,6 +119,7 @@ declare module '@tiptap/core' {
 export interface TextDirectionOptions {
 	types: string[]
 	defaultDirection: Direction | null
+	inferTextDirectionOnParse: boolean
 }
 
 export const TextDirection = Extension.create<TextDirectionOptions>({
@@ -128,6 +129,7 @@ export const TextDirection = Extension.create<TextDirectionOptions>({
 		return {
 			types: [],
 			defaultDirection: null,
+			inferTextDirectionOnParse: false,
 		}
 	},
 
@@ -138,7 +140,15 @@ export const TextDirection = Extension.create<TextDirectionOptions>({
 				attributes: {
 					dir: {
 						default: null,
-						parseHTML: (element) => element.dir || this.options.defaultDirection,
+						parseHTML: (element) => {
+							if (!this.options.inferTextDirectionOnParse) {
+								return element.dir || this.options.defaultDirection
+							}
+							const explicitDirection = element.dir as Direction
+							return validDirections.includes(explicitDirection)
+								? explicitDirection
+								: getTextDirection(element.textContent ?? '') ?? this.options.defaultDirection
+						},
 						renderHTML: (attributes) => {
 							if (attributes.dir === this.options.defaultDirection) {
 								return {}

--- a/src/nodes/Image.ts
+++ b/src/nodes/Image.ts
@@ -17,6 +17,7 @@ const imageFileDropPluginKey = new PluginKey('imageFileDrop')
 const imageExtractAttachmentsKey = new PluginKey('imageExtractAttachments')
 
 interface ImageOptions extends TiptapImageOptions {
+	emitAttachmentEvents: boolean
 	noLazyImages: boolean
 }
 
@@ -53,6 +54,7 @@ const Image = TiptapImage.extend<ImageOptions>({
 	addOptions() {
 		return {
 			...this.parent?.() as ImageOptions,
+			emitAttachmentEvents: true,
 			noLazyImages: false,
 		}
 	},
@@ -62,6 +64,7 @@ const Image = TiptapImage.extend<ImageOptions>({
 	},
 
 	addProseMirrorPlugins() {
+		const emitAttachmentEvents = this.options.emitAttachmentEvents
 		return [
 			new Plugin({
 				key: imageFileDropPluginKey,
@@ -125,7 +128,9 @@ const Image = TiptapImage.extend<ImageOptions>({
 				state: {
 					init(_, { doc }) {
 						const attachmentSrcs = extractAttachmentSrcs(doc)
-						emit('text:editor:attachments:updated', { attachmentSrcs })
+						if (emitAttachmentEvents) {
+							emit('text:editor:attachments:updated', { attachmentSrcs })
+						}
 						return { attachmentSrcs }
 					},
 					apply(tr, value, _oldState, newState) {
@@ -140,7 +145,9 @@ const Image = TiptapImage.extend<ImageOptions>({
 							return value
 						}
 
-						emit('text:editor:attachments:updated', { attachmentSrcs })
+						if (emitAttachmentEvents) {
+							emit('text:editor:attachments:updated', { attachmentSrcs })
+						}
 						return { attachmentSrcs }
 					},
 				},

--- a/src/tests/comparison/MarkdownSourceComponent.spec.ts
+++ b/src/tests/comparison/MarkdownSourceComponent.spec.ts
@@ -1,0 +1,295 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createSourceComparison } = vi.hoisted(() => ({
+	createSourceComparison: vi.fn(),
+}))
+
+vi.mock('../../comparison/markdownSourceComparison.ts', () => ({
+	createMarkdownSourceComparison: createSourceComparison,
+}))
+
+import MarkdownSourceComparison from '../../components/MarkdownSourceComparison.vue'
+
+const readyModel = {
+	status: 'ready' as const,
+	hunks: [
+		{ id: 'source-hunk-0', beforeStart: 1, afterStart: 1, before: [], after: [] },
+		{ id: 'source-hunk-1', beforeStart: 8, afterStart: 8, before: [], after: [] },
+	],
+	gaps: [],
+	lineEndingChange: null,
+}
+
+function sourceLine(number: number, text: string) {
+	return {
+		number,
+		text,
+		eol: 'lf' as const,
+		changed: false,
+		eolChanged: false,
+		segments: [{ text, changed: false }],
+		hasTab: false,
+		hasTrailingWhitespace: false,
+		hasZeroWidth: false,
+		missingFinalNewline: false,
+	}
+}
+
+describe('MarkdownSourceComparison', () => {
+	beforeEach(() => {
+		createSourceComparison.mockReset()
+	})
+
+	it('loads once and keeps source navigation local to the source model', async () => {
+		createSourceComparison.mockResolvedValue(readyModel)
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'Before', afterContent: 'After', layoutMode: 'paired' },
+		})
+
+		await vi.waitFor(() => expect(wrapper.findAll('[data-source-hunk]')).toHaveLength(2))
+		expect(createSourceComparison).toHaveBeenCalledOnce()
+		expect(wrapper.find('[data-source-hunk="source-hunk-0"] button').attributes('aria-current')).toBe('true')
+
+		await wrapper.find('button[aria-label="Next source change"]').trigger('click')
+		expect(wrapper.find('[data-source-hunk="source-hunk-1"] button').attributes('aria-current')).toBe('true')
+		expect(createSourceComparison).toHaveBeenCalledOnce()
+		wrapper.unmount()
+	})
+
+	it('keeps source lines exposed outside the native hunk button', async () => {
+		createSourceComparison.mockResolvedValue({
+			...readyModel,
+			hunks: [{
+				...readyModel.hunks[0],
+				before: [sourceLine(1, 'Readable before')],
+				after: [sourceLine(1, 'Readable after')],
+			}],
+		})
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'Before', afterContent: 'After', layoutMode: 'paired' },
+		})
+
+		await vi.waitFor(() => expect(wrapper.find('[data-source-hunk]').exists()).toBe(true))
+		const hunk = wrapper.find('[data-source-hunk]')
+		expect(hunk.attributes('role')).toBeUndefined()
+		expect(hunk.find('h3 button').exists()).toBe(true)
+		expect(hunk.findAll('code').map((line) => line.text()))
+			.toEqual(['Readable before', 'Readable after'])
+
+		wrapper.unmount()
+	})
+
+	it('names added and removed source lines for assistive technology', async () => {
+		createSourceComparison.mockResolvedValue({
+			...readyModel,
+			hunks: [{
+				...readyModel.hunks[0],
+				before: [{ ...sourceLine(4, 'Old'), changed: true }],
+				after: [{ ...sourceLine(5, 'New'), changed: true }],
+			}],
+		})
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'Old', afterContent: 'New', layoutMode: 'paired' },
+		})
+
+		await vi.waitFor(() => expect(wrapper.find('[data-source-hunk]').exists()).toBe(true))
+		expect(wrapper.findAll('.text-source-comparison__sr-only').map((label) => label.text()))
+			.toEqual(['Removed line 4', 'Added line 5'])
+		wrapper.unmount()
+	})
+
+	it.each([
+		['inserted', [sourceLine(1, 'one'), sourceLine(2, 'three')], [
+			sourceLine(1, 'one'),
+			{ ...sourceLine(2, 'two'), changed: true },
+			sourceLine(3, 'three'),
+		], 'added'],
+		['deleted', [
+			sourceLine(1, 'one'),
+			{ ...sourceLine(2, 'two'), changed: true },
+			sourceLine(3, 'three'),
+		], [sourceLine(1, 'one'), sourceLine(2, 'three')], 'removed'],
+	] as const)('aligns an %s source line without shifting unchanged context', async (_name, before, after, operation) => {
+		createSourceComparison.mockResolvedValue({
+			...readyModel,
+			hunks: [{
+				...readyModel.hunks[0],
+				before,
+				after,
+			}],
+		})
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'one\nthree', afterContent: 'one\ntwo\nthree', layoutMode: 'paired' },
+		})
+
+		await vi.waitFor(() => expect(wrapper.find('[data-source-hunk]').exists()).toBe(true))
+		const rows = wrapper.findAll('[data-source-hunk] .text-source-comparison__row')
+		expect(rows).toHaveLength(3)
+		expect(rows[0]!.findAll('code').map((line) => line.text())).toEqual(['one', 'one'])
+		expect(rows[1]!.find('.text-source-comparison__line--empty').exists()).toBe(true)
+		expect(rows[1]!.find(`.text-source-comparison__line--${operation}`).exists()).toBe(true)
+		expect(rows[1]!.findAll('code').map((line) => line.text())).toEqual(['two'])
+		expect(rows[2]!.findAll('code').map((line) => line.text())).toEqual(['three', 'three'])
+		wrapper.unmount()
+	})
+
+	it('renders and expands leading and trailing source gaps in document order', async () => {
+		createSourceComparison.mockResolvedValue({
+			...readyModel,
+			hunks: [readyModel.hunks[0]],
+			gaps: [{
+				id: 'source-gap-0',
+				slot: 0,
+				before: [sourceLine(1, 'Leading before')],
+				after: [sourceLine(1, 'Leading after')],
+				count: 1,
+			}, {
+				id: 'source-gap-1',
+				slot: 1,
+				before: [sourceLine(8, 'Trailing before')],
+				after: [sourceLine(8, 'Trailing after')],
+				count: 1,
+			}],
+		})
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'Before', afterContent: 'After', layoutMode: 'paired' },
+		})
+
+		await vi.waitFor(() => expect(wrapper.findAll('.text-source-comparison__gap')).toHaveLength(2))
+		expect(wrapper.find<HTMLButtonElement>('button[aria-label="Previous source change"]').element.disabled).toBe(true)
+		expect(wrapper.find<HTMLButtonElement>('button[aria-label="Next source change"]').element.disabled).toBe(true)
+		const flow = wrapper.find('.text-source-comparison__hunks').element.children
+		expect(flow[0]?.classList).toContain('text-source-comparison__gap')
+		expect(flow[1]?.classList).toContain('text-source-comparison__hunk')
+		expect(flow[2]?.classList).toContain('text-source-comparison__gap')
+		const leadingGap = wrapper.find('.text-source-comparison__gap button')
+		expect(leadingGap.attributes('data-source-gap')).toBe('source-gap-0')
+		expect(leadingGap.attributes('aria-expanded')).toBe('false')
+		await leadingGap.trigger('click')
+		expect(leadingGap.attributes('aria-expanded')).toBe('true')
+		expect(wrapper.text()).toContain('Leading before')
+		expect(wrapper.text()).toContain('Leading after')
+		const trailingGap = wrapper.findAll('.text-source-comparison__gap button')[1]!
+		await trailingGap.trigger('click')
+		expect(leadingGap.attributes('aria-expanded')).toBe('false')
+		expect(trailingGap.attributes('aria-expanded')).toBe('true')
+		wrapper.unmount()
+	})
+
+	it('does not offer to render an unsafe number of unchanged source rows', async () => {
+		createSourceComparison.mockResolvedValue({
+			...readyModel,
+			hunks: [readyModel.hunks[0]],
+			gaps: [{
+				id: 'source-gap-0',
+				slot: 0,
+				before: [sourceLine(1, 'Leading before')],
+				after: [sourceLine(1, 'Leading after')],
+				count: 2001,
+			}],
+		})
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'Before', afterContent: 'After', layoutMode: 'paired' },
+		})
+
+		await vi.waitFor(() => expect(wrapper.find('.text-source-comparison__gap').exists()).toBe(true))
+		expect(wrapper.find('.text-source-comparison__gap button').exists()).toBe(false)
+		expect(wrapper.find('.text-source-comparison__gap').text()).toContain('2001 unchanged lines hidden')
+		wrapper.unmount()
+	})
+
+	it('shows an error and retries without retaining partial source state', async () => {
+		createSourceComparison
+			.mockRejectedValueOnce(new Error('source failed'))
+			.mockResolvedValueOnce(readyModel)
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'Before', afterContent: 'After', layoutMode: 'paired' },
+		})
+
+		await vi.waitFor(() => expect(wrapper.find('[role="alert"]').exists()).toBe(true))
+		expect(wrapper.find('[data-source-hunk]').exists()).toBe(false)
+		const retry = wrapper.findAll('button').find((button) => button.text().includes('Retry'))
+		expect(retry).toBeDefined()
+		await retry!.trigger('click')
+		await vi.waitFor(() => expect(wrapper.findAll('[data-source-hunk]')).toHaveLength(2))
+		expect(createSourceComparison).toHaveBeenCalledTimes(2)
+		wrapper.unmount()
+	})
+
+	it('aborts and ignores a pending result after destroy', async () => {
+		let resolve!: (value: typeof readyModel) => void
+		let signal: AbortSignal | undefined
+		createSourceComparison.mockImplementation((_before, _after, requestSignal) => {
+			signal = requestSignal
+			return new Promise<typeof readyModel>((done) => {
+				resolve = done
+			})
+		})
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'Before', afterContent: 'After', layoutMode: 'paired' },
+		})
+		await vi.waitFor(() => expect(signal).toBeDefined())
+
+		wrapper.unmount()
+		expect(signal?.aborted).toBe(true)
+		resolve(readyModel)
+		await Promise.resolve()
+		expect(wrapper.exists()).toBe(false)
+	})
+
+	it('renders the explicit safe-limit state', async () => {
+		createSourceComparison.mockResolvedValue({ status: 'limited', reason: 'complexity' })
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'Before', afterContent: 'After', layoutMode: 'single' },
+		})
+
+		await vi.waitFor(() => expect(wrapper.text()).toContain('safe processing limit'))
+		expect(wrapper.find('[role="status"]').exists()).toBe(true)
+		wrapper.unmount()
+	})
+
+	it('associates the single-pane tabs with their panel', async () => {
+		createSourceComparison.mockResolvedValue(readyModel)
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'Before', afterContent: 'After', layoutMode: 'single' },
+		})
+
+		await vi.waitFor(() => expect(wrapper.findAll('[role="tab"]')).toHaveLength(2))
+		const [before, after] = wrapper.findAll('[role="tab"]')
+		const panel = wrapper.find('[role="tabpanel"]')
+		expect(before!.attributes('aria-controls')).toBe(panel.attributes('id'))
+		expect(after!.attributes('aria-controls')).toBe(panel.attributes('id'))
+		expect(panel.attributes('aria-labelledby')).toBe(before!.attributes('id'))
+
+		await after!.trigger('click')
+		expect(panel.attributes('aria-labelledby')).toBe(after!.attributes('id'))
+		wrapper.unmount()
+	})
+
+	it('summarizes line endings and keeps very long source lines unwrapped', async () => {
+		const longLine = sourceLine(1, 'x'.repeat(2001))
+		createSourceComparison.mockResolvedValue({
+			...readyModel,
+			hunks: [{
+				...readyModel.hunks[0],
+				before: [longLine],
+				after: [longLine],
+			}],
+			lineEndingChange: { before: 'lf', after: 'mixed' },
+		})
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'Before', afterContent: 'After', layoutMode: 'paired' },
+		})
+
+		await vi.waitFor(() => expect(wrapper.find('[data-source-line-ending-change]').exists()).toBe(true))
+		expect(wrapper.find('[data-source-line-ending-change]').text()).toContain('LF → Mixed')
+		expect(wrapper.findAll('.text-source-comparison__line-code--long')).toHaveLength(2)
+		wrapper.unmount()
+	})
+})

--- a/src/tests/comparison/comparisonDecorations.spec.ts
+++ b/src/tests/comparison/comparisonDecorations.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { registerMountedPlugin } from '../../comparison/comparisonEditorLifecycle.ts'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import {
+	createComparisonDecorationPlugin,
+	createMarkdownComparisonModel,
+	prepareComparisonDecorations,
+	setComparisonDecorationState,
+} from '../../comparison/markdownComparison.ts'
+
+describe('comparison decorations', () => {
+	it('avoids a descriptor-by-document cross product for full-document block changes', () => {
+		const before = createComparisonEditor(Array.from({ length: 65 }, (_, index) => `before ${index}`).join('\n\n'))
+		const after = createComparisonEditor(Array.from({ length: 65 }, (_, index) => `# after ${index}`).join('\n\n'))
+		try {
+			const descriptors = createMarkdownComparisonModel(before.state.doc, after.state.doc).descriptors
+			expect(descriptors.length).toBeGreaterThan(60)
+			expect(descriptors.every(({ detail }) => detail === 'block')).toBe(true)
+			const topLevelTraversal = vi.spyOn(before.state.doc, 'forEach')
+
+			const { key, plugin } = createComparisonDecorationPlugin(descriptors, 'before', 'Changed content')
+			const decorations = key.getState(before.state.reconfigure({ plugins: [plugin] }))!.decorations.find()
+
+			expect(decorations.length).toBeGreaterThan(60)
+			expect(topLevelTraversal.mock.calls.length).toBeLessThanOrEqual(2)
+		} finally {
+			before.destroy()
+			after.destroy()
+		}
+	})
+
+	it('bounds inline preparation by range intersections instead of document size', () => {
+		const count = 200
+		const before = createComparisonEditor(Array.from({ length: count }, () => '- [ ] a x a x a x a x a x a x a x a x').join('\n'))
+		const after = createComparisonEditor(Array.from({ length: count }, () => '- [ ] b x b x b x b x b x b x b x b x').join('\n'))
+		try {
+			const descriptors = createMarkdownComparisonModel(before.state.doc, after.state.doc).descriptors
+			const audit = { examinedNodes: 0 }
+			const prepared = prepareComparisonDecorations(before.state.doc, descriptors, 'before', audit)
+
+			expect(descriptors).toHaveLength(count * 8)
+			expect(prepared.length).toBeGreaterThanOrEqual(descriptors.length)
+			expect(audit.examinedNodes).toBeLessThan(descriptors.length * 50)
+		} finally {
+			before.destroy()
+			after.destroy()
+		}
+	})
+
+	it('outlines coarse replacements at node level without destructive inline treatment', () => {
+		const before = createComparisonEditor(`Before ${'a'.repeat(4600)}`)
+		const after = createComparisonEditor(`After ${'b'.repeat(4600)}`)
+		try {
+			const descriptors = createMarkdownComparisonModel(before.state.doc, after.state.doc).descriptors
+			expect(descriptors).toHaveLength(1)
+			expect(descriptors[0]?.detail).toBe('block')
+			for (const [editor, side] of [[before, 'before'], [after, 'after']] as const) {
+				const { key, plugin } = createComparisonDecorationPlugin(descriptors, side, 'Changed content')
+				const decorations = key.getState(editor.state.reconfigure({ plugins: [plugin] }))!.decorations.find()
+				expect(decorations).toHaveLength(1)
+				expect(decorations[0]).toMatchObject({
+					from: 0,
+					to: editor.state.doc.firstChild!.nodeSize,
+				})
+				const attributes = (decorations[0] as unknown as { type: { attrs: Record<string, string> } }).type.attrs
+				expect(attributes.class).toContain('text-comparison-change--block')
+				expect(attributes.class).not.toContain('text-comparison-change--removed')
+				expect(attributes.class).not.toContain('text-comparison-change--added')
+			}
+		} finally {
+			before.destroy()
+			after.destroy()
+		}
+	})
+
+	it('keeps empty block ranges as widgets when other block changes index nodes', () => {
+		const before = createComparisonEditor([
+			'Alpha old',
+			'Beta old',
+			'Gamma old',
+			'Same anchor',
+			'Delete me',
+		].join('\n\n'))
+		const after = createComparisonEditor([
+			'Alpha new',
+			'Insert',
+			'Beta new',
+			'Gamma new',
+			'Same anchor',
+		].join('\n\n'))
+		try {
+			const descriptors = createMarkdownComparisonModel(before.state.doc, after.state.doc).descriptors
+			const inserted = descriptors.find((descriptor) => descriptor.operation === 'insert'
+				&& descriptor.detail === 'block'
+				&& descriptor.before.from === descriptor.before.to)
+			expect(inserted).toBeDefined()
+			expect(descriptors.some((descriptor) => descriptor.detail === 'block'
+				&& descriptor.before.from < descriptor.before.to)).toBe(true)
+
+			const prepared = prepareComparisonDecorations(before.state.doc, descriptors, 'before')
+				.filter(({ descriptor }) => descriptor.id === inserted!.id)
+
+			expect(prepared).toHaveLength(1)
+			expect(prepared[0]).toMatchObject({
+				from: inserted!.before.from,
+				to: inserted!.before.from,
+				type: 'widget',
+			})
+		} finally {
+			before.destroy()
+			after.destroy()
+		}
+	})
+
+	it('uses stable IDs on both sides and does not traverse on navigation', () => {
+		const before = createComparisonEditor('Before one\n\nBefore two')
+		const after = createComparisonEditor('After one\n\nAfter two')
+		try {
+			const descriptors = createMarkdownComparisonModel(before.state.doc, after.state.doc).descriptors
+			const beforeTraversal = vi.spyOn(before.state.doc, 'descendants')
+			const afterTraversal = vi.spyOn(after.state.doc, 'descendants')
+			const beforeHost = document.createElement('div')
+			const afterHost = document.createElement('div')
+			before.setOptions({ element: beforeHost })
+			after.setOptions({ element: afterHost })
+			before.mount(beforeHost)
+			after.mount(afterHost)
+			const beforeDecorations = createComparisonDecorationPlugin(descriptors, 'before', 'Removed')
+			const afterDecorations = createComparisonDecorationPlugin(descriptors, 'after', 'Added')
+			registerMountedPlugin(before, beforeDecorations.plugin)
+			registerMountedPlugin(after, afterDecorations.plugin)
+			const beforeKey = beforeDecorations.key
+			const afterKey = afterDecorations.key
+			beforeTraversal.mockClear()
+			afterTraversal.mockClear()
+			const activeIds = descriptors.map(({ id }) => id)
+			const currentId = activeIds.at(-1)!
+			setComparisonDecorationState(before, beforeKey, { activeIds, currentId })
+			setComparisonDecorationState(after, afterKey, { activeIds, currentId })
+
+			expect(beforeKey.getState(before.state)).toMatchObject({ activeIds, currentId })
+			expect(afterKey.getState(after.state)).toMatchObject({ activeIds, currentId })
+			// Other Text plugins perform a constant number of maintenance walks on
+			// any transaction. Comparison navigation must not add one per descriptor.
+			expect(beforeTraversal.mock.calls.length).toBeLessThanOrEqual(4)
+			expect(afterTraversal.mock.calls.length).toBeLessThanOrEqual(4)
+			const beforeIds = beforeKey.getState(before.state)?.decorations.find()
+				.map((decoration) => (decoration as unknown as { type: { attrs?: Record<string, string> } }).type.attrs?.['data-comparison-change'])
+				.filter((id): id is string => id !== undefined)
+			const afterIds = afterKey.getState(after.state)?.decorations.find()
+				.map((decoration) => (decoration as unknown as { type: { attrs?: Record<string, string> } }).type.attrs?.['data-comparison-change'])
+				.filter((id): id is string => id !== undefined)
+			expect(new Set(beforeIds)).toEqual(new Set(activeIds))
+			expect(new Set(afterIds)).toEqual(new Set(activeIds))
+			expect(beforeIds?.every((id) => !/^\d+$/.test(id))).toBe(true)
+		} finally {
+			before.destroy()
+			after.destroy()
+		}
+	})
+})

--- a/src/tests/comparison/comparisonDocumentLocation.spec.ts
+++ b/src/tests/comparison/comparisonDocumentLocation.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { locateComparisonTarget } from '../../comparison/comparisonDocumentLocation.ts'
+
+describe('comparison document location', () => {
+	it('centers a target with pane-local scroll math and preserves horizontal position', () => {
+		const pane = document.createElement('article')
+		const scroller = document.createElement('div')
+		const target = document.createElement('span')
+		target.dataset.comparisonChange = 'change-safe_1'
+		scroller.append(target)
+		pane.append(scroller)
+		Object.defineProperties(scroller, {
+			clientHeight: { value: 400 },
+			scrollHeight: { value: 2000 },
+			scrollLeft: { value: 35 },
+			scrollTop: { value: 125 },
+		})
+		vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue({ height: 400, top: 100 } as DOMRect)
+		vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({ height: 20, top: 900 } as DOMRect)
+		const scrollTo = vi.fn()
+		Object.defineProperty(scroller, 'scrollTo', { value: scrollTo })
+
+		expect(locateComparisonTarget(pane, scroller, 'change-safe_1', 'smooth')).toBe(true)
+
+		expect(scrollTo).toHaveBeenCalledWith({ behavior: 'smooth', left: 35, top: 735 })
+	})
+
+	it.each([
+		['missing pane', null, document.createElement('div')],
+		['missing scroller', document.createElement('article'), null],
+	])('ignores a %s', (_name, pane, scroller) => {
+		expect(locateComparisonTarget(pane, scroller, 'change-0', 'auto')).toBe(false)
+	})
+
+	it('leaves hidden panes and missing targets available for a later retry', () => {
+		const pane = document.createElement('article')
+		const scroller = document.createElement('div')
+		pane.append(scroller)
+		pane.style.display = 'none'
+		expect(locateComparisonTarget(pane, scroller, 'change-0', 'auto')).toBe(false)
+
+		pane.style.display = ''
+		expect(locateComparisonTarget(pane, scroller, 'change-0', 'auto')).toBe(false)
+	})
+})

--- a/src/tests/comparison/comparisonEditorLifecycle.spec.ts
+++ b/src/tests/comparison/comparisonEditorLifecycle.spec.ts
@@ -3,12 +3,63 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { EditorState, Plugin } from '@tiptap/pm/state'
+
+import { EditorView } from '@tiptap/pm/view'
 import { Editor } from '@tiptap/vue-3'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { consumeStateOnlyComparisonEditor } from '../../comparison/comparisonEditorLifecycle.ts'
 import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import { ATTACHMENT_RESOLVER, EDITOR_UPLOAD } from '../../components/Editor.provider.ts'
+import { OPEN_LINK_HANDLER } from '../../composables/useOpenLinkHandler.ts'
+import { createMarkdownContentComparison } from '../../createMarkdownContentComparison.ts'
 import EditableTable from '../../nodes/EditableTable.js'
 import Table from '../../nodes/Table.js'
+
+vi.mock('@nextcloud/axios', () => ({
+	default: {
+		get: vi.fn().mockResolvedValue({ data: { ocs: { data: { references: {} } } } }),
+		post: vi.fn().mockResolvedValue({ data: { ocs: { data: { references: {} } } } }),
+	},
+}))
+
+vi.mock('@nextcloud/browser-storage', () => ({
+	getBuilder() {
+		const values = new Map<string, string>()
+		return {
+			build() {
+				return {
+					clear: () => values.clear(),
+					getItem: (key: string) => values.get(key) ?? null,
+					removeItem: (key: string) => values.delete(key),
+					setItem: (key: string, value: string) => values.set(key, value),
+				}
+			},
+			clearOnLogout() {
+				return this
+			},
+			persist() {
+				return this
+			},
+		}
+	},
+}))
+
+interface MountSnapshot {
+	editor: Editor
+	element: Parameters<Editor['mount']>[0]
+	contentComponent: Editor['contentComponent']
+	appContext: Editor['appContext']
+	pluginsAfterMount: readonly Plugin[]
+	docBeforeMount: EditorState['doc']
+	dom: HTMLElement
+	callout: Element | null
+}
+
+afterEach(() => {
+	vi.restoreAllMocks()
+	vi.unstubAllGlobals()
+})
 
 describe('comparison editor lifecycle', () => {
 	it('claims only registered state-only comparison editors once', () => {
@@ -38,7 +89,6 @@ describe('comparison editor lifecycle', () => {
 			expect(table).not.toBe(EditableTable)
 		} finally {
 			editor.destroy()
-			mount.mockRestore()
 		}
 	})
 
@@ -60,18 +110,277 @@ describe('comparison editor lifecycle', () => {
 		}
 	})
 
-	it('can parse both documents with one schema', () => {
-		const before = createComparisonEditor('::: info\nBefore\n:::')
-		const after = createComparisonEditor('::: warn\nAfter\n:::', { schema: before.schema })
-		try {
-			expect(after.schema).toBe(before.schema)
-			expect(after.extensionManager.schema).toBe(before.schema)
-			expect(after.state.doc.type.schema).toBe(before.state.doc.type.schema)
-			expect(before.state.doc.firstChild?.attrs.type).toBe('info')
-			expect(after.state.doc.firstChild?.attrs.type).toBe('warn')
-		} finally {
-			before.destroy()
-			after.destroy()
+	it('mounts each original complete document once with providers, decorations, and Vue node views ready', async () => {
+		const snapshots: MountSnapshot[] = []
+		const originalMount = Editor.prototype.mount
+		const mount = vi.spyOn(Editor.prototype, 'mount').mockImplementation(function(this: Editor, element) {
+			const contentComponent = this.contentComponent
+			const appContext = this.appContext
+			const docBeforeMount = this.state.doc
+			originalMount.call(this, element)
+			snapshots.push({
+				appContext,
+				callout: this.view.dom.querySelector('[data-node-view-wrapper][data-text-el="callout"]'),
+				contentComponent,
+				docBeforeMount,
+				dom: this.view.dom,
+				editor: this,
+				element,
+				pluginsAfterMount: this.view.state.plugins,
+			})
+		})
+		const createNodeViews = vi.spyOn(Editor.prototype, 'createNodeViews')
+		const setProps = vi.spyOn(EditorView.prototype, 'setProps')
+		const destroy = vi.spyOn(Editor.prototype, 'destroy')
+		const el = document.createElement('div')
+		const onLoaded = vi.fn(() => {
+			expect(snapshots).toHaveLength(2)
+			expect(el.querySelectorAll('.ProseMirror')).toHaveLength(2)
+			expect(el.querySelectorAll('.text-comparison-change')).not.toHaveLength(0)
+			expect(el.querySelector('.text-comparison__document--before .text-comparison-change--current')).not.toBeNull()
+			expect(el.querySelector('.text-comparison__document--after .text-comparison-change--current')).not.toBeNull()
+			for (const snapshot of snapshots) {
+				expect(snapshot.editor.state).toBe(snapshot.editor.view.state)
+				expect(snapshot.editor.view.dom).toBe(snapshot.dom)
+				expect(snapshot.callout).not.toBeNull()
+				expect(snapshot.editor.view.dom.querySelector('[data-text-el="callout"]')).toBe(snapshot.callout)
+			}
+		})
+
+		const comparison = await createMarkdownContentComparison({
+			afterContent: '::: warn\nAfter\n:::\n\nUnchanged middle\n\nAfter tail',
+			beforeContent: '::: info\nBefore\n:::\n\nUnchanged middle\n\nBefore tail',
+			el,
+			onLoaded,
+		})
+
+		expect(onLoaded).toHaveBeenCalledOnce()
+		expect(mount).toHaveBeenCalledTimes(2)
+		expect(snapshots[0]!.editor.schema).toBe(snapshots[1]!.editor.schema)
+		expect(snapshots[0]!.docBeforeMount.type.schema).toBe(snapshots[1]!.docBeforeMount.type.schema)
+		expect(snapshots.map(({ editor }) => editor.extensionManager.schema))
+			.toEqual([snapshots[0]!.editor.schema, snapshots[0]!.editor.schema])
+		expect(snapshots.map(({ docBeforeMount }) => docBeforeMount.firstChild?.attrs.type))
+			.toEqual(['info', 'warn'])
+		expect(createNodeViews).not.toHaveBeenCalled()
+		expect(setProps).not.toHaveBeenCalled()
+		for (const snapshot of snapshots) {
+			expect(snapshot.element).toBeInstanceOf(HTMLElement)
+			expect(el.contains(snapshot.element as Node)).toBe(true)
+			expect(snapshot.contentComponent).not.toBeNull()
+			expect((snapshot.contentComponent?.ctx as unknown as { _: unknown })._).toBe(snapshot.contentComponent)
+			expect(snapshot.appContext).not.toBeNull()
+			const providers = snapshot.appContext!.provides
+			expect(Object.hasOwn(providers, ATTACHMENT_RESOLVER)).toBe(true)
+			expect(Object.hasOwn(providers, EDITOR_UPLOAD)).toBe(true)
+			expect(Reflect.has(providers, OPEN_LINK_HANDLER)).toBe(true)
+			expect(snapshot.docBeforeMount.textContent).toContain(snapshot === snapshots[0] ? 'Before tail' : 'After tail')
+			expect(snapshot.docBeforeMount.textContent).toContain('Unchanged middle')
+
+			const finalPlugins = snapshot.editor.view.state.plugins
+			expect(snapshot.pluginsAfterMount.every((plugin) => finalPlugins.includes(plugin))).toBe(true)
+			const comparisonPlugins = finalPlugins.filter((plugin) => !snapshot.pluginsAfterMount.includes(plugin))
+			expect(comparisonPlugins).toHaveLength(1)
+			snapshot.editor.view.dispatch(snapshot.editor.view.state.tr.setMeta('comparison-lifecycle-test', true))
+			expect(snapshot.editor.state).toBe(snapshot.editor.view.state)
 		}
+
+		comparison.destroy()
+		comparison.destroy()
+		expect(destroy).toHaveBeenCalledTimes(2)
+		expect(snapshots.every(({ editor }) => editor.isDestroyed)).toBe(true)
+		expect(snapshots.every(({ editor }) => editor.contentComponent === null && editor.appContext === null)).toBe(true)
+		expect(el.childElementCount).toBe(0)
+	})
+
+	it('keeps immutable original documents mounted while switching views', async () => {
+		const beforeContent = 'Before one\n\nSame two\n\nSame three\n\nSame four\n\nBefore five'
+		const afterContent = 'After one\n\nSame two\n\nSame three\n\nSame four\n\nAfter five'
+		const expectedBefore = createComparisonEditor(beforeContent)
+		const expectedAfter = createComparisonEditor(afterContent)
+		const editors: Editor[] = []
+		const originalMount = Editor.prototype.mount
+		vi.spyOn(Editor.prototype, 'mount').mockImplementation(function(this: Editor, element) {
+			editors.push(this)
+			originalMount.call(this, element)
+		})
+		const el = document.createElement('div')
+		try {
+			const comparison = await createMarkdownContentComparison({ afterContent, beforeContent, el })
+			try {
+				expect(editors).toHaveLength(2)
+				expect(editors[0]!.state.doc.toJSON()).toEqual(expectedBefore.state.doc.toJSON())
+				expect(editors[1]!.state.doc.toJSON()).toEqual(expectedAfter.state.doc.toJSON())
+
+				const full = [...el.querySelectorAll<HTMLButtonElement>('[role="tab"]')]
+					.find((button) => button.textContent?.includes('Full documents'))!
+				const changes = [...el.querySelectorAll<HTMLButtonElement>('[role="tab"]')]
+					.find((button) => button.textContent?.trim() === 'Changes')!
+
+				full.click()
+				await vi.waitFor(() => expect(full.getAttribute('aria-selected')).toBe('true'))
+				expect(editors[0]!.state.doc.toJSON()).toEqual(expectedBefore.state.doc.toJSON())
+				expect(editors[1]!.state.doc.toJSON()).toEqual(expectedAfter.state.doc.toJSON())
+
+				changes.click()
+				await vi.waitFor(() => expect(changes.getAttribute('aria-selected')).toBe('true'))
+				full.click()
+				await vi.waitFor(() => expect(full.getAttribute('aria-selected')).toBe('true'))
+				expect(editors[0]!.state.doc.toJSON()).toEqual(expectedBefore.state.doc.toJSON())
+				expect(editors[1]!.state.doc.toJSON()).toEqual(expectedAfter.state.doc.toJSON())
+			} finally {
+				comparison.destroy()
+			}
+		} finally {
+			expectedBefore.destroy()
+			expectedAfter.destroy()
+		}
+	})
+
+	it('renders the read-only node-view and provider fidelity inventory', async () => {
+		class ResizeObserverMock {
+			observe() {}
+			disconnect() {}
+			unobserve() {}
+		}
+		vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+		const content = `::: info
+Callout
+:::
+
+<details>
+<summary>Details</summary>
+Content
+</details>
+
+| Column |
+| --- |
+| Cell |
+
+![Image](image.png)
+
+@[Jane](mention://user/jane) and $1 + 1 = 2$.
+
+[Preview](https://preview.test (preview))
+
+[Open link](https://links.test)
+
+\`\`\`js
+const ready = true
+\`\`\``
+		const openLink = vi.fn()
+		const el = document.createElement('div')
+		document.body.append(el)
+		const comparison = await createMarkdownContentComparison({
+			afterContent: content,
+			beforeContent: content,
+			el,
+			noLazyImages: true,
+			openLinkHandler: openLink,
+		})
+		try {
+			for (const editor of el.querySelectorAll('.ProseMirror')) {
+				expect(editor.querySelector('[data-node-view-wrapper][data-text-el="callout"] .callout__icon')).not.toBeNull()
+				expect(editor.querySelector('[data-node-view-wrapper][data-text-el="details"]')).not.toBeNull()
+				expect(editor.querySelector('[data-node-view-wrapper][data-text-el="preview"]')).not.toBeNull()
+				expect(editor.querySelector('[data-node-view-wrapper].mention .mention-user-bubble')).not.toBeNull()
+				expect(editor.querySelector('[data-node-view-wrapper][data-type="inline-math"] .katex-html')).not.toBeNull()
+				expect(editor.querySelector('[data-node-view-wrapper] > figure[data-component="image-view"]')).not.toBeNull()
+				expect(editor.querySelector('[data-node-view-wrapper].code-block')).not.toBeNull()
+				expect(editor.querySelector('table')).not.toBeNull()
+				expect(editor.querySelector('[data-text-el="table-view"]')).toBeNull()
+			}
+			await vi.waitFor(() => {
+				expect(el.querySelectorAll('figure[data-component="image-view"][data-attachment-type="image"]')).toHaveLength(2)
+			})
+			const link = el.querySelector<HTMLAnchorElement>('a[data-text-el="text-only-link"][href="https://links.test"]')!
+			link.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0, cancelable: true, ctrlKey: true }))
+			expect(openLink).toHaveBeenCalledOnce()
+			expect(openLink).toHaveBeenCalledWith('https://links.test/')
+		} finally {
+			comparison.destroy()
+			el.remove()
+		}
+	})
+
+	it('destroys every editor across repeated same-pair reopen', async () => {
+		const mountedEditors: Editor[] = []
+		const originalMount = Editor.prototype.mount
+		const mount = vi.spyOn(Editor.prototype, 'mount').mockImplementation(function(this: Editor, element) {
+			mountedEditors.push(this)
+			originalMount.call(this, element)
+		})
+		const destroy = vi.spyOn(Editor.prototype, 'destroy')
+		const el = document.createElement('div')
+
+		for (let index = 0; index < 2; index++) {
+			const comparison = await createMarkdownContentComparison({
+				afterContent: 'After',
+				beforeContent: 'Before',
+				el,
+			})
+			comparison.destroy()
+			comparison.destroy()
+			expect(el.childElementCount).toBe(0)
+		}
+
+		expect(mount).toHaveBeenCalledTimes(4)
+		expect(destroy).toHaveBeenCalledTimes(4)
+		expect(new Set(mountedEditors).size).toBe(4)
+		expect(mountedEditors.every((editor) => (
+			editor.isDestroyed
+			&& editor.contentComponent === null
+			&& editor.appContext === null
+		))).toBe(true)
+	})
+
+	it('rejects atomically when the second visible mount fails', async () => {
+		const editors: Editor[] = []
+		const originalMount = Editor.prototype.mount
+		vi.spyOn(Editor.prototype, 'mount').mockImplementation(function(this: Editor, element) {
+			editors.push(this)
+			if (editors.length === 2) {
+				throw new Error('second comparison mount failed')
+			}
+			originalMount.call(this, element)
+		})
+		const destroy = vi.spyOn(Editor.prototype, 'destroy')
+		const el = document.createElement('div')
+
+		await expect(createMarkdownContentComparison({
+			afterContent: 'After',
+			beforeContent: 'Before',
+			el,
+		})).rejects.toThrow('second comparison mount failed')
+
+		expect(editors).toHaveLength(2)
+		expect(destroy).toHaveBeenCalledTimes(2)
+		expect(editors.every((editor) => editor.isDestroyed)).toBe(true)
+		expect(el.childElementCount).toBe(0)
+	})
+
+	it('fails loudly and cleans up when live plugin state cannot be established', async () => {
+		const editors: Editor[] = []
+		const originalMount = Editor.prototype.mount
+		vi.spyOn(Editor.prototype, 'mount').mockImplementation(function(this: Editor, element) {
+			editors.push(this)
+			originalMount.call(this, element)
+		})
+		const originalRegisterPlugin = Editor.prototype.registerPlugin
+		vi.spyOn(Editor.prototype, 'registerPlugin').mockImplementation(function(this: Editor, plugin, handlePlugins) {
+			const nextState = originalRegisterPlugin.call(this, plugin, handlePlugins)
+			return nextState.reconfigure({ plugins: nextState.plugins })
+		})
+		const el = document.createElement('div')
+
+		await expect(createMarkdownContentComparison({
+			afterContent: 'After',
+			beforeContent: 'Before',
+			el,
+		})).rejects.toThrow('Comparison editor plugin initialization failed')
+
+		expect(editors).toHaveLength(2)
+		expect(editors.every((editor) => editor.isDestroyed)).toBe(true)
+		expect(el.childElementCount).toBe(0)
 	})
 })

--- a/src/tests/comparison/comparisonEditorLifecycle.spec.ts
+++ b/src/tests/comparison/comparisonEditorLifecycle.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Editor } from '@tiptap/vue-3'
+import { describe, expect, it, vi } from 'vitest'
+import { consumeStateOnlyComparisonEditor } from '../../comparison/comparisonEditorLifecycle.ts'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import EditableTable from '../../nodes/EditableTable.js'
+import Table from '../../nodes/Table.js'
+
+describe('comparison editor lifecycle', () => {
+	it('claims only registered state-only comparison editors once', () => {
+		const comparisonEditor = createComparisonEditor('State only')
+		try {
+			expect(() => consumeStateOnlyComparisonEditor(comparisonEditor)).not.toThrow()
+			expect(() => consumeStateOnlyComparisonEditor(comparisonEditor))
+				.toThrow('Comparison editor plugin initialization failed')
+		} finally {
+			comparisonEditor.destroy()
+		}
+	})
+
+	it('parses the complete read-only document without creating a detached view', () => {
+		const mount = vi.spyOn(Editor.prototype, 'mount')
+		const editor = createComparisonEditor('Before\n\n| A |\n| --- |\n| one |')
+		try {
+			expect(mount).not.toHaveBeenCalled()
+			expect(editor.options.element).toBeNull()
+			expect(editor.state.doc.textContent).toBe('BeforeAone')
+			expect(editor.state.plugins).toEqual([])
+			expect(editor.isDestroyed).toBe(true)
+			expect(() => editor.view.dom).toThrow('editor view is not available')
+			expect(editor.extensionManager.nodeViews.callout).toBeTypeOf('function')
+			const table = editor.extensionManager.extensions.find(({ name }) => name === 'table')
+			expect(table).toBe(Table)
+			expect(table).not.toBe(EditableTable)
+		} finally {
+			editor.destroy()
+			mount.mockRestore()
+		}
+	})
+
+	it('infers text direction while parsing an immutable comparison document', () => {
+		const editor = createComparisonEditor('English\n\nالعربية')
+		try {
+			const directions: Array<string | null> = []
+			editor.state.doc.descendants((node) => {
+				if (node.type.name === 'paragraph') {
+					directions.push(node.attrs.dir as string | null)
+				}
+				return true
+			})
+
+			expect(directions.slice(0, 2)).toEqual(['ltr', 'rtl'])
+			expect(editor.state.plugins).toEqual([])
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('can parse both documents with one schema', () => {
+		const before = createComparisonEditor('::: info\nBefore\n:::')
+		const after = createComparisonEditor('::: warn\nAfter\n:::', { schema: before.schema })
+		try {
+			expect(after.schema).toBe(before.schema)
+			expect(after.extensionManager.schema).toBe(before.schema)
+			expect(after.state.doc.type.schema).toBe(before.state.doc.type.schema)
+			expect(before.state.doc.firstChild?.attrs.type).toBe('info')
+			expect(after.state.doc.firstChild?.attrs.type).toBe('warn')
+		} finally {
+			before.destroy()
+			after.destroy()
+		}
+	})
+})

--- a/src/tests/comparison/comparisonNavigation.spec.ts
+++ b/src/tests/comparison/comparisonNavigation.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonDescriptor } from '../../comparison/markdownComparison.ts'
+
+import { describe, expect, it } from 'vitest'
+import {
+	COMPARISON_CHANGE_KINDS,
+	comparisonChangeKind,
+	currentIdAfterFilter,
+	currentOrdinal,
+	groupComparisonDescriptors,
+	moveCurrentId,
+	visibleDescriptorIds,
+} from '../../comparison/comparisonNavigation.ts'
+
+function descriptor(id: string, facets: ComparisonDescriptor['facets'], operation: ComparisonDescriptor['operation'] = 'replace') {
+	return {
+		id,
+		sourceOrder: Number(id.slice(1)),
+		operation,
+		detail: 'inline',
+		facets,
+		before: { from: 0, to: 1 },
+		after: { from: 0, to: 1 },
+		context: { before: null, after: null },
+		preview: { before: null, after: null },
+		signals: [],
+	} satisfies ComparisonDescriptor
+}
+
+function inBlock(value: ComparisonDescriptor, beforePath: number[], afterPath = beforePath) {
+	return {
+		...value,
+		context: {
+			before: { code: 'paragraph' as const, path: beforePath, from: 0, to: 10 },
+			after: { code: 'paragraph' as const, path: afterPath, from: 0, to: 10 },
+		},
+	}
+}
+
+describe('comparison navigation', () => {
+	const descriptors = [
+		descriptor('c0', ['text']),
+		descriptor('c1', ['formatting']),
+		descriptor('c2', ['text', 'formatting']),
+		descriptor('c3', ['attribute']),
+	]
+
+	it('hides only pure formatting and preserves mixed changes', () => {
+		expect(visibleDescriptorIds(descriptors, true)).toEqual(['c0', 'c2', 'c3'])
+		expect(visibleDescriptorIds(descriptors, false)).toEqual(['c0', 'c1', 'c2', 'c3'])
+	})
+
+	it('preserves a visible selection and falls forward then backward when hidden', () => {
+		expect(currentIdAfterFilter(descriptors, ['c0', 'c2', 'c3'], 'c2')).toBe('c2')
+		expect(currentIdAfterFilter(descriptors, ['c0', 'c2', 'c3'], 'c1')).toBe('c2')
+		expect(currentIdAfterFilter(descriptors, ['c0'], 'c1')).toBe('c0')
+		expect(currentIdAfterFilter(descriptors, [], 'c1')).toBeNull()
+	})
+
+	it('wraps Previous and Next over active IDs and reports their ordinal', () => {
+		const active = ['c0', 'c2', 'c3']
+		expect(moveCurrentId(active, 'c0', -1)).toBe('c3')
+		expect(moveCurrentId(active, 'c3', 1)).toBe('c0')
+		expect(currentOrdinal(active, 'c2')).toBe(2)
+		expect(currentOrdinal([], null)).toBe(0)
+	})
+
+	it('groups multiple algorithm ranges from one changed block without merging their descriptors', () => {
+		const first = inBlock(descriptor('c0', ['text']), [0])
+		const second = inBlock(descriptor('c1', ['text']), [0])
+		const nextBlock = inBlock(descriptor('c2', ['text']), [1])
+		const move = inBlock(descriptor('c3', ['structure'], 'move'), [2])
+
+		expect(groupComparisonDescriptors([first, second, nextBlock, move])).toEqual([
+			{ id: 'c0', descriptors: [first, second] },
+			{ id: 'c2', descriptors: [nextBlock] },
+			{ id: 'c3', descriptors: [move] },
+		])
+	})
+})
+
+describe('comparison change kinds', () => {
+	const mixed = [
+		descriptor('c0', ['text']),
+		descriptor('c1', ['formatting']),
+		descriptor('c2', ['text', 'formatting']),
+		descriptor('c3', ['attribute']),
+		descriptor('c4', ['structure'], 'insert'),
+		descriptor('c5', ['text'], 'move'),
+		descriptor('c6', ['formatting', 'attribute']),
+		descriptor('c7', ['unknown']),
+		descriptor('c8', ['structure'], 'move'),
+	]
+
+	it('presents the four kinds in one stable order', () => {
+		expect(COMPARISON_CHANGE_KINDS).toEqual(['content', 'formatting', 'move', 'other'])
+	})
+
+	it('assigns exactly one kind so counts sum to the descriptor count', () => {
+		const counts = { content: 0, formatting: 0, move: 0, other: 0 }
+		for (const descriptor of mixed) {
+			counts[comparisonChangeKind(descriptor)]++
+		}
+		expect(counts).toEqual({ content: 3, formatting: 1, move: 2, other: 3 })
+		expect(counts.content + counts.formatting + counts.move + counts.other).toBe(mixed.length)
+	})
+
+	it('lets a move win over its own text and content win over its own formatting', () => {
+		expect(comparisonChangeKind(descriptor('c0', ['text'], 'move'))).toBe('move')
+		expect(comparisonChangeKind(descriptor('c0', ['formatting'], 'move'))).toBe('move')
+		expect(comparisonChangeKind(descriptor('c0', ['formatting']))).toBe('formatting')
+		expect(comparisonChangeKind(descriptor('c0', ['text', 'formatting']))).toBe('content')
+		expect(comparisonChangeKind(descriptor('c0', ['text']))).toBe('content')
+		expect(comparisonChangeKind(descriptor('c0', ['structure'], 'delete'))).toBe('content')
+	})
+
+	it('keeps attribute-only, unknown-only, and mixed formatting changes out of the text kinds', () => {
+		expect(comparisonChangeKind(descriptor('c0', ['attribute']))).toBe('other')
+		expect(comparisonChangeKind(descriptor('c0', ['unknown']))).toBe('other')
+		expect(comparisonChangeKind(descriptor('c0', ['attribute', 'unknown']))).toBe('other')
+		expect(comparisonChangeKind(descriptor('c0', ['formatting', 'attribute']))).toBe('other')
+		expect(comparisonChangeKind(descriptor('c0', []))).toBe('other')
+	})
+})

--- a/src/tests/comparison/comparisonPresentation.spec.ts
+++ b/src/tests/comparison/comparisonPresentation.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonAttributeCode, ComparisonSignal } from '../../comparison/markdownComparisonTypes.ts'
+
+import { describe, expect, it } from 'vitest'
+import { selectComparisonSignal } from '../../comparison/comparisonPresentation.ts'
+
+const bold: ComparisonSignal = { type: 'mark', mark: 'bold', change: 'added' }
+
+function attribute(attribute: ComparisonAttributeCode): ComparisonSignal {
+	return { type: 'attribute', attribute, change: 'changed' }
+}
+
+describe('comparison presentation signal priority', () => {
+	it.each([
+		[['image-alt'], 'image-alt'],
+		[['image-target'], 'image-target'],
+		[['image-alt', 'image-target'], 'image-target'],
+	] as const)('selects %s as %s', (attributes, expected) => {
+		const signals = attributes.map(attribute)
+		expect(selectComparisonSignal(signals)).toEqual(attribute(expected))
+		expect(selectComparisonSignal([...signals].reverse())).toEqual(attribute(expected))
+	})
+
+	it.each([
+		'link',
+		'link-target',
+		'task-state',
+		'heading-level',
+		'list-start',
+		'code-language',
+		'text-direction',
+		'table-span',
+		'table-alignment',
+		'mention-identity',
+		'mathematics',
+		'preview-target',
+		'footnote-reference',
+		'callout-type',
+		'details-state',
+		'unknown-attribute',
+	] as const)('prioritizes %s over generic formatting', (code) => {
+		const expected = attribute(code)
+		expect(selectComparisonSignal([bold, expected])).toEqual(expected)
+		expect(selectComparisonSignal([expected, bold])).toEqual(expected)
+	})
+
+	it('prioritizes structure over generic formatting', () => {
+		const node: ComparisonSignal = { type: 'node' }
+		expect(selectComparisonSignal([bold, node])).toEqual(node)
+		expect(selectComparisonSignal([node, bold])).toEqual(node)
+	})
+})

--- a/src/tests/comparison/comparisonSections.spec.ts
+++ b/src/tests/comparison/comparisonSections.spec.ts
@@ -1,0 +1,241 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import { groupComparisonDescriptors } from '../../comparison/comparisonNavigation.ts'
+import {
+	buildComparisonSections,
+	headingLocations,
+	nearestHeading,
+} from '../../comparison/comparisonSections.ts'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import { createMarkdownComparisonModel } from '../../comparison/markdownComparison.ts'
+
+/** @param content Markdown content */
+function documentOf(content: string) {
+	const editor = createComparisonEditor(content)
+	try {
+		return editor.state.doc
+	} finally {
+		editor.destroy()
+	}
+}
+
+/**
+ * @param beforeContent Before Markdown
+ * @param afterContent After Markdown
+ */
+function sectionsOf(beforeContent: string, afterContent: string) {
+	const before = documentOf(beforeContent)
+	const after = documentOf(afterContent)
+	const { descriptors } = createMarkdownComparisonModel(before, after)
+	return buildComparisonSections(groupComparisonDescriptors(descriptors), before, after)
+}
+
+describe('comparison sections', () => {
+	it('lists headings in document order and skips empty ones', () => {
+		const headings = headingLocations(documentOf('# One\n\ntext\n\n#\n\n## Two\n\nmore'))
+		expect(headings.map(({ text }) => text)).toEqual(['One', 'Two'])
+		expect(headings[0]!.from).toBeLessThan(headings[1]!.from)
+	})
+
+	it('resolves the heading at or before a position and none above the first heading', () => {
+		const headings = headingLocations(documentOf('Intro\n\n# One\n\ntext\n\n## Two\n\nmore'))
+		expect(headings.map(({ text }) => text)).toEqual(['One', 'Two'])
+		expect(nearestHeading(headings, 0)).toBe('')
+		expect(nearestHeading(headings, headings[0]!.from - 1)).toBe('')
+		expect(nearestHeading(headings, headings[0]!.from)).toBe('One')
+		expect(nearestHeading(headings, headings[1]!.from - 1)).toBe('One')
+		expect(nearestHeading(headings, headings[1]!.from)).toBe('Two')
+		expect(nearestHeading(headings, headings[1]!.from + 1000)).toBe('Two')
+		expect(nearestHeading([], 7)).toBe('')
+	})
+
+	it('groups changes under the nearest preceding heading', () => {
+		const sections = sectionsOf(
+			'# Alpha\n\nalpha text\n\n# Beta\n\nbeta text',
+			'# Alpha\n\nalpha changed\n\n# Beta\n\nbeta changed',
+		)
+		expect(sections.map(({ title }) => title)).toEqual(['Alpha', 'Beta'])
+	})
+
+	it('names a renamed section by its new heading', () => {
+		const sections = sectionsOf(
+			'# Release plan\n\nBefore objective\n\nBefore owner',
+			'# Launch plan\n\nAfter objective\n\nAfter owner',
+		)
+		expect(sections.map(({ title }) => title)).toEqual(['Launch plan'])
+	})
+
+	it('falls back to the Before document so a deleted section still resolves', () => {
+		const sections = sectionsOf('# Removed\n\nremoved text\n\ncommon tail', 'common tail')
+		expect(headingLocations(documentOf('common tail'))).toEqual([])
+		expect(sections.map(({ title }) => title)).toEqual(['Removed'])
+	})
+
+	it('does not borrow a Before heading for a change that now sits above every heading', () => {
+		// The body moves above the heading. Its After title is '' because it
+		// really is above the first heading there — an answer, not a miss — so
+		// the Before name 'Old' must not stand in for it.
+		const sections = sectionsOf('# Old\n\nbody one', 'body two\n\n# Old')
+		expect(sections[0]?.title).toBe('')
+	})
+
+	it('correlates headings in a document large enough to defeat a quadratic alignment', () => {
+		// 501 and 502 headings: a quadratic table would be 250k cells, and a
+		// cutoff there would fall back to pairing by position, which the early
+		// insertion shifts by one — filing the last section's delete under its
+		// predecessor while the row still claimed the right name.
+		const body = (index: number, value: string) => `# H${index}\n\nbody ${index} ${value}`
+		const beforeSections = Array.from({ length: 501 }, (_, index) => body(index, 'same'))
+		const afterSections = [...beforeSections]
+		afterSections.splice(1, 0, '# Inserted\n\nfresh')
+		beforeSections[500] = '# H500\n\nremove me\n\nstable anchor\n\nold value'
+		afterSections[501] = '# H500\n\nstable anchor\n\nnew value'
+		const sections = sectionsOf(beforeSections.join('\n\n'), afterSections.join('\n\n'))
+		const last = sections.find(({ title }) => title === 'H500')
+		expect(last).toBeDefined()
+		expect(last!.groups.map((group) => group.descriptors[0]!.operation))
+			.toEqual(expect.arrayContaining(['delete', 'replace']))
+		expect(sections.some(({ title }) => title === 'H499')).toBe(false)
+	})
+
+	it('keeps later headings correlated when one is inserted before them', () => {
+		// An inserted heading shifts every later After index by one. Pairing by
+		// position alone would correlate Before's Beta with After's Inserted, so
+		// the delete under Beta would be filed under the new section instead.
+		const sections = sectionsOf(
+			'# Alpha\n\nalpha body\n\n# Beta\n\nremove me\n\nbeta value',
+			'# Alpha\n\nalpha body\n\n# Inserted\n\nfresh\n\n# Beta\n\nbeta VALUE',
+		)
+		const beta = sections.find(({ title }) => title === 'Beta')
+		expect(beta).toBeDefined()
+		expect(beta!.groups.map((group) => group.descriptors[0]!.operation))
+			.toEqual(expect.arrayContaining(['delete', 'replace']))
+		expect(sections.find(({ title }) => title === 'Inserted')!.groups
+			.every((group) => group.descriptors[0]!.operation === 'insert')).toBe(true)
+	})
+
+	it('does not correlate an unequal ambiguous heading gap by position', () => {
+		const sections = sectionsOf(
+			'# Start\n\nstable start\n\n# Old\n\nremove one\n\nremove two\n\nstable anchor\n\nold value\n\n# End\n\nstable end',
+			'# Start\n\nstable start\n\n# Inserted\n\nfresh\n\n# New\n\nstable anchor\n\nnew value\n\n# End\n\nstable end',
+		)
+		const inserted = sections.find(({ title }) => title === 'Inserted')
+		const old = sections.find(({ title }) => title === 'Old')
+
+		expect(inserted).toBeDefined()
+		expect(inserted!.groups.map((group) => group.descriptors[0]!.operation)).not.toContain('delete')
+		expect(old).toBeDefined()
+		expect(old!.groups.map((group) => group.descriptors[0]!.operation)).toContain('delete')
+	})
+
+	it('does not correlate a multi-heading ambiguous gap by position', () => {
+		const sections = sectionsOf(
+			'# Start\n\nstable start\n\n# Removed\n\nremove one\n\nremove two\n\n# Old\n\nstable anchor\n\nold value\n\n# End\n\nstable end',
+			'# Start\n\nstable start\n\n# Inserted\n\nfresh\n\n# New\n\nstable anchor\n\nnew value\n\n# End\n\nstable end',
+		)
+		const inserted = sections.find(({ title }) => title === 'Inserted')
+		const removed = sections.find(({ title }) => title === 'Removed')
+
+		expect(inserted).toBeDefined()
+		expect(inserted!.groups.map((group) => group.descriptors[0]!.operation)).not.toContain('delete')
+		expect(removed).toBeDefined()
+		expect(removed!.groups.map((group) => group.descriptors[0]!.operation)).toContain('delete')
+	})
+
+	it('does not correlate two renamed headings only because their counts match', () => {
+		const sections = sectionsOf(
+			'# Start\n\nstable start\n\n# Old one\n\nremove one\n\nstable anchor one\n\nold value one\n\n# Old two\n\nremove two\n\nstable anchor two\n\nold value two\n\n# End\n\nstable end',
+			'# Start\n\nstable start\n\n# New one\n\nstable anchor one\n\nnew value one\n\n# New two\n\nstable anchor two\n\nnew value two\n\n# End\n\nstable end',
+		)
+		const titles = sections.map(({ title }) => title)
+
+		expect(titles).toEqual(expect.arrayContaining(['Old one', 'Old two', 'New one', 'New two']))
+		expect(sections.find(({ title }) => title === 'Old one')!.groups
+			.some((group) => group.descriptors[0]!.operation === 'delete')).toBe(true)
+		expect(sections.find(({ title }) => title === 'New one')!.groups
+			.some((group) => group.descriptors[0]!.operation === 'delete')).toBe(false)
+	})
+
+	it('correlates a renamed heading instead of splitting it in three', () => {
+		// The heading change and the replacement resolve from After as New, the
+		// delete from Before as Old. Correlating only on title would report New,
+		// Old, New for what is one section under a new name.
+		const sections = sectionsOf(
+			'# Old\n\nremove me\n\nstable anchor\n\nold value',
+			'# New\n\nstable anchor\n\nnew value',
+		)
+		expect(sections.map(({ title }) => title)).toEqual(['New'])
+	})
+
+	it('keeps a delete and a replace under one heading in the same section', () => {
+		// The delete resolves from Before and the replace from After. If the key
+		// carried the document side, one unchanged heading would split into two
+		// sections with the same title.
+		const sections = sectionsOf(
+			'# Alpha\n\nremove me\n\nstable anchor\n\nold value',
+			'# Alpha\n\nstable anchor\n\nnew value',
+		)
+		expect(sections).toHaveLength(1)
+		expect(sections[0]!.title).toBe('Alpha')
+		expect(sections[0]!.groups.map((group) => group.descriptors[0]!.operation))
+			.toEqual(expect.arrayContaining(['delete', 'replace']))
+	})
+
+	it('keeps a repeated heading separate even when nothing changed between them', () => {
+		// The middle section produces no group, so the two Alpha runs become
+		// adjacent. Matching on heading text alone merges them into one section
+		// spanning two different places in the document; matching on which
+		// heading does not.
+		const sections = sectionsOf(
+			'# Alpha\n\nalpha one\n\n# Beta\n\nbeta same\n\n# Alpha\n\nalpha two',
+			'# Alpha\n\nalpha ONE\n\n# Beta\n\nbeta same\n\n# Alpha\n\nalpha TWO',
+		)
+		expect(sections.map(({ title }) => title)).toEqual(['Alpha', 'Alpha'])
+		expect(new Set(sections.map(({ id }) => id)).size).toBe(2)
+	})
+
+	it('keeps a repeated heading as separate runs rather than one merged section', () => {
+		const sections = sectionsOf(
+			'# Alpha\n\nalpha one\n\n# Beta\n\nbeta one\n\n# Alpha\n\nalpha two',
+			'# Alpha\n\nalpha five\n\n# Beta\n\nbeta five\n\n# Alpha\n\nalpha nine',
+		)
+		expect(sections.map(({ title }) => title)).toEqual(['Alpha', 'Beta', 'Alpha'])
+		expect(sections.filter(({ title }) => title === 'Alpha')).toHaveLength(2)
+		expect(new Set(sections.map(({ id }) => id)).size).toBe(3)
+	})
+
+	it('leaves changes above the first heading without a section title', () => {
+		const sections = sectionsOf(
+			'intro before\n\n# Alpha\n\nalpha one',
+			'intro after\n\n# Alpha\n\nalpha two',
+		)
+		expect(sections.map(({ title }) => title)).toEqual(['', 'Alpha'])
+	})
+
+	it('reports the kinds in stable order and the first group ID', () => {
+		const [section, ...rest] = sectionsOf(
+			'# Alpha\n\nplain text\n\nsecond line',
+			'# Alpha\n\nplain **text**\n\nsecond changed',
+		)
+		expect(rest).toEqual([])
+		// Formatting changed first in the document, but kinds keep presentation order.
+		expect(section!.kinds).toEqual(['content', 'formatting'])
+		expect(section!.groups).toHaveLength(2)
+		expect(section!.id).toBe(section!.groups[0]!.id)
+	})
+
+	it('derives section kinds from grouped descriptors', () => {
+		const [section, ...rest] = sectionsOf(
+			'# Alpha\n\none alpha two beta three',
+			'# Alpha\n\none gamma two delta three',
+		)
+		expect(rest).toEqual([])
+		expect(section!.groups).toHaveLength(1)
+		expect(section!.groups[0]!.descriptors).toHaveLength(2)
+		expect(section!.kinds).toEqual(['content'])
+	})
+})

--- a/src/tests/comparison/comparisonStyles.spec.ts
+++ b/src/tests/comparison/comparisonStyles.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { compileString } from 'sass'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Compile one component's style block.
+ *
+ * These contracts live in the cascade rather than in the DOM, so jsdom cannot
+ * see them: it applies no component CSS, and every assertion made through
+ * `getComputedStyle` there would pass whatever the stylesheet said.
+ *
+ * @param component Component file name
+ */
+function compileComponentStyles(component: string) {
+	const source = readFileSync(resolve(process.cwd(), 'src/components', component), 'utf8')
+	const block = source.match(/<style lang="scss">([\s\S]*?)<\/style>/)
+	expect(block, `${component} has a SCSS style block`).not.toBeNull()
+	return compileString(block![1]!.replace(/@use[^;]+;/gu, '')).css
+}
+
+describe('comparison stylesheet contracts', () => {
+	const contentStyles = compileComponentStyles('MarkdownContentComparison.vue')
+	const listStyles = compileComponentStyles('ComparisonChangeList.vue')
+	const sourceStyles = compileComponentStyles('MarkdownSourceComparison.vue')
+
+	it('never paints with a colour variable Nextcloud does not define', () => {
+		// --color-error-light, --color-success-light and --color-warning-light
+		// exist nowhere in the server. Using one makes the whole declaration
+		// invalid, so the mark silently renders with no fill at all.
+		for (const [name, css] of Object.entries({ contentStyles, listStyles, sourceStyles })) {
+			expect(css, name).not.toMatch(/--color-(error|success|warning|info|primary)-light\b/u)
+		}
+	})
+
+	it('leaves a moved block on the relocation colour', () => {
+		// A moved block node carries both --move and --block. The block rule is
+		// later and more specific, so without an exclusion it repaints
+		// relocation with the warning tokens.
+		const blockRule = contentStyles
+			.split('}')
+			.find((rule) => rule.includes('.text-comparison-change--block'))
+		expect(blockRule).toBeDefined()
+		expect(blockRule).toContain('.text-comparison-change--move')
+	})
+
+	it('outranks the global bare-button rule on the list controls', () => {
+		// core/css/inputs.scss styles every <button> at (0,1,1) — width 130px,
+		// its own border, padding, background and cursor. A single-class
+		// selector loses to it.
+		for (const control of ['__section-toggle', '__change-item']) {
+			expect(listStyles).toContain(`.text-comparison .text-comparison${control} {`)
+			expect(listStyles).not.toContain(`\n.text-comparison${control} {`)
+		}
+	})
+})

--- a/src/tests/comparison/createMarkdownContentComparison.spec.ts
+++ b/src/tests/comparison/createMarkdownContentComparison.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import { RENDERED_COMPARISON_LIMITS } from '../../comparison/renderedComparisonLimit.ts'
+import { createMarkdownContentComparison } from '../../createMarkdownContentComparison.ts'
+
+describe('createMarkdownContentComparison', { timeout: 30_000 }, () => {
+	it.each([
+		[{ beforeContent: null, afterContent: '' }],
+		[{ beforeContent: '', afterContent: undefined }],
+	])('rejects missing comparison content', async (content) => {
+		await expect(createMarkdownContentComparison({
+			el: document.createElement('div'),
+			...content,
+		} as never)).rejects.toThrow('must be strings')
+	})
+
+	it('shows one concise empty state for identical snapshots', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			afterContent: '# Same',
+			beforeContent: '# Same',
+			el,
+		})
+
+		expect(el.querySelector('[data-comparison-empty="identical"]')?.textContent)
+			.toContain('No differences.')
+		expect(el.querySelectorAll('.text-comparison__empty')).toHaveLength(1)
+		comparison.destroy()
+		expect(el.querySelector('.text-comparison-root')).toBeNull()
+	})
+
+	it('preserves every inline preview when one paragraph contains multiple edits', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			afterContent: 'Keep new middle fresh end',
+			beforeContent: 'Keep old middle stale end',
+			el,
+		})
+
+		expect(el.querySelectorAll('.text-comparison__change-item')).toHaveLength(1)
+		expect([...el.querySelectorAll('del')].map(({ textContent }) => textContent)).toEqual(['old', 'stale'])
+		expect([...el.querySelectorAll('ins')].map(({ textContent }) => textContent)).toEqual(['new', 'fresh'])
+		comparison.destroy()
+	})
+
+	it('filters formatting-only changes without losing an explicit empty state', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			afterContent: 'plain **text**',
+			beforeContent: 'plain text',
+			el,
+		})
+		const filter = el.querySelector<HTMLInputElement>('input[type="checkbox"]')!
+
+		filter.checked = true
+		filter.dispatchEvent(new Event('change', { bubbles: true }))
+		await nextTick()
+
+		expect(el.querySelector('[data-comparison-empty="filtered"]')?.textContent)
+			.toContain('formatting-only')
+		comparison.destroy()
+	})
+
+	it('rejects oversized rendered work before parsing it', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			afterContent: 'x'.repeat(RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot + 1),
+			beforeContent: '',
+			el,
+		})
+
+		expect(el.querySelector('[data-comparison-rendered-limit]')?.textContent)
+			.toContain('too large')
+		comparison.destroy()
+	})
+})

--- a/src/tests/comparison/createMarkdownContentComparison.spec.ts
+++ b/src/tests/comparison/createMarkdownContentComparison.spec.ts
@@ -3,10 +3,120 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { describe, expect, it } from 'vitest'
-import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MAX_RENDERED_COMPARISON_DESCRIPTORS } from '../../comparison/hierarchicalMarkdownComparisonModel.ts'
 import { RENDERED_COMPARISON_LIMITS } from '../../comparison/renderedComparisonLimit.ts'
 import { createMarkdownContentComparison } from '../../createMarkdownContentComparison.ts'
+import {
+	ATLAS_CURRENT_CONTENT,
+	ATLAS_INITIAL_CONTENT,
+} from './fixtures/atlasComparison.ts'
+
+const originalScrollTo = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollTo')
+
+beforeEach(() => {
+	Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+		configurable: true,
+		value: vi.fn(),
+		writable: true,
+	})
+})
+
+afterEach(() => {
+	vi.restoreAllMocks()
+	vi.unstubAllGlobals()
+	if (originalScrollTo) {
+		Object.defineProperty(HTMLElement.prototype, 'scrollTo', originalScrollTo)
+	} else {
+		delete (HTMLElement.prototype as { scrollTo?: typeof HTMLElement.prototype.scrollTo }).scrollTo
+	}
+})
+
+/**
+ * @param root Comparison host
+ * @param label Exact tab label
+ */
+function tab(root: HTMLElement, label: string) {
+	const match = [...root.querySelectorAll<HTMLButtonElement>('.text-comparison__view-tabs [role="tab"]')]
+		.find((button) => button.textContent?.trim() === label)
+	expect(match, `Missing ${label} tab`).toBeDefined()
+	return match!
+}
+
+/**
+ * @param root Comparison host
+ * @param text Visible button text
+ */
+function button(root: HTMLElement, text: string) {
+	const match = [...root.querySelectorAll<HTMLButtonElement>('button')]
+		.find((candidate) => candidate.textContent?.includes(text))
+	expect(match, `Missing ${text} button`).toBeDefined()
+	return match!
+}
+
+/**
+ * @param root Comparison host
+ * @param label Exact single-pane tab label
+ */
+function sideTab(root: HTMLElement, label: string) {
+	const match = [...root.querySelectorAll<HTMLButtonElement>('.text-comparison__side-tabs [role="tab"]')]
+		.find((candidate) => candidate.textContent?.trim() === label)
+	expect(match, `Missing ${label} side tab`).toBeDefined()
+	return match!
+}
+
+/**
+ * @param root Comparison host
+ * @param checked Desired filter state
+ */
+function setFormattingFilter(root: HTMLElement, checked: boolean) {
+	const filter = root.querySelector<HTMLInputElement>('input[type="checkbox"]')!
+	filter.checked = checked
+	filter.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+/**
+ * Give one document target deterministic pane-local geometry.
+ *
+ * @param root Comparison host
+ * @param side Document side
+ * @param id Descriptor ID
+ * @param targetTop Target viewport top
+ * @param initialScrollTop Initial pane scroll
+ */
+function documentGeometry(
+	root: HTMLElement,
+	side: 'before' | 'after',
+	id: string,
+	targetTop: number,
+	initialScrollTop: number,
+) {
+	const pane = root.querySelector<HTMLElement>(`.text-comparison__document--${side}`)!
+	const scroller = pane.querySelector<HTMLElement>('.text-comparison__document-scroller')!
+	const target = [...pane.querySelectorAll<HTMLElement>('[data-comparison-change]')]
+		.find((candidate) => candidate.dataset.comparisonChange === id)!
+	expect(target).toBeDefined()
+	Object.defineProperties(scroller, {
+		clientHeight: { configurable: true, value: 400 },
+		scrollHeight: { configurable: true, value: 3000 },
+		scrollTop: { configurable: true, value: initialScrollTop, writable: true },
+	})
+	vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue({
+		bottom: 500,
+		height: 400,
+		top: 100,
+	} as DOMRect)
+	vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({
+		bottom: targetTop + 20,
+		height: 20,
+		top: targetTop,
+	} as DOMRect)
+	const scrollTo = vi.fn((options: ScrollToOptions) => {
+		scroller.scrollTop = options.top ?? scroller.scrollTop
+	})
+	Object.defineProperty(scroller, 'scrollTo', { configurable: true, value: scrollTo })
+	return { pane, scroller, scrollTo, target }
+}
 
 describe('createMarkdownContentComparison', { timeout: 30_000 }, () => {
 	it.each([
@@ -19,63 +129,615 @@ describe('createMarkdownContentComparison', { timeout: 30_000 }, () => {
 		} as never)).rejects.toThrow('must be strings')
 	})
 
-	it('shows one concise empty state for identical snapshots', async () => {
+	it('defaults identical snapshots to Changes with one concise empty state', async () => {
+		const el = document.createElement('div')
+		const onLoaded = vi.fn()
+		const comparison = await createMarkdownContentComparison({
+			afterContent: '',
+			beforeContent: '',
+			el,
+			onLoaded,
+		})
+
+		expect(onLoaded).toHaveBeenCalledOnce()
+		expect(tab(el, 'Changes').getAttribute('aria-selected')).toBe('true')
+		expect(el.querySelector('[data-comparison-empty="identical"]')?.textContent).toContain('No differences.')
+		expect(el.querySelector('[data-comparison-empty-action]')).toBeNull()
+		expect(Object.keys(comparison)).toEqual(['destroy'])
+		comparison.destroy()
+		comparison.destroy()
+		expect(el.childElementCount).toBe(0)
+	})
+
+	it('skips rendered editors above the pre-parse limit and reports the boundary', async () => {
+		const el = document.createElement('div')
+		const beforeContent = 'x'.repeat(RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot + 1)
+		const comparison = await createMarkdownContentComparison({
+			afterContent: 'After',
+			beforeContent,
+			el,
+		})
+
+		expect(el.querySelector('[data-comparison-rendered-limit]')?.textContent)
+			.toContain('too large for rendered views')
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(0)
+		comparison.destroy()
+	})
+	it('reports when semantic change density reaches the model limit', async () => {
+		const el = document.createElement('div')
+		const itemCount = Math.floor(MAX_RENDERED_COMPARISON_DESCRIPTORS / 8) + 1
+		const beforeContent = Array.from({ length: itemCount }, () => '- [ ] a x a x a x a x a x a x a x a x').join('\n')
+		const afterContent = Array.from({ length: itemCount }, () => '- [ ] b x b x b x b x b x b x b x b x').join('\n')
+		const comparison = await createMarkdownContentComparison({ afterContent, beforeContent, el })
+
+		expect(el.querySelector('[data-comparison-rendered-limit]')?.textContent)
+			.toContain('too many changes for rendered views')
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(0)
+		comparison.destroy()
+	})
+	it('reports syntax-only Markdown without inventing rendered changes', async () => {
 		const el = document.createElement('div')
 		const comparison = await createMarkdownContentComparison({
-			afterContent: '# Same',
+			afterContent: '# Same #',
 			beforeContent: '# Same',
 			el,
 		})
 
-		expect(el.querySelector('[data-comparison-empty="identical"]')?.textContent)
-			.toContain('No differences.')
-		expect(el.querySelectorAll('.text-comparison__empty')).toHaveLength(1)
+		expect(el.querySelector('[data-comparison-empty="syntax"]')?.textContent)
+			.toContain('No rendered differences — Markdown syntax differs.')
+		expect(el.querySelectorAll('.text-comparison__change-item')).toHaveLength(0)
 		comparison.destroy()
-		expect(el.querySelector('.text-comparison-root')).toBeNull()
+	})
+	it('uses two peer ARIA tabs with wrapping Arrow, Home, and End behavior', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			afterContent: 'After',
+			beforeContent: 'Before',
+			el,
+		})
+		const tabs = [...el.querySelectorAll<HTMLButtonElement>('.text-comparison__view-tabs [role="tab"]')]
+
+		expect(tabs.map(({ textContent }) => textContent?.trim())).toEqual(['Changes', 'Full documents'])
+		tab(el, 'Changes').dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }))
+		await vi.waitFor(() => expect(tab(el, 'Full documents').getAttribute('aria-selected')).toBe('true'))
+		tab(el, 'Full documents').dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }))
+		await vi.waitFor(() => expect(tab(el, 'Changes').getAttribute('aria-selected')).toBe('true'))
+		tab(el, 'Changes').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+		await vi.waitFor(() => expect(tab(el, 'Full documents').getAttribute('aria-selected')).toBe('true'))
+		tab(el, 'Full documents').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+		await vi.waitFor(() => expect(tab(el, 'Changes').getAttribute('aria-selected')).toBe('true'))
+		comparison.destroy()
+	})
+	it('renders Atlas as one compact, complete, ordered changelog', async () => {
+		class ResizeObserverMock {
+			observe() {}
+			disconnect() {}
+			unobserve() {}
+		}
+		vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+		const el = document.createElement('div')
+		document.body.append(el)
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: ATLAS_INITIAL_CONTENT,
+			afterContent: ATLAS_CURRENT_CONTENT,
+			el,
+		})
+		const list = el.querySelector('.text-comparison__change-list')!
+		const records = [...list.querySelectorAll<HTMLElement>('[data-comparison-select]')]
+		expect(records.length).toBeLessThan(35)
+		expect(records.length).toBeGreaterThan(10)
+		expect(el.querySelector('.text-comparison__changes-count')?.textContent).toContain(`${records.length} changes`)
+		for (const record of records) {
+			expect(record.querySelector('.text-comparison__operation')).not.toBeNull()
+			expect(record.querySelector('.text-comparison__change-label')?.textContent?.trim()).not.toBe('')
+			expect(record.querySelector('.text-comparison__change-context')?.textContent?.trim()).not.toBe('')
+			expect(record.querySelector('.text-comparison__preview')?.textContent?.trim()).not.toBe('')
+			expect(record.getAttribute('aria-label')).toContain(record.querySelector('.text-comparison__preview')?.textContent?.trim())
+			const blockLevel = Boolean(record.querySelector('.text-comparison__detail-badge'))
+			expect(record.getAttribute('aria-label')?.includes('Block-level; fine inline detail is unavailable'))
+				.toBe(blockLevel)
+		}
+		expect(records.some((record) => record.textContent?.includes('edits'))).toBe(true)
+		expect(records[0]?.getAttribute('aria-current')).toBe('true')
+		comparison.destroy()
+		el.remove()
 	})
 
 	it('preserves every inline preview when one paragraph contains multiple edits', async () => {
 		const el = document.createElement('div')
 		const comparison = await createMarkdownContentComparison({
-			afterContent: 'Keep new middle fresh end',
 			beforeContent: 'Keep old middle stale end',
+			afterContent: 'Keep new middle fresh end',
 			el,
 		})
-
-		expect(el.querySelectorAll('.text-comparison__change-item')).toHaveLength(1)
-		expect([...el.querySelectorAll('del')].map(({ textContent }) => textContent)).toEqual(['old', 'stale'])
-		expect([...el.querySelectorAll('ins')].map(({ textContent }) => textContent)).toEqual(['new', 'fresh'])
+		const records = [...el.querySelectorAll<HTMLElement>('[data-comparison-select]')]
+		expect(records).toHaveLength(1)
+		expect(records[0]!.querySelector('.text-comparison__change-label')?.textContent).toContain('2 edits')
+		expect([...records[0]!.querySelectorAll('del')].map(({ textContent }) => textContent)).toEqual(['old', 'stale'])
+		expect([...records[0]!.querySelectorAll('ins')].map(({ textContent }) => textContent)).toEqual(['new', 'fresh'])
+		expect(records[0]!.getAttribute('aria-label')).toContain('old → new')
+		expect(records[0]!.getAttribute('aria-label')).toContain('stale → fresh')
 		comparison.destroy()
 	})
 
-	it('filters formatting-only changes without losing an explicit empty state', async () => {
+	it('uses a heading rename only on the heading row and names its section once above the rows', async () => {
 		const el = document.createElement('div')
 		const comparison = await createMarkdownContentComparison({
-			afterContent: 'plain **text**',
-			beforeContent: 'plain text',
+			beforeContent: '# Release plan\n\nBefore objective\n\nBefore owner',
+			afterContent: '# Launch plan\n\nAfter objective\n\nAfter owner',
 			el,
 		})
-		const filter = el.querySelector<HTMLInputElement>('input[type="checkbox"]')!
-
-		filter.checked = true
-		filter.dispatchEvent(new Event('change', { bubbles: true }))
-		await nextTick()
-
-		expect(el.querySelector('[data-comparison-empty="filtered"]')?.textContent)
-			.toContain('formatting-only')
+		const records = [...el.querySelectorAll<HTMLElement>('[data-comparison-select]')]
+		const heading = records.find((record) => record.querySelector('.text-comparison__change-label')?.textContent?.includes('Heading'))
+		expect(heading?.querySelector('.text-comparison__change-context')?.textContent)
+			.toBe('Release plan → Launch plan')
+		// The renamed section is named once, by its heading, rather than repeated on every row.
+		expect([...el.querySelectorAll<HTMLElement>('.text-comparison__section-title')]
+			.map((section) => section.textContent?.trim()))
+			.toEqual(['Launch plan'])
+		const descendants = records.filter((record) => record !== heading)
+		expect(descendants).toHaveLength(2)
+		expect(descendants.every((record) => record.querySelector('.text-comparison__change-context')?.textContent === 'Paragraph'))
+			.toBe(true)
 		comparison.destroy()
 	})
 
-	it('rejects oversized rendered work before parsing it', async () => {
+	it('does not describe an inserted heading as a rename from its absent-side anchor', async () => {
 		const el = document.createElement('div')
 		const comparison = await createMarkdownContentComparison({
-			afterContent: 'x'.repeat(RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot + 1),
-			beforeContent: '',
+			beforeContent: '# Alpha\n\nalpha body\n\n# Beta\n\nbeta body',
+			afterContent: '# Alpha\n\nalpha body\n\n# Inserted\n\nfresh body\n\n# Beta\n\nbeta body',
 			el,
 		})
+		const heading = [...el.querySelectorAll<HTMLElement>('[data-comparison-select]')]
+			.find((record) => record.querySelector('.text-comparison__change-label')?.textContent === 'Heading added')
 
-		expect(el.querySelector('[data-comparison-rendered-limit]')?.textContent)
-			.toContain('too large')
+		expect(heading).toBeDefined()
+		expect(heading!.querySelector('.text-comparison__change-context')?.textContent).toBe('Heading')
+		expect(heading!.getAttribute('aria-label')).not.toContain('Beta → Inserted')
 		comparison.destroy()
+	})
+
+	it('names a deleted paragraph by what it was, not by where it collapsed to', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: '# Alpha\n\nremove me\n\nstable anchor',
+			afterContent: '# Alpha\n\nstable anchor',
+			el,
+		})
+		const labels = [...el.querySelectorAll<HTMLElement>('[data-comparison-select]')]
+			.map((record) => record.querySelector('.text-comparison__change-label')?.textContent)
+		// A delete's After context is the heading it collapsed into, so reading
+		// that side reports a removed paragraph as "Heading removed".
+		expect(labels).toContain('Paragraph removed')
+		expect(labels).not.toContain('Heading removed')
+		comparison.destroy()
+	})
+
+	it('leads with the label when the passage reads the same on both sides', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: 'Follow the [operator runbook](https://example.invalid/a).',
+			afterContent: 'Follow the [operator runbook](https://example.invalid/b).',
+			el,
+		})
+		const record = [...el.querySelectorAll<HTMLElement>('[data-comparison-select]')]
+			.find((candidate) => candidate.querySelector('.text-comparison__change-label')?.textContent === 'Link target changed')
+		expect(record).toBeDefined()
+		// Only the href moved, so the row must not read "operator runbook → operator runbook"
+		// with the words in its most prominent slot and the actual change buried beneath.
+		expect(record!.querySelector('.text-comparison__preview')?.textContent).not.toContain('→')
+		expect(record!.getAttribute('aria-label')).not.toContain('operator runbook → operator runbook')
+		expect([...record!.querySelector('.text-comparison__change-copy')!.classList])
+			.toContain('text-comparison__change-copy--label-first')
+		comparison.destroy()
+	})
+
+	it('exposes each section as a heading whose name carries the kinds its swatch shows', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: '# Alpha\n\nplain body text\n\n# Beta\n\nuntouched tail',
+			afterContent: '# Alpha\n\nrewritten body text\n\n# Beta\n\nuntouched tail',
+			el,
+		})
+		const toggle = el.querySelector<HTMLElement>('[data-comparison-section]')!
+		expect(toggle.closest('h3')).not.toBeNull()
+		expect(toggle.getAttribute('aria-expanded')).toBe('true')
+		// The coloured dots are aria-hidden, so the kinds must survive in the name.
+		expect(toggle.getAttribute('aria-label')).toContain('Alpha')
+		expect(toggle.getAttribute('aria-label')).toContain('Content')
+		expect(el.querySelectorAll('.text-comparison__kind-dot').length).toBeGreaterThan(0)
+		comparison.destroy()
+	})
+
+	it('distinguishes repeated semantic labels by section heading and preview', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: '# Alpha\n\n- [ ] Publish alpha\n\n# Beta\n\n- [ ] Publish beta',
+			afterContent: '# Alpha\n\n- [x] Publish alpha\n\n# Beta\n\n- [x] Publish beta',
+			el,
+		})
+		expect([...el.querySelectorAll<HTMLElement>('.text-comparison__section-title')]
+			.map((section) => section.textContent?.trim()))
+			.toEqual(expect.arrayContaining(['Alpha', 'Beta']))
+		const records = [...el.querySelectorAll<HTMLElement>('[data-comparison-select]')]
+			.filter((record) => record.querySelector('.text-comparison__change-label')?.textContent === 'Task state changed')
+		expect(records).toHaveLength(2)
+		expect(new Set(records.map((record) => record.querySelector('.text-comparison__preview')?.textContent)).size).toBe(2)
+		// The section reaches assistive technology once, through the group each
+		// row sits in, rather than being repeated on every row's own label.
+		const sections = records.map((record) => {
+			const group = record.closest('[role="group"]')!
+			return el.querySelector(`[id="${group.getAttribute('aria-labelledby')}"]`)?.textContent ?? ''
+		})
+		expect(sections[0]).toContain('Alpha')
+		expect(sections[1]).toContain('Beta')
+		expect(records.every((record) => !record.getAttribute('aria-label')?.includes('Section:'))).toBe(true)
+		comparison.destroy()
+	})
+
+	it('shows Block-level only for coarse descriptors', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: `Before ${'a'.repeat(4600)}\n\nKeep before`,
+			afterContent: `After ${'b'.repeat(4600)}\n\nKeep after`,
+			el,
+		})
+		const records = [...el.querySelectorAll<HTMLElement>('[data-comparison-select]')]
+		expect(records.some((record) => record.querySelector('.text-comparison__detail-badge'))).toBe(true)
+		expect(records.some((record) => !record.querySelector('.text-comparison__detail-badge'))).toBe(true)
+		for (const record of records) {
+			const badge = record.querySelector('.text-comparison__detail-badge')
+			if (badge) {
+				expect(badge.textContent).toBe('Block-level')
+				expect(record.getAttribute('aria-label')).toContain('Block-level; fine inline detail is unavailable')
+			}
+		}
+		comparison.destroy()
+	})
+
+	it('filters formatting records with deterministic next-then-previous fallback', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: 'Plain first\n\nKeep second\n\nBefore third',
+			afterContent: '**Plain first**\n\nKeep second\n\nAfter third',
+			el,
+		})
+		const records = [...el.querySelectorAll<HTMLButtonElement>('[data-comparison-select]')]
+		const formatting = records.find((record) => record.textContent?.includes('Bold added'))!
+		expect(formatting).toBeDefined()
+		expect(formatting.querySelector('.text-comparison__preview')?.textContent?.trim()).toBe('Plain first')
+		expect(formatting.getAttribute('aria-label')).not.toContain('→')
+		const formattingIndex = records.indexOf(formatting)
+		const expected = records.slice(formattingIndex + 1).find((record) => record !== formatting)
+			?? records.slice(0, formattingIndex).at(-1)!
+		formatting.click()
+		await vi.waitFor(() => expect(tab(el, 'Full documents').getAttribute('aria-selected')).toBe('true'))
+		tab(el, 'Changes').click()
+		await vi.waitFor(() => expect(tab(el, 'Changes').getAttribute('aria-selected')).toBe('true'))
+		setFormattingFilter(el, true)
+		await vi.waitFor(() => expect(el.querySelector(`[data-comparison-select="${formatting.dataset.comparisonSelect}"]`)).toBeNull())
+		expect(el.querySelector('[aria-current="true"][data-comparison-select]')?.getAttribute('data-comparison-select'))
+			.toBe(expected.dataset.comparisonSelect)
+		comparison.destroy()
+	})
+
+	it('replaces a pending single-pane target when filtering its descriptor', async () => {
+		const callbacks: ResizeObserverCallback[] = []
+		class ResizeObserverMock {
+			constructor(callback: ResizeObserverCallback) { callbacks.push(callback) }
+			observe() {}
+			disconnect() {}
+			unobserve() {}
+		}
+		vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+		const el = document.createElement('div')
+		document.body.append(el)
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: 'Plain first\n\nBefore second',
+			afterContent: '**Plain first**\n\nAfter second',
+			el,
+		})
+		callbacks[0]!([{ contentRect: { width: 700 } } as ResizeObserverEntry], {} as ResizeObserver)
+		await Promise.resolve()
+		const records = [...el.querySelectorAll<HTMLButtonElement>('[data-comparison-select]')]
+		const formatting = records.find((record) => record.textContent?.includes('Bold added'))!
+		const formattingIndex = records.indexOf(formatting)
+		const fallback = records.slice(formattingIndex + 1).find((record) => record !== formatting)
+			?? records.slice(0, formattingIndex).at(-1)!
+		const afterGeometry = documentGeometry(el, 'after', fallback.dataset.comparisonSelect!, 900, 0)
+
+		formatting.click()
+		await vi.waitFor(() => expect(tab(el, 'Full documents').getAttribute('aria-selected')).toBe('true'))
+		expect(afterGeometry.scrollTo).not.toHaveBeenCalled()
+		tab(el, 'Changes').click()
+		await vi.waitFor(() => expect(tab(el, 'Changes').getAttribute('aria-selected')).toBe('true'))
+		setFormattingFilter(el, true)
+		await vi.waitFor(() => expect(el.querySelector('[aria-current="true"][data-comparison-select]')?.getAttribute('data-comparison-select'))
+			.toBe(fallback.dataset.comparisonSelect))
+		tab(el, 'Full documents').click()
+		sideTab(el, 'After').click()
+		await vi.waitFor(() => expect(afterGeometry.scrollTo).toHaveBeenCalledOnce())
+
+		comparison.destroy()
+		el.remove()
+	})
+
+	it('shows a focused filtered-empty state for formatting-only changes', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: 'Release ready',
+			afterContent: 'Release **ready**',
+			el,
+		})
+		setFormattingFilter(el, true)
+		await vi.waitFor(() => expect(el.querySelector('[data-comparison-empty="filtered"]')?.textContent)
+			.toContain('All rendered changes are formatting-only and hidden'))
+		expect(el.querySelector('[data-comparison-select]')).toBeNull()
+		expect(el.querySelector('[data-comparison-change]')).toBeNull()
+		comparison.destroy()
+	})
+
+	it('selecting a distant move opens Full documents and independently centers both sides', async () => {
+		const before = '# Start\n\nStart text\n\n## Moved\n\nMoved text\n\n## End\n\nEnd text'
+		const after = '## Moved\n\nMoved text\n\n# Start\n\nStart text\n\n## End\n\nEnd text'
+		const el = document.createElement('div')
+		document.body.append(el)
+		const comparison = await createMarkdownContentComparison({ beforeContent: before, afterContent: after, el })
+		const record = [...el.querySelectorAll<HTMLButtonElement>('[data-comparison-select]')]
+			.find((candidate) => candidate.textContent?.includes('Moved section'))!
+		expect(record).toBeDefined()
+		const id = record.dataset.comparisonSelect!
+		const beforeGeometry = documentGeometry(el, 'before', id, 1500, 40)
+		const afterGeometry = documentGeometry(el, 'after', id, 700, 90)
+
+		record.focus()
+		record.click()
+		await vi.waitFor(() => expect(tab(el, 'Full documents').getAttribute('aria-selected')).toBe('true'))
+		expect(beforeGeometry.scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 1250 }))
+		expect(afterGeometry.scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 500 }))
+		expect(document.activeElement).toBe(record)
+		expect(el.querySelector('[aria-live="polite"]')?.textContent).toContain('Moved section')
+		expect(el.querySelectorAll(`.text-comparison-change--current[data-comparison-change="${id}"]`).length)
+			.toBeGreaterThanOrEqual(2)
+		comparison.destroy()
+		el.remove()
+	})
+
+	it('keeps the document navigation live region mounted before the first selection', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({ beforeContent: 'Before', afterContent: 'After', el })
+		const liveRegion = el.querySelector('[data-comparison-announcement][aria-live="polite"]')
+		expect(liveRegion).not.toBeNull()
+		expect(liveRegion?.textContent).toBe('')
+
+		el.querySelector<HTMLButtonElement>('[data-comparison-select]')!.click()
+		await vi.waitFor(() => expect(liveRegion?.textContent).toContain('Change 1 of 1'))
+		expect(liveRegion).toBe(el.querySelector('[data-comparison-announcement]'))
+		comparison.destroy()
+	})
+
+	it('locates an insertion through its compact empty-side boundary target', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: 'Before\n\nAfter anchor',
+			afterContent: 'Before\n\nInserted\n\nAfter anchor',
+			el,
+		})
+		const record = [...el.querySelectorAll<HTMLButtonElement>('[data-comparison-select]')]
+			.find((candidate) => candidate.textContent?.includes('added'))!
+		const id = record.dataset.comparisonSelect!
+		const beforeGeometry = documentGeometry(el, 'before', id, 600, 0)
+		const afterGeometry = documentGeometry(el, 'after', id, 900, 0)
+		expect(beforeGeometry.target.classList).toContain('text-comparison-change--empty')
+		expect(beforeGeometry.target.getAttribute('role')).toBe('note')
+		record.click()
+		await vi.waitFor(() => expect(beforeGeometry.scrollTo).toHaveBeenCalled())
+		expect(afterGeometry.scrollTo).toHaveBeenCalled()
+		const currentEmptyTarget = `[data-comparison-change="${id}"].text-comparison-change--empty[aria-current="true"]`
+		await vi.waitFor(() => expect(el.querySelector(currentEmptyTarget)).not.toBeNull())
+		comparison.destroy()
+	})
+
+	it('uses the same two-pane location path for Previous and Next', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: 'Before one\n\nSame\n\nBefore two',
+			afterContent: 'After one\n\nSame\n\nAfter two',
+			el,
+		})
+		tab(el, 'Full documents').click()
+		await vi.waitFor(() => expect(tab(el, 'Full documents').getAttribute('aria-selected')).toBe('true'))
+		const ids = [...el.querySelectorAll<HTMLElement>('[data-comparison-select]')].map(({ dataset }) => dataset.comparisonSelect!)
+		expect(ids).toHaveLength(2)
+		const nextBefore = documentGeometry(el, 'before', ids[1]!, 800, 0)
+		const nextAfter = documentGeometry(el, 'after', ids[1]!, 1000, 0)
+		button(el, 'Next').click()
+		await vi.waitFor(() => expect(nextBefore.scrollTo).toHaveBeenCalled())
+		expect(nextAfter.scrollTo).toHaveBeenCalled()
+		expect(el.querySelector(`[data-comparison-change="${ids[1]}"][aria-current="true"]`)).not.toBeNull()
+
+		const previousBefore = documentGeometry(el, 'before', ids[0]!, 500, 0)
+		const previousAfter = documentGeometry(el, 'after', ids[0]!, 650, 0)
+		button(el, 'Previous').click()
+		await vi.waitFor(() => expect(previousBefore.scrollTo).toHaveBeenCalled())
+		expect(previousAfter.scrollTo).toHaveBeenCalled()
+		comparison.destroy()
+	})
+
+	it('disables document navigation when only one change is available', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: 'Before',
+			afterContent: 'After',
+			el,
+		})
+		tab(el, 'Full documents').click()
+		await vi.waitFor(() => expect(tab(el, 'Full documents').getAttribute('aria-selected')).toBe('true'))
+		expect(button(el, 'Previous').disabled).toBe(true)
+		expect(button(el, 'Next').disabled).toBe(true)
+		comparison.destroy()
+	})
+
+	it('reports hidden formatting in Full documents and offers Show', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: 'Plain first\n\nBefore second',
+			afterContent: '**Plain first**\n\nAfter second',
+			el,
+		})
+		setFormattingFilter(el, true)
+		tab(el, 'Full documents').click()
+		await vi.waitFor(() => expect(el.querySelector('[data-comparison-hidden-formatting]')?.textContent)
+			.toContain('1 formatting change hidden'))
+		button(el, 'Show').click()
+		await vi.waitFor(() => expect(el.querySelector('[data-comparison-hidden-formatting]')).toBeNull())
+		tab(el, 'Changes').click()
+		await vi.waitFor(() => expect(el.querySelector<HTMLInputElement>('input[type="checkbox"]')?.checked).toBe(false))
+		comparison.destroy()
+	})
+
+	it('preserves paired scroll positions through view switches', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({ beforeContent: 'Before', afterContent: 'After', el })
+		tab(el, 'Full documents').click()
+		const beforeScroller = el.querySelector<HTMLElement>('.text-comparison__document--before .text-comparison__document-scroller')!
+		const afterScroller = el.querySelector<HTMLElement>('.text-comparison__document--after .text-comparison__document-scroller')!
+		beforeScroller.scrollTop = 125
+		afterScroller.scrollTop = 475
+		tab(el, 'Changes').click()
+		tab(el, 'Full documents').click()
+		await Promise.resolve()
+		expect(beforeScroller.scrollTop).toBe(125)
+		expect(afterScroller.scrollTop).toBe(475)
+		comparison.destroy()
+	})
+
+	it('keeps a pending target and separate scroll position for each single pane', async () => {
+		const callbacks: ResizeObserverCallback[] = []
+		class ResizeObserverMock {
+			constructor(callback: ResizeObserverCallback) { callbacks.push(callback) }
+			observe() {}
+			disconnect() {}
+			unobserve() {}
+		}
+		vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+		const el = document.createElement('div')
+		document.body.append(el)
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: 'Before one\n\nBefore two',
+			afterContent: 'After one\n\nAfter two',
+			el,
+		})
+		callbacks[0]!([{ contentRect: { width: 700 } } as ResizeObserverEntry], {} as ResizeObserver)
+		await Promise.resolve()
+		const record = el.querySelector<HTMLButtonElement>('[data-comparison-select]')!
+		const id = record.dataset.comparisonSelect!
+		const beforeGeometry = documentGeometry(el, 'before', id, 700, 10)
+		const afterGeometry = documentGeometry(el, 'after', id, 1100, 30)
+		record.click()
+		await vi.waitFor(() => expect(beforeGeometry.scrollTo).toHaveBeenCalledOnce())
+		expect(afterGeometry.scrollTo).not.toHaveBeenCalled()
+		beforeGeometry.scroller.scrollTop = 321
+		const beforeTab = sideTab(el, 'Before')
+		beforeTab.focus()
+		beforeTab.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+		await vi.waitFor(() => expect(afterGeometry.scrollTo).toHaveBeenCalledOnce())
+		expect(sideTab(el, 'After').getAttribute('aria-selected')).toBe('true')
+		expect(document.activeElement).toBe(sideTab(el, 'After'))
+		afterGeometry.scroller.scrollTop = 654
+		sideTab(el, 'Before').click()
+		await Promise.resolve()
+		expect(beforeGeometry.scrollTo).toHaveBeenCalledOnce()
+		expect(beforeGeometry.scroller.scrollTop).toBe(321)
+		sideTab(el, 'After').click()
+		await Promise.resolve()
+		expect(afterGeometry.scrollTo).toHaveBeenCalledOnce()
+		expect(afterGeometry.scroller.scrollTop).toBe(654)
+		comparison.destroy()
+		el.remove()
+	})
+
+	it('derives paired and single geometry only from the comparison container', async () => {
+		const callbacks: ResizeObserverCallback[] = []
+		class ResizeObserverMock {
+			constructor(callback: ResizeObserverCallback) { callbacks.push(callback) }
+			observe() {}
+			disconnect() {}
+			unobserve() {}
+		}
+		vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({ beforeContent: 'Before', afterContent: 'After', el })
+		const root = el.querySelector<HTMLElement>('.text-comparison')!
+		const resize = async (containerWidth: number, viewportWidth: number) => {
+			Object.defineProperty(window, 'innerWidth', { configurable: true, value: viewportWidth })
+			callbacks[0]!([{ contentRect: { width: containerWidth } } as ResizeObserverEntry], {} as ResizeObserver)
+			await Promise.resolve()
+		}
+		expect(callbacks).toHaveLength(1)
+		await resize(1200, 500)
+		expect(root.classList).toContain('text-comparison--paired')
+		await resize(900, 1600)
+		expect(root.classList).toContain('text-comparison--paired')
+		await resize(0, 1600)
+		expect(root.classList).toContain('text-comparison--paired')
+		await resize(700, 1600)
+		expect(root.classList).toContain('text-comparison--single')
+		tab(el, 'Full documents').click()
+		await vi.waitFor(() => expect(el.querySelector('[aria-label="Version to display"]')).not.toBeNull())
+		comparison.destroy()
+	})
+
+	it('renders complete original documents in independent scrollers', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: 'A old\n\nB\n\nC\n\nD\n\nE\n\nF\n\nG\n\nH',
+			afterContent: 'A new\n\nB\n\nC\n\nD\n\nE\n\nF\n\nG\n\nInserted\n\nH',
+			el,
+		})
+		for (const editor of el.querySelectorAll('.ProseMirror')) {
+			expect(editor.textContent).toContain('C')
+			expect(editor.textContent).toContain('G')
+		}
+		expect(el.querySelectorAll('.text-comparison__document-scroller')).toHaveLength(2)
+		const scrollHints = [...el.querySelectorAll('[data-comparison-independent-scrolling]')]
+		expect(scrollHints).toHaveLength(2)
+		expect(scrollHints.every(({ textContent }) => textContent?.includes('Independent scroll'))).toBe(true)
+		expect(el.querySelector('.text-comparison__document-guidance')).toBeNull()
+		expect(el.querySelector('.text-comparison__document--before .text-comparison__sr-only')?.textContent)
+			.toContain('line-through')
+		expect(el.querySelector('.text-comparison__documents')?.parentElement?.classList).toContain('text-comparison')
+		comparison.destroy()
+	})
+
+	it('owns exactly one root ResizeObserver and disconnects it on destroy', async () => {
+		const observers: Array<{ disconnect: ReturnType<typeof vi.fn>, observe: ReturnType<typeof vi.fn> }> = []
+		class ResizeObserverMock {
+			disconnect = vi.fn()
+			observe = vi.fn()
+			unobserve = vi.fn()
+			constructor() { observers.push(this) }
+		}
+		vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({ beforeContent: 'Before', afterContent: 'After', el })
+		expect(observers).toHaveLength(1)
+		expect(observers[0]!.observe).toHaveBeenCalledWith(el.querySelector('.text-comparison'))
+		comparison.destroy()
+		expect(observers[0]!.disconnect).toHaveBeenCalledOnce()
+	})
+
+	it('unmounts and removes its root when onLoaded fails', async () => {
+		const el = document.createElement('div')
+		await expect(createMarkdownContentComparison({
+			afterContent: 'After',
+			beforeContent: 'Before',
+			el,
+			onLoaded() {
+				throw new Error('loaded callback failed')
+			},
+		})).rejects.toThrow('loaded callback failed')
+		expect(el.childElementCount).toBe(0)
 	})
 })

--- a/src/tests/comparison/createMarkdownContentComparison.spec.ts
+++ b/src/tests/comparison/createMarkdownContentComparison.spec.ts
@@ -149,65 +149,97 @@ describe('createMarkdownContentComparison', { timeout: 30_000 }, () => {
 		expect(el.childElementCount).toBe(0)
 	})
 
-	it('skips rendered editors above the pre-parse limit and reports the boundary', async () => {
+	it('skips rendered editors above the pre-parse limit and defaults to Source', async () => {
+		const oversized = 'a'.repeat(RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot + 1)
 		const el = document.createElement('div')
-		const beforeContent = 'x'.repeat(RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot + 1)
+		const onLoaded = vi.fn()
 		const comparison = await createMarkdownContentComparison({
-			afterContent: 'After',
-			beforeContent,
+			afterContent: `${oversized}b`,
+			beforeContent: oversized,
 			el,
+			onLoaded,
 		})
 
+		expect(onLoaded).toHaveBeenCalledOnce()
+		expect(tab(el, 'Changes').disabled).toBe(true)
+		expect(tab(el, 'Full documents').disabled).toBe(true)
+		expect(tab(el, 'Markdown source').getAttribute('aria-selected')).toBe('true')
 		expect(el.querySelector('[data-comparison-rendered-limit]')?.textContent)
 			.toContain('too large for rendered views')
 		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(0)
+		expect(el.textContent).toContain('Source compares literal Markdown')
 		comparison.destroy()
 	})
-	it('reports when semantic change density reaches the model limit', async () => {
-		const el = document.createElement('div')
+
+	it('falls back to Source when change density reaches the model limit', async () => {
 		const itemCount = Math.floor(MAX_RENDERED_COMPARISON_DESCRIPTORS / 8) + 1
 		const beforeContent = Array.from({ length: itemCount }, () => '- [ ] a x a x a x a x a x a x a x a x').join('\n')
 		const afterContent = Array.from({ length: itemCount }, () => '- [ ] b x b x b x b x b x b x b x b x').join('\n')
+		const el = document.createElement('div')
 		const comparison = await createMarkdownContentComparison({ afterContent, beforeContent, el })
 
+		expect(tab(el, 'Changes').disabled).toBe(true)
+		expect(tab(el, 'Full documents').disabled).toBe(true)
+		expect(tab(el, 'Markdown source').getAttribute('aria-selected')).toBe('true')
 		expect(el.querySelector('[data-comparison-rendered-limit]')?.textContent)
 			.toContain('too many changes for rendered views')
+		expect(el.querySelector('[data-comparison-rendered-limit]')?.textContent)
+			.not.toContain('too large')
 		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(0)
 		comparison.destroy()
 	})
-	it('reports syntax-only Markdown without inventing rendered changes', async () => {
+
+	it('keeps syntax-only differences in Changes and offers one Source action', async () => {
 		const el = document.createElement('div')
 		const comparison = await createMarkdownContentComparison({
-			afterContent: '# Same #',
-			beforeContent: '# Same',
+			beforeContent: '# Heading',
+			afterContent: '# Heading #',
 			el,
 		})
 
+		expect(tab(el, 'Changes').getAttribute('aria-selected')).toBe('true')
 		expect(el.querySelector('[data-comparison-empty="syntax"]')?.textContent)
 			.toContain('No rendered differences — Markdown syntax differs.')
-		expect(el.querySelectorAll('.text-comparison__change-item')).toHaveLength(0)
+		const action = el.querySelector<HTMLButtonElement>('[data-comparison-empty-action]')!
+		expect(action.textContent).toContain('Open Markdown source')
+		action.click()
+		await vi.waitFor(() => expect(tab(el, 'Markdown source').getAttribute('aria-selected')).toBe('true'))
+		expect(el.textContent).toContain('Source compares literal Markdown')
+		await vi.waitFor(() => expect(el.textContent).toContain('# Heading #'))
 		comparison.destroy()
 	})
-	it('uses two peer ARIA tabs with wrapping Arrow, Home, and End behavior', async () => {
+
+	it('uses exactly three peer ARIA tabs with wrapping Arrow, Home, and End behavior', async () => {
 		const el = document.createElement('div')
 		const comparison = await createMarkdownContentComparison({
-			afterContent: 'After',
-			beforeContent: 'Before',
+			beforeContent: 'Before one\n\nBefore two',
+			afterContent: 'After one\n\nAfter two',
 			el,
 		})
 		const tabs = [...el.querySelectorAll<HTMLButtonElement>('.text-comparison__view-tabs [role="tab"]')]
+		expect(tabs.map(({ textContent }) => textContent?.trim())).toEqual([
+			'Changes',
+			'Full documents',
+			'Markdown source',
+		])
+		expect(el.querySelectorAll('[role="tablist"]')).toHaveLength(1)
+		const selectedId = el.querySelector('[aria-current="true"][data-comparison-select]')?.getAttribute('data-comparison-select')
 
-		expect(tabs.map(({ textContent }) => textContent?.trim())).toEqual(['Changes', 'Full documents'])
-		tab(el, 'Changes').dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }))
+		tab(el, 'Changes').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
 		await vi.waitFor(() => expect(tab(el, 'Full documents').getAttribute('aria-selected')).toBe('true'))
-		tab(el, 'Full documents').dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }))
+		tab(el, 'Full documents').dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }))
+		await vi.waitFor(() => expect(tab(el, 'Markdown source').getAttribute('aria-selected')).toBe('true'))
+		tab(el, 'Markdown source').dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }))
 		await vi.waitFor(() => expect(tab(el, 'Changes').getAttribute('aria-selected')).toBe('true'))
 		tab(el, 'Changes').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
-		await vi.waitFor(() => expect(tab(el, 'Full documents').getAttribute('aria-selected')).toBe('true'))
-		tab(el, 'Full documents').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+		await vi.waitFor(() => expect(tab(el, 'Markdown source').getAttribute('aria-selected')).toBe('true'))
+		tab(el, 'Markdown source').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
 		await vi.waitFor(() => expect(tab(el, 'Changes').getAttribute('aria-selected')).toBe('true'))
+		expect(el.querySelector(`[aria-current="true"][data-comparison-select="${selectedId}"]`)).not.toBeNull()
+		expect(el.querySelector('[aria-label="Rendered comparison mode"]')).toBeNull()
 		comparison.destroy()
 	})
+
 	it('renders Atlas as one compact, complete, ordered changelog', async () => {
 		class ResizeObserverMock {
 			observe() {}
@@ -726,6 +758,21 @@ describe('createMarkdownContentComparison', { timeout: 30_000 }, () => {
 		expect(observers[0]!.observe).toHaveBeenCalledWith(el.querySelector('.text-comparison'))
 		comparison.destroy()
 		expect(observers[0]!.disconnect).toHaveBeenCalledOnce()
+	})
+
+	it('renders HTML-like source literally without creating executable elements', async () => {
+		const el = document.createElement('div')
+		const comparison = await createMarkdownContentComparison({
+			beforeContent: '<script>globalThis.pwned = true</script>',
+			afterContent: '<img src=x onerror="globalThis.pwned = true">',
+			el,
+		})
+		tab(el, 'Markdown source').click()
+		await vi.waitFor(() => expect(el.textContent).toContain('onerror'))
+		expect(el.querySelector('script')).toBeNull()
+		expect(el.querySelector('img')).toBeNull()
+		expect((globalThis as { pwned?: boolean }).pwned).toBeUndefined()
+		comparison.destroy()
 	})
 
 	it('unmounts and removes its root when onLoaded fails', async () => {

--- a/src/tests/comparison/editorCallbackIsolation.spec.ts
+++ b/src/tests/comparison/editorCallbackIsolation.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { describe, expect, it, vi } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+
+describe('comparison editor isolation', () => {
+	it('disables interactive extensions and global editor events', () => {
+		const attachments = vi.fn()
+		const search = vi.fn()
+		subscribe('text:editor:attachments:updated', attachments)
+		subscribe('text:editor:search-results', search)
+		const editor = createComparisonEditor('![One](.attachments.1/one.png) find')
+
+		try {
+			const extensionNames = editor.extensionManager.extensions.map(({ name }) => name)
+			expect(extensionNames).not.toContain('focustrap')
+			expect(extensionNames).not.toContain('CustomKeymap')
+			expect(extensionNames).not.toContain('Search')
+			expect(attachments).not.toHaveBeenCalled()
+			expect(search).not.toHaveBeenCalled()
+		} finally {
+			editor.destroy()
+			unsubscribe('text:editor:attachments:updated', attachments)
+			unsubscribe('text:editor:search-results', search)
+		}
+	})
+})

--- a/src/tests/comparison/fixtures/atlasComparison.ts
+++ b/src/tests/comparison/fixtures/atlasComparison.ts
@@ -1,0 +1,214 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const ATLAS_ROLLBACK_SECTION = `## Rollback ownership
+
+Maya owns rollback approval.
+
+Escalate checkout regressions to the release commander.`
+
+const ATLAS_EVIDENCE_SECTION = `## Audit archive
+
+Each decision receives a durable timestamp.
+
+Signed records remain with the project history.`
+
+const ATLAS_READINESS_SECTION = `## Regional readiness
+
+All checkout regions use the same health gate.
+
+Regional owners confirm capacity before launch.`
+
+export const ATLAS_INITIAL_CONTENT = `---
+release: atlas-2.4
+status: draft
+owner: Maya Chen
+---
+
+# Atlas 2.4 release plan
+
+> Draft rollout window: Thursday, 18 July.
+
+## Objective
+
+Ship **Atlas 2.4** to a 10% pilot cohort while protecting checkout availability.
+
+Release owner: Maya Chen.
+
+Status cadence: every 15 minutes.
+
+All named owners have acknowledged the window.
+
+Status dashboard is available to the release team.
+
+The dashboard is reviewed before each traffic increase.
+
+Keep the [incident channel](https://chat.example.test/atlas) staffed during rollout.
+
+The incident commander acknowledges every escalation.
+
+Follow the [operator runbook](https://docs.example.test/atlas/draft).
+
+The release commander validates every operator handoff.
+
+Customer update is ready for review.
+
+Checkout remains available throughout the launch.
+
+${ATLAS_ROLLBACK_SECTION}
+
+${ATLAS_EVIDENCE_SECTION}
+
+${ATLAS_READINESS_SECTION}
+
+## Decision protocol
+
+The release commander records every traffic decision.
+
+## Rollout checklist
+
+- [x] Freeze schema changes
+- [ ] Confirm support coverage
+- [ ] Enable the pilot cohort
+
+## Schedule
+
+| Stage | Owner | Traffic |
+| --- | --- | --- |
+| Pilot | Maya | 10% |
+| General availability | Lee | Pending |
+
+Checkout remains available throughout the launch.
+
+::: info
+The checkout health gate must remain green for fifteen minutes.
+:::
+
+Health checks are sampled from every checkout region.
+
+<details>
+<summary>Escalation contacts</summary>
+Maya leads release decisions; Noor leads rollback execution.
+</details>
+
+## Guardrail
+
+\`\`\`js
+const rolloutPercent = 10
+const rollbackThreshold = 0.02
+\`\`\`
+
+Rollback if error rate exceeds \`2%\`.
+
+The rollout decision is recorded in the release evidence.[^atlas-draft]
+
+Visual evidence follows the signed release decision.
+
+![Atlas rollout dashboard](/core/img/logo/logo.svg)
+
+The image checksum is recorded separately.
+
+[^atlas-draft]: Draft approval requires checkout error rate below two percent.
+`
+
+export const ATLAS_SYNTAX_ONLY_CONTENT = ATLAS_INITIAL_CONTENT
+	.replace('# Atlas 2.4 release plan', '# Atlas 2.4 release plan #')
+	.replace('Status dashboard is available to the release team.', 'Status dashboard is available to the release team. ')
+	.replaceAll('\n', '\r\n')
+	.replace(/\r\n$/, '')
+
+export const ATLAS_CURRENT_CONTENT = `---
+release: atlas-2.4
+status: launch-ready
+owner: Maya Chen and Noor Patel
+---
+
+# Atlas 2.4 launch plan
+
+> Approved rollout window: Friday, 19 July.
+
+## Objective
+
+Ship **Atlas 2.4** through a 25% progressive rollout while protecting checkout availability.
+
+Release owner: **Maya Chen**.
+
+Status cadence: *every 15 minutes*.
+
+All named owners have acknowledged the window.
+
+[Status dashboard](https://status.example.test/atlas) is available to the release team.
+
+The dashboard is reviewed before each traffic increase.
+
+Keep the incident channel staffed during rollout.
+
+The incident commander acknowledges every escalation.
+
+Follow the [operator runbook](https://docs.example.test/atlas/2.4).
+
+The release commander validates every operator handoff.
+
+Customer **launch update** is ready for publication.
+
+Checkout remains available throughout the launch.
+
+${ATLAS_EVIDENCE_SECTION}
+
+${ATLAS_READINESS_SECTION}
+
+${ATLAS_ROLLBACK_SECTION}
+
+## Decision protocol
+
+The release commander records every traffic decision.
+
+## Rollout checklist
+
+- [x] Freeze schema changes
+- [x] Confirm support coverage
+- [x] Enable the pilot cohort
+- [ ] Publish the customer update
+
+## Schedule
+
+| Stage | Owner | Traffic |
+| --- | --- | --- |
+| Canary | Maya | 25% |
+| General availability | Lee | 100% |
+| Rollback rehearsal | Noor | Complete |
+
+Checkout remains available throughout the launch.
+
+::: warn
+The checkout health gate must remain green for fifteen minutes.
+:::
+
+Health checks are sampled from every checkout region.
+
+<details>
+<summary>Escalation contacts</summary>
+Maya leads release decisions; Noor executes rollback and Lee owns customer communication.
+</details>
+
+## Guardrail
+
+\`\`\`js
+const rolloutPercent = 25
+const rollbackThreshold = 0.015
+\`\`\`
+
+Rollback if error rate exceeds \`1.5%\` for five minutes.
+
+The rollout decision is recorded in the release evidence.[^atlas-launch]
+
+Visual evidence follows the signed release decision.
+
+![Atlas launch control room](/core/img/logo/logo.svg)
+
+The image checksum is recorded separately.
+
+[^atlas-launch]: Launch approval requires checkout error rate below one and a half percent for five minutes.
+`

--- a/src/tests/comparison/hierarchicalMarkdownComparison.spec.ts
+++ b/src/tests/comparison/hierarchicalMarkdownComparison.spec.ts
@@ -1,0 +1,586 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonModelAudit } from '../../comparison/hierarchicalMarkdownComparisonModel.ts'
+import type { ComparisonDescriptor, ComparisonSide } from '../../comparison/markdownComparisonTypes.ts'
+
+import { describe, expect, it } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import {
+	ComparisonModelLimitError,
+	createHierarchicalMarkdownComparisonModel,
+	MAX_ALIGNMENT_PRODUCT,
+	MAX_INLINE_ENVELOPE_SIZE,
+} from '../../comparison/hierarchicalMarkdownComparisonModel.ts'
+import {
+	ATLAS_CURRENT_CONTENT,
+	ATLAS_INITIAL_CONTENT,
+	ATLAS_SYNTAX_ONLY_CONTENT,
+} from './fixtures/atlasComparison.ts'
+
+function compare(beforeContent: string, afterContent: string, audit?: ComparisonModelAudit) {
+	const beforeEditor = createComparisonEditor(beforeContent)
+	const afterEditor = createComparisonEditor(afterContent)
+	try {
+		const before = beforeEditor.state.doc
+		const after = afterEditor.state.doc
+		return {
+			before,
+			after,
+			model: createHierarchicalMarkdownComparisonModel(before, after, { audit }),
+		}
+	} finally {
+		beforeEditor.destroy()
+		afterEditor.destroy()
+	}
+}
+
+function rangeText(doc: Node, descriptor: ComparisonDescriptor, side: ComparisonSide) {
+	const { from, to } = descriptor[side]
+	return doc.textBetween(from, to, '\n', '\ufffc')
+}
+
+function expectValidRanges(doc: Node, descriptors: readonly ComparisonDescriptor[], side: ComparisonSide) {
+	for (const descriptor of descriptors) {
+		const range = descriptor[side]
+		expect(range.from, `${side} ${descriptor.id} starts before the document`).toBeGreaterThanOrEqual(0)
+		expect(range.to, `${side} ${descriptor.id} ends before it starts`).toBeGreaterThanOrEqual(range.from)
+		expect(range.to, `${side} ${descriptor.id} ends after the document`).toBeLessThanOrEqual(doc.content.size)
+	}
+}
+
+function topLevelRanges(doc: Node) {
+	const ranges: Array<{ from: number, to: number, text: string }> = []
+	doc.forEach((node, from) => ranges.push({
+		from,
+		to: from + node.nodeSize,
+		text: node.textContent,
+	}))
+	return ranges
+}
+
+function touched(range: { from: number, to: number }, block: { from: number, to: number }) {
+	return range.from < block.to && range.to > block.from
+}
+
+describe('hierarchical Markdown comparison', () => {
+	it('normalizes documents created by separate schema instances before comparing them', () => {
+		const { model } = compare('# Heading\n\nSame content', '# Heading\n\nSame content')
+		expect(model.descriptors).toEqual([])
+	})
+
+	it('detects attrs-only textblock changes before content diffing', () => {
+		const { model } = compare('# Title', '## Title')
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]).toMatchObject({
+			detail: 'block',
+			facets: ['attribute'],
+			signals: [{ type: 'attribute', attribute: 'heading-level', change: 'changed' }],
+		})
+	})
+
+	it('keeps unsupported semantic attributes visible without exposing values', () => {
+		const { model } = compare('- item', '* item')
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]).toMatchObject({
+			facets: ['attribute', 'unknown'],
+			signals: [{ type: 'attribute', attribute: 'unknown-attribute', change: 'changed' }],
+		})
+		expect(JSON.stringify(model.descriptors)).not.toContain('bullet')
+	})
+
+	it.each([
+		['text', 'Before text', 'After text', 'text'],
+		['formatting', 'plain text', 'plain **text**', 'bold'],
+		['link', 'plain text', '[plain text](https://example.test)', 'link'],
+		['list start', '1. item', '3. item', 'list-start'],
+		['task state', '- [ ] item', '- [x] item', 'task-state'],
+		['code language', '```js\nsame\n```', '```ts\nsame\n```', 'code-language'],
+		['callout type', '::: info\nsame\n:::', '::: warn\nsame\n:::', 'callout-type'],
+		['image identity', '![Before](before.png)', '![After](after.png)', 'image-target'],
+		['mention identity', '@[Jane](mention://user/jane)', '@[John](mention://user/john)', 'mention-identity'],
+		['preview target', '[Preview](https://before.test (preview))', '[Preview](https://after.test (preview))', 'preview-target'],
+		['mathematics', '$1 + 1 = 2$', '$1 + 2 = 3$', 'mathematics'],
+		['footnote identity', 'Text[^before].\n\n[^before]: Same', 'Text[^after].\n\n[^after]: Same', 'footnote-reference'],
+	] as const)('classifies supported %s semantics', (_name, before, after, semantic) => {
+		const descriptors = compare(before, after).model.descriptors
+		expect(descriptors.length).toBeGreaterThan(0)
+		const encoded = JSON.stringify(descriptors.flatMap(({ facets, signals }) => [facets, signals]))
+		expect(encoded).toContain(semantic)
+	})
+
+	it.each([
+		['bold', 'plain text', 'plain **text**', { type: 'mark', mark: 'bold', change: 'added' }],
+		['italic', 'plain text', 'plain *text*', { type: 'mark', mark: 'italic', change: 'added' }],
+		['strike', 'plain text', 'plain ~~text~~', { type: 'mark', mark: 'strike', change: 'added' }],
+		['highlight', 'plain text', 'plain ==text==', { type: 'mark', mark: 'highlight', change: 'added' }],
+		['inline code', 'plain text', 'plain `text`', { type: 'mark', mark: 'inline-code', change: 'added' }],
+		['link added', 'text', '[text](https://example.test)', { type: 'attribute', attribute: 'link', change: 'added' }],
+		['link removed', '[text](https://example.test)', 'text', { type: 'attribute', attribute: 'link', change: 'removed' }],
+		['link target', '[text](https://before.test)', '[text](https://after.test)', { type: 'attribute', attribute: 'link-target', change: 'changed' }],
+		['heading level', '# Heading', '## Heading', { type: 'attribute', attribute: 'heading-level', change: 'changed' }],
+		['list start', '1. item', '3. item', { type: 'attribute', attribute: 'list-start', change: 'changed' }],
+		['task state', '- [ ] item', '- [x] item', { type: 'attribute', attribute: 'task-state', change: 'changed' }],
+		['code language', '```js\nsame\n```', '```ts\nsame\n```', { type: 'attribute', attribute: 'code-language', change: 'changed' }],
+		['callout type', '::: info\nsame\n:::', '::: warn\nsame\n:::', { type: 'attribute', attribute: 'callout-type', change: 'changed' }],
+		['image description', '![Before](same.png)', '![After](same.png)', { type: 'attribute', attribute: 'image-alt', change: 'changed' }],
+		['image target', '![Same](before.png)', '![Same](after.png)', { type: 'attribute', attribute: 'image-target', change: 'changed' }],
+		['mention identity', '@[Jane](mention://user/jane)', '@[John](mention://user/john)', { type: 'attribute', attribute: 'mention-identity', change: 'changed' }],
+		['mathematics', '$1 + 1 = 2$', '$1 + 2 = 3$', { type: 'attribute', attribute: 'mathematics', change: 'changed' }],
+		['preview target', '[Preview](https://before.test (preview))', '[Preview](https://after.test (preview))', { type: 'attribute', attribute: 'preview-target', change: 'changed' }],
+		['footnote identity', 'Text[^before].\n\n[^before]: Same', 'Text[^after].\n\n[^after]: Same', { type: 'attribute', attribute: 'footnote-reference', change: 'changed' }],
+		['table alignment', '| A |\n|:---|\n| 1 |', '| A |\n|---:|\n| 1 |', { type: 'attribute', attribute: 'table-alignment', change: 'changed' }],
+	] as const)('emits the supported %s signal', (_name, before, after, signal) => {
+		expect(compare(before, after).model.descriptors.flatMap(({ signals }) => signals)).toContainEqual(signal)
+	})
+
+	it('classifies underline marks present in editor documents', () => {
+		const editor = createComparisonEditor('plain text')
+		try {
+			const before = editor.state.doc
+			const after = editor.state.tr.addMark(7, 11, editor.schema.marks.underline!.create()).doc
+			expect(createHierarchicalMarkdownComparisonModel(before, after).descriptors.flatMap(({ signals }) => signals))
+				.toContainEqual({ type: 'mark', mark: 'underline', change: 'added' })
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('matches nested attributes after an earlier top-level insertion shifts their paths', () => {
+		const { model } = compare(
+			'Introduction\n\n- [ ] Confirm support coverage',
+			'New preface\n\nIntroduction\n\n- [x] Confirm support coverage',
+		)
+		expect(model.descriptors.flatMap(({ signals }) => signals)).toContainEqual({
+			type: 'attribute',
+			attribute: 'task-state',
+			change: 'changed',
+		})
+	})
+
+	it('keeps Atlas semantics and conservative exact moves', () => {
+		const { model } = compare(ATLAS_INITIAL_CONTENT, ATLAS_CURRENT_CONTENT)
+		const signals = model.descriptors.flatMap(({ signals }) => signals)
+		const contexts = model.descriptors.flatMap(({ context }) => [context.before?.code, context.after?.code])
+
+		expect(model.descriptors.some(({ operation }) => operation === 'move')).toBe(true)
+		expect(signals).toEqual(expect.arrayContaining([
+			{ type: 'mark', mark: 'bold', change: 'added' },
+			{ type: 'mark', mark: 'italic', change: 'added' },
+			{ type: 'attribute', attribute: 'link', change: 'added' },
+			{ type: 'attribute', attribute: 'link', change: 'removed' },
+			{ type: 'attribute', attribute: 'link-target', change: 'changed' },
+			{ type: 'attribute', attribute: 'task-state', change: 'changed' },
+			{ type: 'attribute', attribute: 'callout-type', change: 'changed' },
+			{ type: 'attribute', attribute: 'footnote-reference', change: 'changed' },
+			{ type: 'attribute', attribute: 'image-alt', change: 'changed' },
+		]))
+		expect(contexts).toEqual(expect.arrayContaining([
+			'front-matter',
+			'quote',
+			'paragraph',
+			'heading',
+			'task',
+			'table-cell',
+			'callout',
+			'details',
+			'code-block',
+			'footnote-reference',
+			'image',
+			'footnote',
+		]))
+		const trafficChanges = model.descriptors.filter(({ preview }) => (
+			preview.before?.kind === 'text'
+			&& preview.before.text === 'Pending'
+			&& preview.after?.kind === 'text'
+			&& preview.after.text === '100%'
+		))
+		expect(model.descriptors).toHaveLength(35)
+		expect(trafficChanges).toHaveLength(1)
+		expect(trafficChanges[0]).toMatchObject({ detail: 'inline', facets: ['text'] })
+	})
+
+	it('treats syntax-only Markdown differences as the same rendered document', () => {
+		expect(compare(ATLAS_INITIAL_CONTENT, ATLAS_SYNTAX_ONLY_CONTENT).model.descriptors).toEqual([])
+	})
+
+	it('falls back to one honest block range for a changed token island over the inline budget', () => {
+		const stableIsland = ' UNCHANGED ISLAND '
+		const before = `prefix ${'a'.repeat(2600)}${stableIsland}${'b'.repeat(2600)} suffix`
+		const after = `prefix ${'x'.repeat(2600)}${stableIsland}${'y'.repeat(2600)} suffix`
+		const result = compare(before, after)
+
+		expect(result.model.descriptors).toHaveLength(1)
+		expect(result.model.descriptors[0]?.detail).toBe('block')
+		expect(result.model.descriptors.every(({ detail }) => detail !== 'inline')).toBe(true)
+		expect(rangeText(result.before, result.model.descriptors[0]!, 'before')).toContain(stableIsland.trim())
+		expect(rangeText(result.after, result.model.descriptors[0]!, 'after')).toContain(stableIsland.trim())
+	})
+
+	it.each([
+		[MAX_INLINE_ENVELOPE_SIZE - 2, 'inline'],
+		[MAX_INLINE_ENVELOPE_SIZE, 'inline'],
+		[MAX_INLINE_ENVELOPE_SIZE + 2, 'block'],
+	] as const)('bounds a leaf ChangeSet at an envelope of %i', (envelope, detail) => {
+		const sideLength = envelope / 2
+		const { model } = compare(`prefix${'a'.repeat(sideLength)}suffix`, `prefix${'b'.repeat(sideLength)}suffix`)
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]?.detail).toBe(detail)
+	})
+
+	it.each([
+		['pure insertion overlap clamp', 'aa', 'aaa', 'insert'],
+		['pure deletion overlap clamp', 'aaa', 'aa', 'delete'],
+		['start insertion', 'middle end', 'start middle end', 'insert'],
+		['middle insertion', 'start end', 'start middle end', 'insert'],
+		['end insertion', 'start middle', 'start middle end', 'insert'],
+		['start deletion', 'start middle end', 'middle end', 'delete'],
+		['middle deletion', 'start middle end', 'start end', 'delete'],
+		['end deletion', 'start middle end', 'start middle', 'delete'],
+	] as const)('keeps a bounded inline %s valid', (_name, before, after, operation) => {
+		const result = compare(before, after)
+		expect(result.model.descriptors).toHaveLength(1)
+		expect(result.model.descriptors[0]).toMatchObject({ detail: 'inline', operation })
+		expectValidRanges(result.before, result.model.descriptors, 'before')
+		expectValidRanges(result.after, result.model.descriptors, 'after')
+	})
+
+	it('keeps a small edit inline inside a very long paragraph', () => {
+		const shared = 'same '.repeat(1500)
+		const { before, after, model } = compare(`${shared}before ${shared}`, `${shared}after ${shared}`)
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]?.detail).toBe('inline')
+		expect(rangeText(before, model.descriptors[0]!, 'before')).toBe('before')
+		expect(rangeText(after, model.descriptors[0]!, 'after')).toBe('after')
+	})
+
+	it('aligns more than 500 siblings around one sparse edit', () => {
+		const paragraphs = Array.from({ length: 512 }, (_, index) => `paragraph ${index}`)
+		const before = paragraphs.join('\n\n')
+		const after = paragraphs.with(256, 'paragraph changed').join('\n\n')
+		const { model } = compare(before, after)
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]?.detail).toBe('inline')
+	})
+
+	it('classifies every block in a large document with more than 500 siblings', () => {
+		const before = Array.from({ length: 512 }, (_, index) => `before ${index}`).join('\n\n')
+		const after = Array.from({ length: 512 }, (_, index) => `after ${index}`).join('\n\n')
+		const result = compare(before, after)
+		const beforeBlocks = topLevelRanges(result.before).filter(({ text }) => text)
+		const afterBlocks = topLevelRanges(result.after).filter(({ text }) => text)
+
+		expect(result.model.descriptors).toHaveLength(512)
+		for (const block of beforeBlocks) {
+			expect(result.model.descriptors.some(({ before: range }) => touched(range, block))).toBe(true)
+		}
+		for (const block of afterBlocks) {
+			expect(result.model.descriptors.some(({ after: range }) => touched(range, block))).toBe(true)
+		}
+	})
+
+	it.each([
+		[199, 200, MAX_ALIGNMENT_PRODUCT - 200],
+		[200, 200, MAX_ALIGNMENT_PRODUCT],
+		[201, 200, MAX_ALIGNMENT_PRODUCT + 200],
+	] as const)('keeps sibling alignment bounded for %i by %i nodes', (beforeCount, afterCount, product) => {
+		expect(beforeCount * afterCount).toBe(product)
+		const before = Array.from({ length: beforeCount }, (_, index) => `before ${index}`).join('\n\n')
+		const after = Array.from({ length: afterCount }, (_, index) => `after ${index}`).join('\n\n')
+		const result = compare(before, after)
+		expectValidRanges(result.before, result.model.descriptors, 'before')
+		expectValidRanges(result.after, result.model.descriptors, 'after')
+		for (const block of topLevelRanges(result.before).filter(({ text }) => text)) {
+			expect(result.model.descriptors.some(({ before: range }) => touched(range, block))).toBe(true)
+		}
+		for (const block of topLevelRanges(result.after).filter(({ text }) => text)) {
+			expect(result.model.descriptors.some(({ after: range }) => touched(range, block))).toBe(true)
+		}
+	})
+
+	it('keeps inline precision for a global edit plus one added block', () => {
+		const before = Array.from({ length: 80 }, (_, index) => `Foo release block ${index}`).join('\n\n')
+		const after = [
+			...Array.from({ length: 80 }, (_, index) => `Bar release block ${index}`),
+			'Appended release block',
+		].join('\n\n')
+		const { model } = compare(before, after)
+
+		expect(model.descriptors.filter(({ operation }) => operation === 'delete')).toHaveLength(0)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'insert' && detail === 'block')).toHaveLength(1)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'replace' && detail === 'inline')).toHaveLength(80)
+	})
+
+	it('degrades linearly beyond the alignment ceiling without rewriting the document', () => {
+		const beforeBlocks = Array.from({ length: 250 }, (_, index) => `Foo release block ${index}`)
+		const afterBlocks = Array.from({ length: 250 }, (_, index) => `Bar release block ${index}`)
+		afterBlocks.splice(125, 0, 'Inserted release block')
+		const { model } = compare(beforeBlocks.join('\n\n'), afterBlocks.join('\n\n'))
+
+		expect(beforeBlocks.length * afterBlocks.length).toBeGreaterThan(MAX_ALIGNMENT_PRODUCT)
+		expect(model.descriptors.filter(({ operation }) => operation === 'delete')).toHaveLength(0)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'insert' && detail === 'block')).toHaveLength(1)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'replace' && detail === 'inline')).toHaveLength(250)
+	})
+
+	it('isolates one type change beyond the alignment ceiling', () => {
+		const before = Array.from({ length: 250 }, (_, index) => `Foo release block ${index}`)
+		const after = Array.from({ length: 250 }, (_, index) => `Bar release block ${index}`)
+		after[125] = '# Bar release block 125'
+		const { model } = compare(before.join('\n\n'), after.join('\n\n'))
+
+		expect(model.descriptors.filter(({ operation }) => operation === 'delete')).toHaveLength(1)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'insert' && detail === 'block')).toHaveLength(1)
+		expect(model.descriptors.filter(({ operation, detail }) => operation === 'replace' && detail === 'inline')).toHaveLength(249)
+	})
+
+	it('bounds classification work for dense checklist edits', () => {
+		const count = 200
+		const audit: ComparisonModelAudit = { examinedNodes: 0, fingerprintGroupAllocations: 0 }
+		const result = compare(
+			Array.from({ length: count }, () => '- [ ] a x a x a x a x a x a x a x a x').join('\n'),
+			Array.from({ length: count }, () => '- [ ] b x b x b x b x b x b x b x b x').join('\n'),
+			audit,
+		)
+
+		expect(result.model.descriptors).toHaveLength(count * 8)
+		expect(audit.examinedNodes).toBeLessThan(result.model.descriptors.length * 50)
+	})
+
+	it('stops at the shared descriptor boundary before more classification', () => {
+		const before = createComparisonEditor(Array.from({ length: 20 }, () => '- [ ] a x a x a x a x').join('\n'))
+		const after = createComparisonEditor(Array.from({ length: 20 }, () => '- [ ] b x b x b x b x').join('\n'))
+		const audit: ComparisonModelAudit = { examinedNodes: 0, fingerprintGroupAllocations: 0 }
+		try {
+			expect(() => createHierarchicalMarkdownComparisonModel(
+				before.state.doc,
+				after.state.doc,
+				{ audit, maximumDescriptors: 10 },
+			)).toThrow(ComparisonModelLimitError)
+			expect(audit.examinedNodes).toBeLessThan(1000)
+		} finally {
+			before.destroy()
+			after.destroy()
+		}
+	})
+
+	it.each([
+		[
+			'interleaved insertions',
+			Array.from({ length: 80 }, (_, index) => `- item ${index * 2}`).join('\n'),
+			Array.from({ length: 160 }, (_, index) => `- item ${index}`).join('\n'),
+		],
+		[
+			'interleaved deletions',
+			Array.from({ length: 160 }, (_, index) => `- item ${index}`).join('\n'),
+			Array.from({ length: 80 }, (_, index) => `- item ${index * 2}`).join('\n'),
+		],
+		[
+			'multiple moved groups',
+			Array.from({ length: 60 }, (_, index) => `Block ${index}`).join('\n\n'),
+			[
+				...Array.from({ length: 20 }, (_, index) => `Block ${index + 40}`),
+				...Array.from({ length: 20 }, (_, index) => `Block ${index}`),
+				...Array.from({ length: 20 }, (_, index) => `Block ${index + 20}`),
+			].join('\n\n'),
+		],
+	] as const)('keeps %s classification output-sensitive', (_name, before, after) => {
+		const audit: ComparisonModelAudit = { examinedNodes: 0, fingerprintGroupAllocations: 0 }
+		const result = compare(before, after, audit)
+		let nodes = 0
+		for (const doc of [result.before, result.after]) {
+			doc.descendants(() => {
+				nodes++
+			})
+		}
+
+		expect(result.model.descriptors.length).toBeGreaterThan(0)
+		expect(audit.examinedNodes).toBeLessThan((nodes + result.model.descriptors.length) * 80)
+	})
+
+	it('allocates repeated sibling fingerprint groups by distinct fingerprint', () => {
+		const count = 400
+		const before = Array.from({ length: count }, () => '- [ ] TODO')
+		const after = [...before]
+		after[Math.floor(count / 2)] = '- [x] DONE'
+		const audit: ComparisonModelAudit = { examinedNodes: 0, fingerprintGroupAllocations: 0 }
+		const { model } = compare(before.join('\n'), after.join('\n'), audit)
+
+		expect(model.descriptors.length).toBeGreaterThan(0)
+		expect(audit.fingerprintGroupAllocations).toBeLessThan(count / 4)
+	})
+
+	it.each([
+		['start insertion', 'two\n\nthree', 'one\n\ntwo\n\nthree', 'insert'],
+		['middle insertion', 'one\n\nthree', 'one\n\ntwo\n\nthree', 'insert'],
+		['end insertion', 'one\n\ntwo', 'one\n\ntwo\n\nthree', 'insert'],
+		['start deletion', 'one\n\ntwo\n\nthree', 'two\n\nthree', 'delete'],
+		['middle deletion', 'one\n\ntwo\n\nthree', 'one\n\nthree', 'delete'],
+		['end deletion', 'one\n\ntwo\n\nthree', 'one\n\ntwo', 'delete'],
+	] as const)('represents a block %s', (_name, before, after, operation) => {
+		const { model } = compare(before, after)
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]).toMatchObject({ operation, detail: 'block' })
+	})
+
+	it('pairs the later duplicate on equal alignment scores', () => {
+		const { before, model } = compare('Same\n\nSame', 'Same')
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]?.operation).toBe('delete')
+		const firstBlock = topLevelRanges(before)[0]!
+		expect(model.descriptors[0]?.before).toEqual({ from: firstBlock.from, to: firstBlock.to })
+	})
+
+	it('uses the same deterministic duplicate convention for list items', () => {
+		const { model } = compare('- Same\n- Same', '- Same')
+		expect(model.descriptors).toHaveLength(1)
+		expect(model.descriptors[0]).toMatchObject({ operation: 'delete', detail: 'block' })
+		expect(model.descriptors[0]?.context.before?.code).toBe('list-item')
+	})
+
+	it.each([
+		['duplicate top-level blocks', 'Same\n\nSame\n\nOther', 'Other\n\nSame\n\nSame'],
+		['top-level block duplicated inside a blockquote', 'Moved\n\nAlpha\n\nBravo\n\n> Moved', 'Alpha\n\nBravo\n\nMoved\n\n> Moved'],
+		['nested list reorder', '- Alpha\n- Bravo', '- Bravo\n- Alpha'],
+	])('does not infer an ambiguous %s move', (_name, before, after) => {
+		const { model } = compare(before, after)
+		expect(model.descriptors.some(({ operation }) => operation === 'move')).toBe(false)
+		expect(model.descriptors.length).toBeGreaterThan(0)
+	})
+
+	it.each([
+		['heading reorder', '# Alpha\n\n# Bravo\n\n# Charlie', '# Bravo\n\n# Charlie\n\n# Alpha'],
+		['section move', '# Alpha\n\nAlpha body\n\n# Bravo\n\nBravo body', '# Bravo\n\nBravo body\n\n# Alpha\n\nAlpha body'],
+		['crossing moves', 'Alpha\n\nBravo\n\nCharlie\n\nDelta', 'Charlie\n\nDelta\n\nAlpha\n\nBravo'],
+	] as const)('detects a conservative exact %s', (_name, before, after) => {
+		const { model } = compare(before, after)
+		expect(model.descriptors.some(({ operation }) => operation === 'move')).toBe(true)
+		expect(model.descriptors.every(({ operation, detail }) => operation !== 'move' || detail === 'block')).toBe(true)
+	})
+
+	it('keeps the exact move separate from the nearby Zed edit reproduction', () => {
+		const result = compare(
+			['Zed', 'One', 'Two', 'Three', 'Four', 'Five', 'Six'].join('\n\n'),
+			['One', 'Two modified', 'Three', 'Four', 'Five', 'Six', 'Zed'].join('\n\n'),
+		)
+		expect(result.model.descriptors.filter(({ operation }) => operation === 'move')).toHaveLength(1)
+		const edit = result.model.descriptors.find(({ detail, operation }) => detail === 'inline' && operation === 'insert')
+		expect(edit).toBeDefined()
+		expect(rangeText(result.before, edit!, 'before')).toBe('')
+		expect(rangeText(result.after, edit!, 'after')).toBe(' modified')
+	})
+
+	it('does not label an edited moved block as an exact move', () => {
+		const result = compare('Zed\n\nOne\n\nTwo', 'One\n\nTwo\n\nZed modified')
+		expect(result.model.descriptors.some(({ operation }) => operation === 'move')).toBe(false)
+		expect(result.model.descriptors.some(({ before }) => result.before.textBetween(before.from, before.to).includes('Zed'))).toBe(true)
+		expect(result.model.descriptors.some(({ after }) => result.after.textBetween(after.from, after.to).includes('Zed modified'))).toBe(true)
+	})
+
+	it.each([
+		['front matter', '---\ntitle: Before\n---\n\nBody', '---\ntitle: After\n---\n\nBody', 'front-matter'],
+		['nested bullet and ordered lists', '- Parent\n  1. Before', '- Parent\n  1. After', 'list-item'],
+		['nested task list', '- [ ] Parent\n  - [ ] Before', '- [x] Parent\n  - [ ] After', 'task'],
+		['table text', '| A | B |\n|---|---|\n| 1 | Before |', '| A | B |\n|---|---|\n| 1 | After |', 'table-cell'],
+		['table row insertion', '| A |\n|---|\n| 1 |', '| A |\n|---|\n| 1 |\n| 2 |', 'table-cell'],
+		['table row deletion', '| A |\n|---|\n| 1 |\n| 2 |', '| A |\n|---|\n| 1 |', 'table-cell'],
+		['table cell insertion', '| A |\n|---|\n| 1 |', '| A | B |\n|---|---|\n| 1 | 2 |', 'table-cell'],
+		['table cell deletion', '| A | B |\n|---|---|\n| 1 | 2 |', '| A |\n|---|\n| 1 |', 'table-cell'],
+		['table alignment', '| A |\n|:---|\n| 1 |', '| A |\n|---:|\n| 1 |', 'table-cell'],
+	] as const)('recurses through %s', (_name, before, after, context) => {
+		const { model } = compare(before, after)
+		expect(model.descriptors.length).toBeGreaterThan(0)
+		expect(model.descriptors.some(({ context: descriptorContext }) => (
+			descriptorContext.before?.code === context || descriptorContext.after?.code === context
+		))).toBe(true)
+	})
+
+	it('does not leak a sibling structural edit into an inline text descriptor', () => {
+		const result = compare(
+			'- Alpha old\n- Bravo',
+			'- Alpha new\n- Bravo\n  - Nested',
+		)
+		const textChange = result.model.descriptors.find(({ preview }) => (
+			preview.before?.kind === 'text'
+			&& preview.before.text === 'old'
+			&& preview.after?.kind === 'text'
+			&& preview.after.text === 'new'
+		))
+
+		expect(textChange).toMatchObject({ detail: 'inline', facets: ['text'] })
+		expect(textChange?.signals).not.toContainEqual(expect.objectContaining({ type: 'node' }))
+	})
+
+	it('classifies details state, table span, and explicit direction attributes', () => {
+		const editor = createComparisonEditor('<details>\n<summary>Title</summary>\nBody\n</details>\n\n| A |\n|---|\n| 1 |\n\nDirection')
+		try {
+			const before = editor.state.doc
+			let detailsPosition = -1
+			let cellPosition = -1
+			let paragraphPosition = -1
+			before.descendants((node, position) => {
+				if (node.type.name === 'details') {
+					detailsPosition = position
+				}
+				if (cellPosition < 0 && node.type.name === 'tableCell') {
+					cellPosition = position
+				}
+				if (node.type.name === 'paragraph' && node.textContent === 'Direction') {
+					paragraphPosition = position
+				}
+			})
+			const after = editor.state.tr
+				.setNodeAttribute(detailsPosition, 'openDetails', true)
+				.setNodeAttribute(cellPosition, 'colspan', 2)
+				.setNodeAttribute(paragraphPosition, 'dir', 'rtl')
+				.doc
+			const signals = createHierarchicalMarkdownComparisonModel(before, after).descriptors.flatMap(({ signals }) => signals)
+			expect(signals).toEqual(expect.arrayContaining([
+				{ type: 'attribute', attribute: 'details-state', change: 'changed' },
+				{ type: 'attribute', attribute: 'table-span', change: 'changed' },
+				{ type: 'attribute', attribute: 'text-direction', change: 'changed' },
+			]))
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('keeps ranges valid, anchors unchanged, output deterministic, and swap coverage symmetric', () => {
+		for (let seed = 1; seed <= 12; seed++) {
+			const unchanged = `anchor ${seed}`
+			const beforeContent = [`before ${seed}`, unchanged, `tail ${seed}`].join('\n\n')
+			const afterContent = [seed % 2 ? `insert ${seed}` : `after ${seed}`, unchanged, seed % 2 ? `after ${seed}` : `tail ${seed}`].join('\n\n')
+			const result = compare(beforeContent, afterContent)
+			const repeated = compare(beforeContent, afterContent)
+			const swapped = compare(afterContent, beforeContent)
+
+			expect(result.model.descriptors).toEqual(repeated.model.descriptors)
+			expectValidRanges(result.before, result.model.descriptors, 'before')
+			expectValidRanges(result.after, result.model.descriptors, 'after')
+			const beforeAnchor = topLevelRanges(result.before).find(({ text }) => text === unchanged)!
+			const afterAnchor = topLevelRanges(result.after).find(({ text }) => text === unchanged)!
+			expect(result.model.descriptors.some(({ before }) => touched(before, beforeAnchor))).toBe(false)
+			expect(result.model.descriptors.some(({ after }) => touched(after, afterAnchor))).toBe(false)
+			const beforeBlocks = topLevelRanges(result.before).filter(({ text }) => text)
+			const afterBlocks = topLevelRanges(result.after).filter(({ text }) => text)
+			const beforeTexts = new Set(beforeBlocks.map(({ text }) => text))
+			const afterTexts = new Set(afterBlocks.map(({ text }) => text))
+			for (const block of beforeBlocks.filter(({ text }) => !afterTexts.has(text))) {
+				expect(result.model.descriptors.filter(({ before }) => touched(before, block))).toHaveLength(1)
+			}
+			for (const block of afterBlocks.filter(({ text }) => !beforeTexts.has(text))) {
+				expect(result.model.descriptors.filter(({ after }) => touched(after, block))).toHaveLength(1)
+			}
+			const inserted = result.model.descriptors.filter(({ operation }) => operation === 'insert').length
+			const deleted = result.model.descriptors.filter(({ operation }) => operation === 'delete').length
+			expect(swapped.model.descriptors.filter(({ operation }) => operation === 'insert')).toHaveLength(deleted)
+			expect(swapped.model.descriptors.filter(({ operation }) => operation === 'delete')).toHaveLength(inserted)
+			const beforeCoverage = result.model.descriptors.map((descriptor) => rangeText(result.before, descriptor, 'before')).toSorted()
+			const swappedAfterCoverage = swapped.model.descriptors.map((descriptor) => rangeText(swapped.after, descriptor, 'after')).toSorted()
+			expect(swappedAfterCoverage).toEqual(beforeCoverage)
+		}
+	})
+})

--- a/src/tests/comparison/markdownComparison.spec.ts
+++ b/src/tests/comparison/markdownComparison.spec.ts
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { EditorState } from '@tiptap/pm/state'
 import { describe, expect, it } from 'vitest'
 import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
-import { createMarkdownComparisonModel } from '../../comparison/markdownComparison.ts'
+import {
+	createComparisonDecorationPlugin,
+	createMarkdownComparisonModel,
+} from '../../comparison/markdownComparison.ts'
 import { stableSerialize } from '../../comparison/markdownComparisonClassification.ts'
 import {
 	ATLAS_CURRENT_CONTENT,
@@ -201,6 +205,16 @@ describe('semantic Markdown comparison', () => {
 			beforeEditor.destroy()
 			afterEditor.destroy()
 		}
+	})
+
+	it('creates valid decorations for inline, structural, and empty-side changes', () => {
+		const { before, after, model } = compare('- one\n- two', '- one\n- changed\n- two')
+		const beforeDecorations = createComparisonDecorationPlugin(model.descriptors, 'before', 'Removed content')
+		const afterDecorations = createComparisonDecorationPlugin(model.descriptors, 'after', 'Added content')
+		const beforeState = EditorState.create({ doc: before, plugins: [beforeDecorations.plugin] })
+		const afterState = EditorState.create({ doc: after, plugins: [afterDecorations.plugin] })
+		expect(beforeDecorations.key.getState(beforeState)?.decorations.find().length).toBeGreaterThan(0)
+		expect(afterDecorations.key.getState(afterState)?.decorations.find().length).toBeGreaterThan(0)
 	})
 
 	it('keeps a small edit in a large document narrow', () => {

--- a/src/tests/comparison/markdownComparison.spec.ts
+++ b/src/tests/comparison/markdownComparison.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import { createMarkdownComparisonModel } from '../../comparison/markdownComparison.ts'
+import { stableSerialize } from '../../comparison/markdownComparisonClassification.ts'
+import {
+	ATLAS_CURRENT_CONTENT,
+	ATLAS_INITIAL_CONTENT,
+} from './fixtures/atlasComparison.ts'
+
+function compare(beforeContent: string, afterContent: string) {
+	const before = createComparisonEditor(beforeContent)
+	const after = createComparisonEditor(afterContent)
+	try {
+		return {
+			before: before.state.doc,
+			after: after.state.doc,
+			model: createMarkdownComparisonModel(before.state.doc, after.state.doc),
+		}
+	} finally {
+		before.destroy()
+		after.destroy()
+	}
+}
+
+describe('semantic Markdown comparison', () => {
+	it('serializes object keys by code units rather than locale collation', () => {
+		expect(stableSerialize({ ä: 1, z: 2, a: 3 })).toBe('{"a":3,"z":2,"ä":1}')
+	})
+
+	it.each([
+		['identical documents', '# Heading\n\nText', '# Heading\n\nText'],
+		['both empty', '', ''],
+		['equivalent heading syntax', '# Heading', '# Heading #'],
+	])('finds no semantic change for %s', (_name, before, after) => {
+		expect(compare(before, after).model.descriptors).toEqual([])
+	})
+
+	it.each([
+		['empty to content', '', 'content'],
+		['content to empty', 'content', ''],
+		['text insertion', 'one', 'one two'],
+		['text deletion', 'one two', 'one'],
+		['text replacement', 'one two', 'one three'],
+		['punctuation-heavy words', 'wait...what?!', 'wait—what?'],
+		['semantic whitespace', 'one\ntwo', 'one  \ntwo'],
+		['Unicode', 'café', 'cafe'],
+		['CJK', '发布计划', '发布方案'],
+		['emoji and graphemes', '👩‍💻 e\u0301', '👨‍💻 é'],
+		['bidi and RTL', 'English', 'العربية'],
+		['bold', 'text', '**text**'],
+		['italic', 'text', '*text*'],
+		['strike', 'text', '~~text~~'],
+		['inline code', 'text', '`text`'],
+		['link target', '[text](https://before.example)', '[text](https://after.example)'],
+		['heading attribute', '# Heading', '## Heading'],
+		['list attribute', '1. item', '3. item'],
+		['task attribute', '- [ ] item', '- [x] item'],
+		['paragraph and blockquote', 'paragraph', '> paragraph'],
+		['code block', '```js\nconst value = 1\n```', '```js\nconst value = 2\n```'],
+		['nested list', '- parent\n  - child one', '- parent\n  - child two'],
+		['deleted list item', '- one\n- two\n- three', '- one\n- three'],
+		['table cell', '| A | B |\n|---|---|\n| 1 | 2 |', '| A | B |\n|---|---|\n| 1 | 3 |'],
+		['deleted table row', '| A |\n|---|\n| 1 |\n| 2 |', '| A |\n|---|\n| 1 |'],
+		['deleted table cell', '| A | B |\n|---|---|\n| 1 | 2 |', '| A |\n|---|\n| 1 |'],
+		['whole table', '| A |\n|---|\n| 1 |', 'No table'],
+		['whole list', '- one\n- two', 'No list'],
+		['callout', '::: info\nBefore\n:::', '::: info\nAfter\n:::'],
+		['details', '<details>\n<summary>Title</summary>\nBefore\n</details>', '<details>\n<summary>Title</summary>\nAfter\n</details>'],
+		['mention', '@[Jane](mention://user/jane)', '@[John](mention://user/john)'],
+		['preview', '[Before](https://example.test (preview))', '[After](https://example.test (preview))'],
+		['image', '![Before](.attachments.1/before.png)', '![After](.attachments.1/after.png)'],
+		['missing historical attachment', '![Missing](.attachments.1/missing.png)', 'No image'],
+		['mathematics', '$1 + 1 = 2$', '$1 + 2 = 3$'],
+		['open cross-parent change', 'one\n\ntwo', '- one\n- two'],
+	])('detects %s', (_name, before, after) => {
+		expect(compare(before, after).model.descriptors.length).toBeGreaterThan(0)
+	})
+
+	it.each([
+		['text replacement', 'one two', 'one three', ['text'], []],
+		['bold added', 'plain text', 'plain **text**', ['formatting'], [{ type: 'mark', mark: 'bold', change: 'added' }]],
+		['bold removed', 'plain **text**', 'plain text', ['formatting'], [{ type: 'mark', mark: 'bold', change: 'removed' }]],
+		['italic added', 'plain text', 'plain *text*', ['formatting'], [{ type: 'mark', mark: 'italic', change: 'added' }]],
+		['strike added', 'plain text', 'plain ~~text~~', ['formatting'], [{ type: 'mark', mark: 'strike', change: 'added' }]],
+		['highlight added', 'plain text', 'plain ==text==', ['formatting'], [{ type: 'mark', mark: 'highlight', change: 'added' }]],
+		['mixed text and formatting', 'plain text', 'plain **changed**', ['text', 'formatting'], [{ type: 'mark', mark: 'bold', change: 'added' }]],
+		['link added', 'text', '[text](https://example.test)', ['attribute'], [{ type: 'attribute', attribute: 'link', change: 'added' }]],
+		['link removed', '[text](https://example.test)', 'text', ['attribute'], [{ type: 'attribute', attribute: 'link', change: 'removed' }]],
+		['link target', '[text](https://before.test)', '[text](https://after.test)', ['attribute'], [{ type: 'attribute', attribute: 'link-target', change: 'changed' }]],
+		['heading level', '# Heading', '## Heading', ['attribute'], [{ type: 'attribute', attribute: 'heading-level', change: 'changed' }]],
+		['list start', '1. item', '3. item', ['attribute'], [{ type: 'attribute', attribute: 'list-start', change: 'changed' }]],
+		['task state', '- [ ] item', '- [x] item', ['attribute'], [{ type: 'attribute', attribute: 'task-state', change: 'changed' }]],
+		['code language', '```js\nsame\n```', '```ts\nsame\n```', ['attribute'], [{ type: 'attribute', attribute: 'code-language', change: 'changed' }]],
+		['image attributes', '![Before](before.png)', '![After](after.png)', ['attribute'], [
+			{ type: 'attribute', attribute: 'image-alt', change: 'changed' },
+			{ type: 'attribute', attribute: 'image-target', change: 'changed' },
+		]],
+	] as const)('classifies %s', (_name, before, after, facets, signals) => {
+		const descriptors = compare(before, after).model.descriptors
+		expect(descriptors).toHaveLength(1)
+		expect(descriptors[0]?.facets).toEqual(facets)
+		expect(descriptors[0]?.signals).toEqual(signals)
+	})
+
+	it.each([
+		['front matter', '---\ntitle: Before\n---\n\nBody', '---\ntitle: After\n---\n\nBody', 'front-matter'],
+		['nested list', '- parent\n  - before', '- parent\n  - after', 'list-item'],
+		['table cell', '| A |\n|---|\n| Before |', '| A |\n|---|\n| After |', 'table-cell'],
+		['callout', '::: info\nBefore\n:::', '::: info\nAfter\n:::', 'callout'],
+		['details', '<details>\n<summary>Title</summary>\nBefore\n</details>', '<details>\n<summary>Title</summary>\nAfter\n</details>', 'details'],
+		['footnote definition', 'Text[^one].\n\n[^one]: Before', 'Text[^one].\n\n[^one]: After', 'footnote'],
+	] as const)('uses a meaningful %s context', (_name, before, after, context) => {
+		for (const descriptor of compare(before, after).model.descriptors) {
+			expect(descriptor.context.before?.code).toBe(context)
+			expect(descriptor.context.after?.code).toBe(context)
+		}
+	})
+
+	it('returns immutable, translation-independent descriptors with safe leaf previews', () => {
+		const { model } = compare('![Before](before.png)', '![After](after.png)')
+		const descriptor = model.descriptors[0]!
+		expect(Object.isFrozen(model)).toBe(true)
+		expect(Object.isFrozen(model.descriptors)).toBe(true)
+		expect(Object.isFrozen(descriptor.signals)).toBe(true)
+		expect(descriptor.preview).toEqual({
+			before: { kind: 'node', node: 'image' },
+			after: { kind: 'node', node: 'image' },
+		})
+		expect(JSON.stringify(descriptor)).not.toContain('before.png')
+		expect(JSON.stringify(descriptor)).not.toContain('After changed')
+	})
+
+	it.each([
+		['text replacement', 'one two', 'one three', 'two', 'three'],
+		['formatting-only replacement', 'plain text', 'plain **text**', 'text', 'text'],
+		['link-target replacement', '[text](https://before.example)', '[text](https://after.example)', 'text', 'text'],
+		['table-cell replacement', '| A | B |\n|---|---|\n| 1 | 2 |', '| A | B |\n|---|---|\n| 1 | 3 |', '2', '3'],
+	])('keeps %s ranges on the changed content', (_name, beforeContent, afterContent, beforeText, afterText) => {
+		const { before, after, model } = compare(beforeContent, afterContent)
+		expect(model.descriptors).toHaveLength(1)
+		const [change] = model.descriptors
+		expect(before.textBetween(change!.before.from, change!.before.to)).toBe(beforeText)
+		expect(after.textBetween(change!.after.from, change!.after.to)).toBe(afterText)
+	})
+
+	it('detects normalized node attributes without a text change', () => {
+		const beforeEditor = createComparisonEditor('same text')
+		try {
+			const before = beforeEditor.state.doc
+			const after = beforeEditor.state.tr.setNodeAttribute(0, 'dir', 'rtl').doc
+			expect(createMarkdownComparisonModel(before, after).descriptors).not.toEqual([])
+		} finally {
+			beforeEditor.destroy()
+		}
+	})
+
+	it('classifies a normalized text-direction attribute without exposing its raw value', () => {
+		const editor = createComparisonEditor('same text')
+		try {
+			const before = editor.state.doc
+			const after = editor.state.tr.setNodeAttribute(0, 'dir', 'rtl').doc
+			const descriptor = createMarkdownComparisonModel(before, after).descriptors[0]
+			expect(descriptor).toMatchObject({
+				facets: ['attribute'],
+				signals: [{ type: 'attribute', attribute: 'text-direction', change: 'changed' }],
+			})
+			expect(JSON.stringify(descriptor)).not.toContain('rtl')
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('keeps an explicit direction removal on unchanged neutral text', () => {
+		const editor = createComparisonEditor('1234')
+		try {
+			const before = editor.state.tr.setNodeAttribute(0, 'dir', 'rtl').doc
+			const after = editor.state.tr.setNodeAttribute(0, 'dir', null).doc
+			expect(createMarkdownComparisonModel(before, after).descriptors[0]?.signals)
+				.toContainEqual({ type: 'attribute', attribute: 'text-direction', change: 'changed' })
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('keeps an explicit direction removal when neutral text also changes', () => {
+		const beforeEditor = createComparisonEditor('1234')
+		const afterEditor = createComparisonEditor('5678')
+		try {
+			const before = beforeEditor.state.tr.setNodeAttribute(0, 'dir', 'rtl').doc
+			const signals = createMarkdownComparisonModel(before, afterEditor.state.doc)
+				.descriptors.flatMap(({ signals }) => signals)
+
+			expect(signals)
+				.toContainEqual({ type: 'attribute', attribute: 'text-direction', change: 'changed' })
+		} finally {
+			beforeEditor.destroy()
+			afterEditor.destroy()
+		}
+	})
+
+	it('keeps a small edit in a large document narrow', () => {
+		const common = Array.from({ length: 1000 }, (_, index) => `line ${index}`).join('\n\n')
+		const { model } = compare(common, common.replace('line 500', 'line changed'))
+		expect(model.descriptors).toHaveLength(1)
+		const [change] = model.descriptors
+		expect(change!.before.to - change!.before.from).toBeLessThan(20)
+		expect(change!.after.to - change!.after.from).toBeLessThan(20)
+		expect(change!.detail).toBe('inline')
+	})
+
+	it('uses honest block detail beyond the bounded inline budget', () => {
+		const before = `# Before\n\n${'a'.repeat(6000)}`
+		const after = `# After\n\n${'b'.repeat(6000)}`
+		const { model } = compare(before, after)
+		expect(model.descriptors).toHaveLength(2)
+		expect(model.descriptors.map(({ detail }) => detail)).toEqual(['inline', 'block'])
+	})
+
+	it('pins the Atlas launch-plan semantic classifications', () => {
+		const { model } = compare(ATLAS_INITIAL_CONTENT, ATLAS_CURRENT_CONTENT)
+		const signals = model.descriptors.flatMap(({ signals }) => signals)
+		const contexts = model.descriptors.flatMap(({ context }) => [
+			context.before?.code,
+			context.after?.code,
+		])
+
+		expect(model.descriptors.filter(({ operation }) => operation === 'move')).toHaveLength(1)
+		expect(model.descriptors.filter(({ facets }) => facets.length === 1 && facets[0] === 'formatting'))
+			.toHaveLength(2)
+		expect(model.descriptors).toContainEqual(expect.objectContaining({ facets: ['text', 'formatting'] }))
+		expect(signals).toEqual(expect.arrayContaining([
+			{ type: 'mark', mark: 'bold', change: 'added' },
+			{ type: 'mark', mark: 'italic', change: 'added' },
+			{ type: 'attribute', attribute: 'link', change: 'added' },
+			{ type: 'attribute', attribute: 'link', change: 'removed' },
+			{ type: 'attribute', attribute: 'link-target', change: 'changed' },
+			{ type: 'attribute', attribute: 'task-state', change: 'changed' },
+			{ type: 'attribute', attribute: 'callout-type', change: 'changed' },
+			{ type: 'attribute', attribute: 'footnote-reference', change: 'changed' },
+			{ type: 'attribute', attribute: 'image-alt', change: 'changed' },
+		]))
+		expect(signals).not.toContainEqual({ type: 'attribute', attribute: 'text-direction', change: 'changed' })
+		expect(contexts).toEqual(expect.arrayContaining([
+			'front-matter',
+			'quote',
+			'paragraph',
+			'heading',
+			'task',
+			'table-cell',
+			'callout',
+			'details',
+			'code-block',
+			'footnote-reference',
+			'image',
+			'footnote',
+		]))
+	})
+})

--- a/src/tests/comparison/markdownComparisonMoves.spec.ts
+++ b/src/tests/comparison/markdownComparisonMoves.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import { confirmReservedExactMoves } from '../../comparison/markdownComparisonMoves.ts'
+
+describe('Markdown comparison moves', () => {
+	it('does not traverse either document without reserved move candidates', () => {
+		const beforeEditor = createComparisonEditor('Before')
+		const afterEditor = createComparisonEditor('After')
+		try {
+			const beforeDescendants = vi.spyOn(beforeEditor.state.doc, 'descendants')
+			const afterDescendants = vi.spyOn(afterEditor.state.doc, 'descendants')
+
+			expect(confirmReservedExactMoves(beforeEditor.state.doc, afterEditor.state.doc, []))
+				.toEqual({ groups: [], rejected: [] })
+			expect(beforeDescendants).not.toHaveBeenCalled()
+			expect(afterDescendants).not.toHaveBeenCalled()
+		} finally {
+			beforeEditor.destroy()
+			afterEditor.destroy()
+		}
+	})
+})

--- a/src/tests/comparison/markdownSourceComparison.spec.ts
+++ b/src/tests/comparison/markdownSourceComparison.spec.ts
@@ -1,0 +1,399 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+	createMarkdownSourceComparison,
+	SOURCE_DIFF_LIMITS,
+} from '../../comparison/markdownSourceComparison.ts'
+import { compareMarkdownSourceLines } from '../../comparison/markdownSourceComparisonProtocol.ts'
+import {
+	ATLAS_CURRENT_CONTENT,
+	ATLAS_INITIAL_CONTENT,
+	ATLAS_SYNTAX_ONLY_CONTENT,
+} from './fixtures/atlasComparison.ts'
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe('Markdown source comparison', () => {
+	it('uses one bounded result contract in the worker and synchronous fallback', () => {
+		expect(compareMarkdownSourceLines({
+			after: 'new\n',
+			before: 'old\n',
+			maximumEditLength: 10,
+			timeoutMilliseconds: 1000,
+		})).toMatchObject({ status: 'ready' })
+		expect(compareMarkdownSourceLines({
+			after: 'new\n',
+			before: 'old\n',
+			maximumEditLength: 0,
+			timeoutMilliseconds: 1000,
+		})).toEqual({ status: 'limited' })
+	})
+
+	it.each(['', '# Same\n', 'line 1\r\nline 2'])('returns no hunks for identical raw source', async (source) => {
+		await expect(createMarkdownSourceComparison(source, source)).resolves.toMatchObject({
+			status: 'ready',
+			hunks: [],
+		})
+	})
+
+	it('summarizes a file-wide line-ending change without presenting a rewrite', async () => {
+		const model = await createMarkdownSourceComparison('first\nsecond\n', 'first\r\nsecond\r\n')
+		expect(model).toMatchObject({
+			status: 'ready',
+			hunks: [],
+			lineEndingChange: { before: 'lf', after: 'crlf' },
+		})
+	})
+
+	it.each([
+		['uniform to mixed', 'first\nsecond\n', 'first\r\nsecond\n', { before: 'lf', after: 'mixed' }],
+		['mixed pattern', 'first\r\nsecond\n', 'first\nsecond\r\n', { before: 'mixed', after: 'mixed' }],
+	] as const)('does not hide a %s line-ending-only change', async (_name, before, after, lineEndingChange) => {
+		await expect(createMarkdownSourceComparison(before, after)).resolves.toMatchObject({
+			status: 'ready',
+			hunks: [],
+			lineEndingChange,
+		})
+	})
+
+	it('does not report equal mixed conventions across content edits', async () => {
+		await expect(createMarkdownSourceComparison(
+			'first\r\nold\nthird\r\n',
+			'first\nnew\r\nthird\r\n',
+		)).resolves.toMatchObject({
+			status: 'ready',
+			lineEndingChange: null,
+		})
+	})
+
+	it('preserves exact line content and adds bounded intra-line emphasis', async () => {
+		const model = await createMarkdownSourceComparison('one old value\n', 'one new value\n')
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		expect(model.hunks).toHaveLength(1)
+		expect(model.hunks[0]?.before[0]).toMatchObject({ number: 1, text: 'one old value', changed: true, eol: 'lf' })
+		expect(model.hunks[0]?.after[0]).toMatchObject({ number: 1, text: 'one new value', changed: true, eol: 'lf' })
+		expect(model.hunks[0]?.before[0]?.segments).toContainEqual({ text: 'old', changed: true })
+		expect(model.hunks[0]?.after[0]?.segments).toContainEqual({ text: 'new', changed: true })
+	})
+
+	it('keeps line-level changes when word emphasis exceeds its time limit', async () => {
+		let now = 0
+		const clock = vi.spyOn(Date, 'now').mockImplementation(() => now += 11)
+		try {
+			const before = `${'a '.repeat(999)}a`
+			const after = `${'b '.repeat(999)}b`
+			const model = await createMarkdownSourceComparison(before, after)
+			expect(model.status).toBe('ready')
+			if (model.status !== 'ready') {
+				return
+			}
+			expect(model.hunks[0]?.before[0]?.changed).toBe(true)
+			expect(model.hunks[0]?.after[0]?.changed).toBe(true)
+			expect(model.hunks[0]?.before[0]?.segments.some(({ changed }) => changed)).toBe(false)
+			expect(model.hunks[0]?.after[0]?.segments.some(({ changed }) => changed)).toBe(false)
+		} finally {
+			clock.mockRestore()
+		}
+	})
+
+	it('keeps syntax-only equivalent Markdown visible', async () => {
+		const model = await createMarkdownSourceComparison('# Heading', '# Heading #')
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		expect(model.hunks.length).toBeGreaterThan(0)
+		expect(model.hunks[0]?.before.some(({ text }) => text === '# Heading')).toBe(true)
+		expect(model.hunks[0]?.after.some(({ text }) => text === '# Heading #')).toBe(true)
+	})
+
+	it.each([
+		['insertion at the start', 'two\nthree\n', 'one\ntwo\nthree\n', 0, 1],
+		['line insertion', 'one\nthree\n', 'one\ntwo\nthree\n', 0, 1],
+		['insertion at the end', 'one\ntwo\n', 'one\ntwo\nthree\n', 0, 1],
+		['deletion at the start', 'one\ntwo\nthree\n', 'two\nthree\n', 1, 0],
+		['line deletion', 'one\ntwo\nthree\n', 'one\nthree\n', 1, 0],
+		['deletion at the end', 'one\ntwo\nthree\n', 'one\ntwo\n', 1, 0],
+		['line replacement', 'one\nold\nthree\n', 'one\nnew\nthree\n', 1, 1],
+	] as const)('preserves a simple %s', async (_name, before, after, removed, added) => {
+		const model = await createMarkdownSourceComparison(before, after)
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		expect(model.hunks).toHaveLength(1)
+		expect(model.lineEndingChange).toBeNull()
+		expect(model.hunks[0]?.before.filter(({ changed }) => changed)).toHaveLength(removed)
+		expect(model.hunks[0]?.after.filter(({ changed }) => changed)).toHaveLength(added)
+	})
+
+	it('preserves changed blank lines as source lines', async () => {
+		const model = await createMarkdownSourceComparison('one\n\ntwo\n', 'one\n \ntwo\n')
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		expect(model.hunks.flatMap(({ before }) => before)).toContainEqual(expect.objectContaining({ text: '' }))
+		expect(model.hunks.flatMap(({ after }) => after)).toContainEqual(expect.objectContaining({ text: ' ', changed: true, hasTrailingWhitespace: true }))
+	})
+
+	it('exposes spaces, tabs, zero-width characters, EOL changes, and missing final newline', async () => {
+		const before = 'tab\tvalue  \r\nzero\u200Bwidth\nlast'
+		const after = 'tab value \nzero width\nlast\n'
+		const model = await createMarkdownSourceComparison(before, after)
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		const beforeLines = model.hunks.flatMap(({ before }) => before)
+		const afterLines = model.hunks.flatMap(({ after }) => after)
+		expect(beforeLines[0]).toMatchObject({ hasTab: true, hasTrailingWhitespace: true, eol: 'crlf' })
+		expect(beforeLines.some(({ hasZeroWidth }) => hasZeroWidth)).toBe(true)
+		expect(beforeLines.at(-1)).toMatchObject({ missingFinalNewline: true, eol: 'none' })
+		expect(afterLines.at(-1)).toMatchObject({ missingFinalNewline: false, eol: 'lf' })
+		expect(beforeLines.some(({ eolChanged }) => eolChanged)).toBe(true)
+	})
+
+	it.each([
+		['CJK', '发布计划', '发布方案'],
+		['RTL and bidi', 'English', '\u2067العربية\u2069'],
+		['emoji', '👩‍💻', '👨‍💻'],
+		['combining marks', 'e\u0301', 'é'],
+		['HTML-like source', '<script>globalThis.pwned = true</script>', '<img src=x onerror=alert(1)>'],
+	])('returns %s as literal source text', async (_name, before, after) => {
+		const model = await createMarkdownSourceComparison(before, after)
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		expect(model.hunks[0]?.before.map(({ text }) => text).join('\n')).toContain(before)
+		expect(model.hunks[0]?.after.map(({ text }) => text).join('\n')).toContain(after)
+	})
+
+	it('groups distant changes into hunks with an expandable gap payload', async () => {
+		const before = Array.from({ length: 20 }, (_, index) => `line ${index}`)
+		const after = [...before]
+		after[1] = 'changed one'
+		after[18] = 'changed eighteen'
+		const model = await createMarkdownSourceComparison(before.join('\n'), after.join('\n'))
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		expect(model.hunks).toHaveLength(2)
+		expect(model.gaps).toHaveLength(1)
+		expect(model.gaps[0]?.count).toBeGreaterThan(0)
+		expect(model.gaps[0]?.before.every(({ changed }) => !changed)).toBe(true)
+	})
+
+	it('keeps changed cores disjoint when their context merges', async () => {
+		const before = Array.from({ length: 12 }, (_, index) => `line ${index}`)
+		const after = [...before]
+		before[1] = 'first old value'
+		after[1] = 'first new value'
+		before[8] = 'second old value'
+		after[8] = 'second new value'
+		const model = await createMarkdownSourceComparison(before.join('\n'), after.join('\n'))
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+
+		expect(model.hunks).toHaveLength(1)
+		const hunk = model.hunks[0]!
+		expect(hunk.before.filter(({ changed }) => changed).map(({ number }) => number)).toEqual([2, 9])
+		expect(hunk.after.filter(({ changed }) => changed).map(({ number }) => number)).toEqual([2, 9])
+		expect(hunk.before.find(({ text }) => text === 'line 5')).toMatchObject({
+			changed: false,
+			eolChanged: false,
+			segments: [{ text: 'line 5', changed: false }],
+		})
+		expect(hunk.after.find(({ text }) => text === 'line 5')).toMatchObject({
+			changed: false,
+			eolChanged: false,
+			segments: [{ text: 'line 5', changed: false }],
+		})
+		expect(hunk.before.find(({ text }) => text === 'first old value')?.segments)
+			.toContainEqual({ text: 'old', changed: true })
+		expect(hunk.after.find(({ text }) => text === 'second new value')?.segments)
+			.toContainEqual({ text: 'new', changed: true })
+	})
+
+	it('exposes unchanged source before and after a middle hunk', async () => {
+		const before = Array.from({ length: 25 }, (_, index) => `line ${index}`)
+		const after = [...before]
+		after[10] = 'changed ten'
+		const model = await createMarkdownSourceComparison(before.join('\n'), after.join('\n'))
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		expect(model.hunks).toHaveLength(1)
+		expect(model.gaps.map(({ slot }) => slot)).toEqual([0, 1])
+		expect(model.gaps[0]?.before[0]?.text).toBe('line 0')
+		expect(model.gaps[1]?.before.at(-1)?.text).toBe('line 24')
+		expect(model.gaps.every(({ before: left, after: right }) => (
+			left.every(({ changed }) => !changed)
+			&& right.every(({ changed }) => !changed)
+		))).toBe(true)
+	})
+
+	it('returns an explicit size limit and supports caller cancellation', async () => {
+		const large = 'x'.repeat(SOURCE_DIFF_LIMITS.maximumCharacters + 1)
+		await expect(createMarkdownSourceComparison(large, '')).resolves.toEqual({ status: 'limited', reason: 'size' })
+
+		const controller = new AbortController()
+		controller.abort()
+		await expect(createMarkdownSourceComparison('before', 'after', controller.signal))
+			.rejects.toMatchObject({ name: 'AbortError' })
+	})
+
+	it('rejects excessive line-object cardinality below the character limit', async () => {
+		const manyShortLines = 'x\n'.repeat(SOURCE_DIFF_LIMITS.maximumLines + 1)
+		expect(manyShortLines.length).toBeLessThan(SOURCE_DIFF_LIMITS.maximumCharacters)
+		await expect(createMarkdownSourceComparison(manyShortLines, ''))
+			.resolves.toEqual({ status: 'limited', reason: 'size' })
+	})
+
+	it('terminates an in-flight worker when the caller cancels', async () => {
+		const terminate = vi.fn()
+		class WorkerMock {
+			addEventListener() {}
+
+			postMessage() {}
+			terminate = terminate
+		}
+		vi.stubGlobal('Worker', WorkerMock)
+		const controller = new AbortController()
+		const result = createMarkdownSourceComparison('before', 'after', controller.signal)
+		controller.abort()
+		await expect(result).rejects.toMatchObject({ name: 'AbortError' })
+		expect(terminate).toHaveBeenCalledOnce()
+	})
+
+	it('observes cancellation that occurs while the worker is created', async () => {
+		const controller = new AbortController()
+		const postMessage = vi.fn()
+		const terminate = vi.fn()
+		class WorkerMock {
+			listeners = new Map<string, EventListener>()
+
+			constructor() {
+				controller.abort()
+			}
+
+			addEventListener(type: string, listener: EventListener) {
+				this.listeners.set(type, listener)
+			}
+
+			removeEventListener(type: string) {
+				this.listeners.delete(type)
+			}
+
+			postMessage = postMessage.mockImplementation(() => {
+				this.listeners.get('message')?.({ data: { status: 'ready', changes: [] } } as unknown as Event)
+			})
+
+			terminate = terminate
+		}
+		vi.stubGlobal('Worker', WorkerMock)
+
+		await expect(createMarkdownSourceComparison('before', 'after', controller.signal))
+			.rejects.toMatchObject({ name: 'AbortError' })
+		expect(postMessage).not.toHaveBeenCalled()
+		expect(terminate).toHaveBeenCalledOnce()
+	})
+
+	it('bounds word emphasis across fragmented changed runs', async () => {
+		const clock = vi.spyOn(Date, 'now').mockReturnValue(0)
+		try {
+			const changedLineCount = SOURCE_DIFF_LIMITS.maximumWordDiffPairs + 1
+			const before = Array.from({ length: changedLineCount }, (_, index) => [
+				`old value ${index}`,
+				`unchanged ${index}`,
+			]).flat()
+			const after = before.map((line) => line.replace('old', 'new'))
+			const model = await createMarkdownSourceComparison(before.join('\n'), after.join('\n'))
+			expect(model.status).toBe('ready')
+			if (model.status !== 'ready') {
+				return
+			}
+
+			const changedLines = model.hunks.flatMap(({ after }) => after).filter(({ changed }) => changed)
+			const emphasizedLines = changedLines.filter(({ segments }) => segments.some(({ changed }) => changed))
+			expect(changedLines).toHaveLength(changedLineCount)
+			expect(emphasizedLines).toHaveLength(SOURCE_DIFF_LIMITS.maximumWordDiffPairs)
+		} finally {
+			clock.mockRestore()
+		}
+	})
+
+	it('returns an explicit complexity limit for a total rewrite beyond the edit budget', async () => {
+		const lineCount = SOURCE_DIFF_LIMITS.maximumEditLength / 2 + 1
+		const before = Array.from({ length: lineCount }, () => 'before').join('\n')
+		const after = Array.from({ length: lineCount }, () => 'after').join('\n')
+		await expect(createMarkdownSourceComparison(before, after)).resolves.toEqual({ status: 'limited', reason: 'complexity' })
+	})
+
+	it('does not return more source rows than the view can render safely', async () => {
+		const lineCount = SOURCE_DIFF_LIMITS.maximumDisplayedRows + 1
+		const before = Array.from({ length: lineCount }, (_, index) => `before ${index}`).join('\n')
+		const after = Array.from({ length: lineCount }, (_, index) => `after ${index}`).join('\n')
+
+		await expect(createMarkdownSourceComparison(before, after))
+			.resolves.toEqual({ status: 'limited', reason: 'complexity' })
+	})
+
+	it('counts removal-heavy and addition-heavy runs in one displayed-row bound', async () => {
+		const lineCount = SOURCE_DIFF_LIMITS.maximumDisplayedRows / 2 + 1
+		const before = [
+			...Array.from({ length: lineCount }, (_, index) => `removed ${index}`),
+			'shared anchor',
+		].join('\n')
+		const after = [
+			'shared anchor',
+			...Array.from({ length: lineCount }, (_, index) => `added ${index}`),
+		].join('\n')
+
+		await expect(createMarkdownSourceComparison(before, after))
+			.resolves.toEqual({ status: 'limited', reason: 'complexity' })
+	})
+
+	it('preserves the Atlas syntax-only EOL, whitespace, and final-newline differences', async () => {
+		const model = await createMarkdownSourceComparison(ATLAS_INITIAL_CONTENT, ATLAS_SYNTAX_ONLY_CONTENT)
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		const before = model.hunks.flatMap(({ before }) => before)
+		const after = model.hunks.flatMap(({ after }) => after)
+		const beforeLineCount = before.length + model.gaps.flatMap(({ before }) => before).length
+		const afterLineCount = after.length + model.gaps.flatMap(({ after }) => after).length
+		expect(model.hunks.length).toBeGreaterThan(0)
+		expect(model.lineEndingChange).toEqual({ before: 'lf', after: 'crlf' })
+		expect(before.filter(({ changed }) => changed).length).toBeLessThan(beforeLineCount)
+		expect(after.filter(({ changed }) => changed).length).toBeLessThan(afterLineCount)
+		expect(after.some(({ eol }) => eol === 'crlf')).toBe(true)
+		expect(after.some(({ hasTrailingWhitespace }) => hasTrailingWhitespace)).toBe(true)
+		expect(after.at(-1)).toMatchObject({ eol: 'none', missingFinalNewline: true })
+	})
+
+	it('keeps changed Atlas code literal in the source model', async () => {
+		const model = await createMarkdownSourceComparison(ATLAS_INITIAL_CONTENT, ATLAS_CURRENT_CONTENT)
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		expect(model.hunks.flatMap(({ after }) => after).map(({ text }) => text))
+			.toContain('const rollbackThreshold = 0.015')
+	})
+})

--- a/src/tests/comparison/markdownSourceComparisonWorker.spec.ts
+++ b/src/tests/comparison/markdownSourceComparisonWorker.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { SourceComparisonWorkerRequest } from '../../comparison/markdownSourceComparisonProtocol.ts'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+	vi.resetModules()
+	vi.unstubAllGlobals()
+})
+
+describe('Markdown source comparison worker', () => {
+	it('handles ready and limited protocol responses', async () => {
+		let listener: ((event: MessageEvent<SourceComparisonWorkerRequest>) => void) | undefined
+		const addEventListener = vi.fn((type, nextListener) => {
+			expect(type).toBe('message')
+			listener = nextListener
+		})
+		const postMessage = vi.fn()
+		vi.stubGlobal('addEventListener', addEventListener)
+		vi.stubGlobal('postMessage', postMessage)
+
+		await import('../../comparison/markdownSourceComparison.worker.ts')
+		expect(addEventListener).toHaveBeenCalledOnce()
+
+		listener?.(new MessageEvent('message', {
+			data: {
+				after: 'new\n',
+				before: 'old\n',
+				maximumEditLength: 10,
+				timeoutMilliseconds: 1000,
+			},
+		}))
+		expect(postMessage).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'ready' }))
+
+		listener?.(new MessageEvent('message', {
+			data: {
+				after: 'new\n',
+				before: 'old\n',
+				maximumEditLength: 0,
+				timeoutMilliseconds: 1000,
+			},
+		}))
+		expect(postMessage).toHaveBeenLastCalledWith({ status: 'limited' })
+	})
+})

--- a/src/tests/comparison/renderedComparisonLimit.spec.ts
+++ b/src/tests/comparison/renderedComparisonLimit.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+	exceedsRenderedComparisonLimit,
+	RENDERED_COMPARISON_LIMITS,
+} from '../../comparison/renderedComparisonLimit.ts'
+
+describe('renderedComparisonLimit', () => {
+	it('keeps at least 20% below the smallest measured failing dimensions', () => {
+		expect(RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot).toBeLessThanOrEqual(Math.floor(264_599 * 0.8))
+		expect(RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot).toBeLessThanOrEqual(Math.floor(8_163 * 0.8))
+	})
+
+	it('allows a normal page comparison', () => {
+		expect(exceedsRenderedComparisonLimit('# Before\n\nContent', '# After\n\nRevised content')).toBe(false)
+	})
+
+	it.each([
+		RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot - 1,
+		RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot,
+	])('allows a snapshot with %i characters', (length) => {
+		expect(exceedsRenderedComparisonLimit('a'.repeat(length), 'After')).toBe(false)
+	})
+
+	it('rejects either snapshot above the character limit', () => {
+		const oversized = 'a'.repeat(RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot + 1)
+		expect(exceedsRenderedComparisonLimit(oversized, 'After')).toBe(true)
+		expect(exceedsRenderedComparisonLimit('Before', oversized)).toBe(true)
+	})
+
+	it.each([
+		RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot - 1,
+		RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot,
+	])('allows a snapshot with %i lines', (lineCount) => {
+		const content = Array.from({ length: lineCount }, () => 'line').join('\n')
+		expect(exceedsRenderedComparisonLimit(content, 'After')).toBe(false)
+	})
+
+	it('rejects either snapshot above the line limit with LF, CRLF, or CR separators', () => {
+		const lineCount = RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot + 1
+		for (const separator of ['\n', '\r\n', '\r']) {
+			const oversized = Array.from({ length: lineCount }, () => 'line').join(separator)
+			expect(exceedsRenderedComparisonLimit(oversized, 'After')).toBe(true)
+			expect(exceedsRenderedComparisonLimit('Before', oversized)).toBe(true)
+		}
+	})
+})

--- a/src/tests/components/Menu/actionStateCleanup.spec.js
+++ b/src/tests/components/Menu/actionStateCleanup.spec.js
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ActionList from '../../../components/Menu/ActionList.vue'
+import { BaseActionEntry } from '../../../components/Menu/BaseActionEntry.js'
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe('menu action state cleanup', () => {
+	it('cancels pending action state updates before the editor is destroyed', () => {
+		vi.useFakeTimers()
+		const context = createContext()
+
+		BaseActionEntry.mounted.call(context)
+		context.$_updateState()
+		BaseActionEntry.beforeUnmount.call(context)
+		vi.runAllTimers()
+
+		expect(context.updateState).not.toHaveBeenCalled()
+		expect(context.editor.off).toHaveBeenCalledWith('update', context.$_updateState)
+		expect(context.editor.off).toHaveBeenCalledWith('selectionUpdate', context.$_updateState)
+	})
+
+	it('keeps and clears the list child update independently from the base update', () => {
+		vi.useFakeTimers()
+		const context = createContext()
+
+		BaseActionEntry.mounted.call(context)
+		const updateState = context.$_updateState
+		ActionList.mounted.call(context)
+		const updateChildrenState = context.$_updateChildrenState
+		updateState()
+		updateChildrenState()
+
+		ActionList.beforeUnmount.call(context)
+		BaseActionEntry.beforeUnmount.call(context)
+		vi.runAllTimers()
+
+		expect(updateChildrenState).not.toBe(updateState)
+		expect(context.updateState).not.toHaveBeenCalled()
+		expect(context.checkStateOfChildren).not.toHaveBeenCalled()
+		expect(context.editor.off).toHaveBeenCalledWith('update', updateState)
+		expect(context.editor.off).toHaveBeenCalledWith('update', updateChildrenState)
+	})
+})
+
+function createContext() {
+	return {
+		actionEntry: {},
+		checkStateOfChildren: vi.fn(),
+		editor: {
+			off: vi.fn(),
+			on: vi.fn(),
+		},
+		setTabIndexOnButton: vi.fn(),
+		state: { disabled: false },
+		updateState: vi.fn(),
+		$emit: vi.fn(),
+	}
+}

--- a/src/tests/extensions/TextDirection.spec.ts
+++ b/src/tests/extensions/TextDirection.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Transaction } from '@tiptap/pm/state'
+
+import { Editor } from '@tiptap/core'
+import { afterEach, describe, expect, it } from 'vitest'
+import RichText from '../../extensions/RichText.ts'
+import TextDirection from '../../extensions/TextDirection.ts'
+import markdownit from '../../markdownit/index.js'
+
+const directionTypes = [
+	'blockquote',
+	'callout',
+	'detailsSummary',
+	'footnote',
+	'heading',
+	'listItem',
+	'paragraph',
+	'tableCell',
+	'tableHeader',
+	'taskItem',
+]
+
+const editors: Editor[] = []
+
+afterEach(() => {
+	for (const editor of editors.splice(0)) {
+		editor.destroy()
+	}
+})
+
+function createEditor(
+	defaultDirection: 'ltr' | 'rtl' | 'auto' | null = null,
+	content?: string,
+	inferTextDirectionOnParse = true,
+) {
+	const editor = new Editor({
+		content,
+		extensions: [
+			RichText.configure({
+				editing: false,
+				extensions: [TextDirection.configure({
+					defaultDirection,
+					inferTextDirectionOnParse,
+					types: directionTypes,
+				})],
+			}),
+		],
+	})
+	editors.push(editor)
+	return editor
+}
+
+function captureAppendedTransactions(editor: Editor) {
+	const transactions: Transaction[] = []
+	editor.on('transaction', ({ appendedTransactions }) => transactions.push(...appendedTransactions))
+	return transactions
+}
+
+function directionSteps(transactions: readonly Transaction[]) {
+	return transactions.flatMap(({ steps }) => steps).filter((step) => {
+		const json = step.toJSON() as { attr?: string, attrs?: Record<string, unknown> }
+		return json.attr === 'dir' || json.attrs?.dir !== undefined
+	})
+}
+
+function nodeDirections(editor: Editor, type: string) {
+	const directions: Array<string | null> = []
+	editor.state.doc.descendants((node) => {
+		if (node.type.name === type) {
+			directions.push(node.attrs.dir as string | null)
+		}
+		return true
+	})
+	return directions
+}
+
+describe('TextDirection', () => {
+	it('keeps parse-time inference opt-in', () => {
+		const editor = createEditor(null, '<p>English</p>', false)
+		expect(nodeDirections(editor, 'paragraph')[0]).toBeNull()
+	})
+
+	it('infers parsed LTR and RTL content without an appended direction transaction', () => {
+		const editor = createEditor()
+		const appended = captureAppendedTransactions(editor)
+		editor.commands.setContent('<p>English</p><p>العربية</p>')
+
+		expect(nodeDirections(editor, 'paragraph').slice(0, 2)).toEqual(['ltr', 'rtl'])
+		expect(directionSteps(appended)).toEqual([])
+	})
+
+	it('preserves explicit valid direction before inferred content direction', () => {
+		const editor = createEditor()
+		editor.commands.setContent([
+			'<p dir="rtl">English</p>',
+			'<p dir="ltr">العربية</p>',
+			'<p dir="auto">English</p>',
+			'<p dir="invalid">English</p>',
+		].join(''))
+
+		expect(nodeDirections(editor, 'paragraph').slice(0, 4)).toEqual(['rtl', 'ltr', 'auto', 'ltr'])
+	})
+
+	it.each([
+		[null, [null, null]],
+		['rtl', ['rtl', 'rtl']],
+	] as const)('uses the %s default for neutral and empty parsed content', (defaultDirection, expected) => {
+		const editor = createEditor(defaultDirection, '<p>1234</p><p></p>')
+		expect(nodeDirections(editor, 'paragraph').slice(0, 2)).toEqual(expected)
+	})
+
+	it('infers direction for every configured nested RichText node', () => {
+		const editor = createEditor()
+		const markdown = [
+			'# Heading',
+			'',
+			'> Quote',
+			'',
+			'- List item',
+			'',
+			'- [ ] Task item',
+			'',
+			'::: info',
+			'Callout',
+			':::',
+			'',
+			'<details>',
+			'<summary>Summary</summary>',
+			'Details',
+			'</details>',
+			'',
+			'| Header |',
+			'|---|',
+			'| Cell |',
+			'',
+			'Reference[^note].',
+			'',
+			'[^note]: Footnote',
+		].join('\n')
+		editor.commands.setContent(markdownit.render(markdown))
+
+		for (const type of directionTypes) {
+			expect(nodeDirections(editor, type), type).not.toEqual([])
+			expect(nodeDirections(editor, type), type).toEqual(expect.arrayContaining(['ltr']))
+		}
+	})
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,15 @@ const config = createAppConfig(
 		},
 		config: {
 			base: process.env.BASE,
+			worker: {
+				rollupOptions: {
+					output: {
+						assetFileNames: 'js/[name]-[hash][extname]',
+						chunkFileNames: 'js/[name]-[hash].worker.chunk.mjs',
+						entryFileNames: 'js/[name]-[hash].worker.mjs',
+					},
+				},
+			},
 			resolve: {
 				dedupe: ['vue'],
 			},


### PR DESCRIPTION
**In one sentence:** the Markdown source view that catches what rendering hides — line endings, whitespace, syntax — computed in a worker.

## What and why

Two revisions can render identically and still differ: LF vs CRLF, trailing whitespace, a missing final newline, link syntax rewritten. The semantic engine works on parsed documents, so by design it cannot see these. This PR adds the view that can.

## What's in this PR

- A **Markdown source** view comparing the literal text, with line numbers and token-level emphasis
- Explicit diagnostics: line-ending changes, per-line LF/CRLF badges, trailing whitespace, missing final newlines
- All computation in a **cancellable module worker** with three explicit limits: 2,000,000 characters, 50,000 edits, 2,000 ms — a limit always reports itself as limited, never as "identical"

![The Changes view honestly reporting zero rendered differences, with a direct button to the Markdown source view](https://raw.githubusercontent.com/hweihwang/text/demo-assets/04-rendered-equal-source-diff.png)
*Zero rendered changes, stated honestly — the whole reason this view exists.*

![Markdown source view: line numbers, −/+ gutters, token-level emphasis](https://raw.githubusercontent.com/hweihwang/text/demo-assets/03-markdown-source-literal-wide.png)
*The source view. Source change groups can differ from rendered ones.*

![Diagnostics: LF → CRLF banner, per-line badges, trailing-whitespace badge](https://raw.githubusercontent.com/hweihwang/text/demo-assets/05-source-eol-whitespace-diagnostics.png)
*Explicit diagnostics for what the rendered view cannot show.*

## Design notes

- **Source is a separate subsystem, not a mode** — the semantic engine can't see what parsing discards, and that is the entire subject of this view.
- **The worker exists even for small documents**: Myers complexity tracks edit distance, not size, so a size cap alone would not stop a two-second UI freeze.
- **The worker is emitted under `js/`** (verified: `js/markdownSourceComparison.worker-Bn7Bh2ec.worker.mjs`, no `assets/`) so the post-merge asset pipeline regenerates it. Under Vite's default `assets/` it would build locally but disappear after merge.
- **`diff@8.0.3`** (BSD-3-Clause, kpdecker/jsdiff) is declared here only — T1–T3 don't import it.

## Stack

Depends on: #9045. Last Text unit — after this, Collectives nextcloud/collectives#2697 and #2698. Opened stacked — the diff narrows as predecessors merge; I'll rebase before review.

## Verification

`ts:check` and `lint` pass; complete suite 1,917/1,917. Worker `ready`/`limited` protocol responses are tested against the real module. Production build re-run at this tip: emitted `js/markdownSourceComparison.worker-Bn7Bh2ec.worker.mjs`, no `assets/` directory.

## AI assistance

Commits carry `Assisted-by: Codex:gpt-5.6-sol`; an independent review pass was run with Claude Opus 5. Description drafted with Hermes (deepseek-v4-pro) from my notes, then reviewed by me.

## Related

- https://github.com/nextcloud/collectives/issues/599
- https://github.com/nextcloud/text/issues/4422
