### PR TITLE
Render highlighted documents

### DIFF
--- a/src/comparison/comparisonNavigation.ts
+++ b/src/comparison/comparisonNavigation.ts
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonEdit as Edit, ComparisonSide as Side } from './markdownComparisonTypes.ts'
+
+export function isPureFormatting(edit: Edit) {
+	return edit.descriptors.every(({ facets }) => facets.length === 1 && facets[0] === 'formatting')
+}
+
+export function currentIdAfterFilter(
+	edits: readonly Edit[],
+	activeIds: readonly string[],
+	currentId: string | null,
+) {
+	const active = new Set(activeIds)
+	if (currentId && active.has(currentId)) {
+		return currentId
+	}
+	if (active.size === 0) {
+		return null
+	}
+	const currentIndex = edits.findIndex(({ id }) => id === currentId)
+	if (currentIndex >= 0) {
+		for (let index = currentIndex + 1; index < edits.length; index++) {
+			if (active.has(edits[index]!.id)) {
+				return edits[index]!.id
+			}
+		}
+		for (let index = currentIndex - 1; index >= 0; index--) {
+			if (active.has(edits[index]!.id)) {
+				return edits[index]!.id
+			}
+		}
+	}
+	return edits.find(({ id }) => active.has(id))?.id ?? null
+}
+
+export function moveCurrentId(activeIds: readonly string[], currentId: string | null, offset: number) {
+	if (activeIds.length === 0) {
+		return null
+	}
+	const current = Math.max(0, activeIds.indexOf(currentId ?? ''))
+	const next = ((current + offset) % activeIds.length + activeIds.length) % activeIds.length
+	return activeIds[next]!
+}
+
+export function currentOrdinal(activeIds: readonly string[], currentId: string | null) {
+	const index = currentId ? activeIds.indexOf(currentId) : -1
+	return index < 0 ? 0 : index + 1
+}
+
+export function comparisonSideForKey(key: string): Side | null {
+	if (key === 'ArrowLeft' || key === 'ArrowUp' || key === 'Home') {
+		return 'before'
+	}
+	return key === 'ArrowRight' || key === 'ArrowDown' || key === 'End' ? 'after' : null
+}
+export function comparisonScrollBehavior(): ScrollBehavior {
+	return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'
+}
+
+export function locateComparisonTarget(pane: HTMLElement | null, scroller: HTMLElement | null, id: string, behavior: ScrollBehavior, fallbackRect?: () => { top: number, height: number } | null) {
+	if (!pane || !scroller || !pane.contains(scroller) || pane.hidden || pane.style.display === 'none') {
+		return false
+	}
+	const target = [...pane.querySelectorAll<HTMLElement>('[data-comparison-change]')]
+		.find((element) => element.dataset.comparisonChange === id)
+	const targetRect = target?.getBoundingClientRect() ?? fallbackRect?.()
+	if (!targetRect) {
+		return false
+	}
+	const scrollerRect = scroller.getBoundingClientRect()
+	const centeredTop = scroller.scrollTop + targetRect.top - scrollerRect.top
+		- (scroller.clientHeight - targetRect.height) / 2
+	const maximumTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight)
+	scroller.scrollTo({
+		behavior,
+		left: scroller.scrollLeft,
+		top: Math.min(Math.max(0, centeredTop), maximumTop),
+	})
+	return true
+}

--- a/src/comparison/markdownComparison.ts
+++ b/src/comparison/markdownComparison.ts
@@ -3,5 +3,255 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { Editor } from '@tiptap/core'
+import type { Node } from '@tiptap/pm/model'
+import type { PluginKey } from '@tiptap/pm/state'
+import type { LocatedComparisonNode as LocatedNode } from './comparisonDocumentIndex.ts'
+import type { ComparisonDescriptor as Descriptor, ComparisonSide as Side } from './markdownComparisonTypes.ts'
+
+import { Plugin, PluginKey as ProseMirrorPluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+import { createComparisonDocumentIndex, findComparisonNodes } from './comparisonDocumentIndex.ts'
+
 export { ComparisonModelLimitError, createHierarchicalMarkdownComparisonModel as createMarkdownComparisonModel } from './hierarchicalMarkdownComparisonModel.ts'
 export type * from './markdownComparisonTypes.ts'
+
+export interface ComparisonDecorationState {
+	activeIds: readonly string[]
+	currentIds: readonly string[]
+}
+
+export interface PreparedComparisonDecoration {
+	descriptor: Descriptor
+	from: number
+	to: number
+	type: 'inline' | 'node'
+}
+
+type State = ComparisonDecorationState
+type Prepared = PreparedComparisonDecoration
+interface PluginState extends State {
+	decorations: DecorationSet
+	prepared: readonly Prepared[]
+}
+
+export type ComparisonDecorationKey = PluginKey<PluginState>
+
+export const RENDERED_COMPARISON_LIMITS = Object.freeze({
+	maximumCharactersPerSnapshot: 210_000,
+	maximumCharactersPerLine: 20_000,
+	maximumLinesPerSnapshot: 6_500,
+})
+const LIMITS = RENDERED_COMPARISON_LIMITS
+
+export class ComparisonProjectionError extends Error {
+	constructor(id: string) {
+		super(`Comparison range cannot be projected: ${id}`)
+		this.name = 'ComparisonProjectionError'
+	}
+}
+
+export function exceedsRenderedComparisonLimit(before: string, after: string): boolean {
+	return [before, after].some((content) => {
+		if (content.length > LIMITS.maximumCharactersPerSnapshot) {
+			return true
+		}
+		let lines = content ? 1 : 0
+		let lineCharacters = 0
+		for (let index = 0; index < content.length; index++) {
+			if (content[index] === '\n' || (content[index] === '\r' && content[index + 1] !== '\n')) {
+				lines++
+				lineCharacters = 0
+				if (lines > LIMITS.maximumLinesPerSnapshot) {
+					return true
+				}
+			} else if (content[index] !== '\r' && ++lineCharacters > LIMITS.maximumCharactersPerLine) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+let pluginId = 0
+export function createComparisonDecorationPlugin(descriptors: readonly Descriptor[], side: Side, markerLabel: string, initialState: State = { activeIds: descriptors.map(({ id }) => id), currentIds: [] }) {
+	const key = new ProseMirrorPluginKey<PluginState>(`markdown-comparison-${side}-${pluginId++}`)
+	const plugin = new Plugin<PluginState>({
+		key,
+		state: {
+			init: (_, state) => createPluginState(state.doc, descriptors, side, initialState, markerLabel),
+			apply: (transaction, current) => {
+				if (transaction.docChanged) {
+					return { activeIds: [], currentIds: [], decorations: DecorationSet.empty, prepared: [] }
+				}
+				const update = transaction.getMeta(key) as State | undefined
+				if (!update) {
+					return current
+				}
+				const selection = normalizeDecorationState(descriptors, update)
+				return {
+					...selection,
+					prepared: current.prepared,
+					decorations: buildDecorationSet(transaction.doc, current.prepared, selection, side, markerLabel),
+				}
+			},
+		},
+		props: {
+			decorations: (state) => key.getState(state)?.decorations ?? DecorationSet.empty,
+		},
+	})
+	return { key, plugin }
+}
+
+export function setComparisonDecorationState(editor: Editor, key: ComparisonDecorationKey, state: State) {
+	editor.view.dispatch(editor.state.tr.setMeta(key, state))
+}
+
+function createPluginState(doc: Node, descriptors: readonly Descriptor[], side: Side, selection: State, markerLabel: string): PluginState {
+	const prepared = prepareComparisonDecorations(doc, descriptors, side)
+	const normalized = normalizeDecorationState(descriptors, selection)
+	return {
+		...normalized,
+		prepared,
+		decorations: buildDecorationSet(doc, prepared, normalized, side, markerLabel),
+	}
+}
+
+function normalizeDecorationState(descriptors: readonly Descriptor[], state: State): State {
+	const known = new Set(descriptors.map(({ id }) => id))
+	const activeIds = [...new Set(state.activeIds)].filter((id) => known.has(id))
+	const active = new Set(activeIds)
+	return {
+		activeIds,
+		currentIds: [...new Set(state.currentIds)].filter((id) => active.has(id)),
+	}
+}
+
+export function prepareComparisonDecorations(doc: Node, descriptors: readonly Descriptor[], side: Side) {
+	const index = createComparisonDocumentIndex(doc)
+	return descriptors.flatMap((descriptor): Prepared[] => {
+		const source = descriptor[side]
+		if (source.from === source.to) {
+			return []
+		}
+		const from = clamp(source.from, 0, doc.content.size)
+		const to = clamp(source.to, 0, doc.content.size)
+		if (from >= to) {
+			throw new ComparisonProjectionError(descriptor.id)
+		}
+		const candidates = findComparisonNodes({ from, to }, index.children)
+		const parts = descriptor.detail === 'block'
+			? projectBlock(descriptor, side, from, to, candidates)
+			: projectInline(descriptor, from, to, candidates)
+		if (parts.length > 0) {
+			return parts
+		}
+		const fallback = projectionFallback(candidates, descriptor, side, from, to)
+		if (!fallback) {
+			throw new ComparisonProjectionError(descriptor.id)
+		}
+		return [{ descriptor, ...fallback, type: 'node' }]
+	})
+}
+
+function projectBlock(descriptor: Descriptor, side: Side, from: number, to: number, nodes: readonly LocatedNode[]) {
+	const topLevel = nodes.filter(({ parent }) => parent === null)
+	const covered = topLevel
+		.filter((node) => from <= node.from && to >= node.to)
+		.map(({ from: nodeFrom, to: nodeTo }) => ({ descriptor, from: nodeFrom, to: nodeTo, type: 'node' as const }))
+	if (covered.length > 0) {
+		return covered
+	}
+	const enclosing = nodes
+		.filter(({ node, from: nodeFrom, to: nodeTo }) => !node.isText && nodeFrom <= from && nodeTo >= to)
+		.toSorted((a, b) => (a.to - a.from) - (b.to - b.from) || b.path.length - a.path.length)[0]
+	if (enclosing) {
+		return [{ descriptor, from: enclosing.from, to: enclosing.to, type: 'node' as const }]
+	}
+	const context = descriptor.context[side]
+	const exact = context && context.from < context.to
+		? nodes.find((node) => node.from === context.from && node.to === context.to)
+		: undefined
+	return exact ? [{ descriptor, from: exact.from, to: exact.to, type: 'node' as const }] : []
+}
+
+function projectInline(descriptor: Descriptor, from: number, to: number, nodes: readonly LocatedNode[]) {
+	const parts: Prepared[] = []
+	for (const { node, from: position, to: end } of nodes) {
+		if (node.isText) {
+			const partFrom = Math.max(from, position)
+			const partTo = Math.min(to, end)
+			if (partFrom < partTo) {
+				parts.push({ descriptor, from: partFrom, to: partTo, type: 'inline' })
+			}
+			continue
+		}
+		const fullyCovered = from <= position && to >= end
+		const edgeChanged = (from <= position && to > position && to <= position + 1)
+			|| (from < end && to >= end && from >= end - 1)
+		const semanticsChanged = descriptor.facets.some((facet) => facet !== 'text' && facet !== 'formatting')
+		if (node.isLeaf || (semanticsChanged && (fullyCovered || edgeChanged))) {
+			parts.push({ descriptor, from: position, to: end, type: 'node' })
+		}
+	}
+	return parts
+}
+
+function projectionFallback(nodes: readonly LocatedNode[], descriptor: Descriptor, side: Side, from: number, to: number) {
+	const context = descriptor.context[side]
+	if (context && context.from < context.to) {
+		const exact = nodes.find((node) => node.from === context.from && node.to === context.to)
+		if (exact) {
+			return { from: exact.from, to: exact.to }
+		}
+	}
+	const enclosing = nodes
+		.filter(({ node, from: nodeFrom, to: nodeTo }) => !node.isText && nodeFrom <= from && nodeTo >= to)
+		.toSorted((a, b) => (a.to - a.from) - (b.to - b.from) || b.path.length - a.path.length)[0]
+	return enclosing ? { from: enclosing.from, to: enclosing.to } : null
+}
+
+function buildDecorationSet(doc: Node, prepared: readonly Prepared[], state: State, side: Side, markerLabel: string) {
+	const active = new Set(state.activeIds)
+	const current = new Set(state.currentIds)
+	const decorations = prepared.flatMap((item): Decoration[] => {
+		if (!active.has(item.descriptor.id)) {
+			return []
+		}
+		const attributes = changeAttributes(item.descriptor, side, current.has(item.descriptor.id), markerLabel)
+		return [item.type === 'inline'
+			? Decoration.inline(item.from, item.to, attributes)
+			: Decoration.node(item.from, item.to, attributes)]
+	})
+	return DecorationSet.create(doc, decorations)
+}
+
+function changeAttributes(descriptor: Descriptor, side: Side, current: boolean, label: string) {
+	const pureFormatting = descriptor.facets.length === 1 && descriptor.facets[0] === 'formatting'
+	const coarse = descriptor.detail === 'block' && descriptor.operation === 'replace'
+	const treatment = coarse
+		? 'block'
+		: pureFormatting
+			? 'formatting'
+			: descriptor.operation === 'move'
+				? 'move'
+				: descriptor.facets.includes('attribute') && !descriptor.facets.includes('text')
+					? 'attribute'
+					: side === 'before' ? 'removed' : 'added'
+	const classes = ['text-comparison-change', `text-comparison-change--${treatment}`]
+	if (descriptor.detail === 'block' && !coarse) {
+		classes.push('text-comparison-change--block')
+	}
+	if (current) {
+		classes.push('text-comparison-change--current')
+	}
+	return {
+		class: classes.join(' '),
+		'data-comparison-change': descriptor.id,
+		'aria-label': label,
+		...(current ? { 'aria-current': 'true' } : {}),
+	}
+}
+function clamp(value: number, minimum: number, maximum: number) {
+	return Math.min(Math.max(value, minimum), maximum)
+}

--- a/src/comparison/markdownSourceDisplay.ts
+++ b/src/comparison/markdownSourceDisplay.ts
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const visibleControlNames: Readonly<Record<string, string>> = {
+	'\t': 'TAB',
+	'\u00AD': 'SHY',
+	'\u061C': 'ALM',
+	'\u0085': 'NEL',
+	'\u200B': 'ZWSP',
+	'\u200C': 'ZWNJ',
+	'\u200D': 'ZWJ',
+	'\u200E': 'LRM',
+	'\u200F': 'RLM',
+	'\u2060': 'WORD JOINER',
+	'\uFEFF': 'BOM',
+	'\u2028': 'LS',
+	'\u2029': 'PS',
+	'\u202A': 'LRE',
+	'\u202B': 'RLE',
+	'\u202C': 'PDF',
+	'\u202D': 'LRO',
+	'\u202E': 'RLO',
+	'\u2066': 'LRI',
+	'\u2067': 'RLI',
+	'\u2068': 'FSI',
+	'\u2069': 'PDI',
+}
+
+export const COMPLETE_SOURCE_DISPLAY_LIMITS = Object.freeze({
+	maximumInputCharactersPerSide: 1_000_000,
+	maximumVisibleCharactersPerSide: 1_000_000,
+	maximumVisibleCharactersPerLine: 20_000,
+})
+const LIMITS = COMPLETE_SOURCE_DISPLAY_LIMITS
+
+function sourcePrefix(value: string, maximumCharacters: number) {
+	let prefix = value.slice(0, Math.max(0, maximumCharacters))
+	const finalCodeUnit = prefix.charCodeAt(prefix.length - 1)
+	const nextCodeUnit = value.charCodeAt(prefix.length)
+	if (finalCodeUnit >= 0xD800 && finalCodeUnit <= 0xDBFF
+		&& nextCodeUnit >= 0xDC00 && nextCodeUnit <= 0xDFFF) {
+		prefix = prefix.slice(0, -1)
+	}
+	return prefix
+}
+
+function renderMarkdownSource(source: string, maximumCharacters: number, maximumLineCharacters = Number.POSITIVE_INFINITY) {
+	let visible = ''
+	let lineCharacters = 0
+	for (const character of source) {
+		const named = visibleControlNames[character]
+		const code = character.codePointAt(0)!
+		let rendered = character
+		if (named) {
+			rendered = `⟦${named}⟧`
+		} else if (character.length === 1 && code >= 0xD800 && code <= 0xDFFF) {
+			rendered = `⟦U+${code.toString(16).toUpperCase()}⟧`
+		} else if ((code < 0x20 && character !== '\n' && character !== '\r') || code === 0x7F) {
+			rendered = `⟦U+${code.toString(16).toUpperCase().padStart(4, '0')}⟧`
+		}
+		if (rendered.length > maximumCharacters - visible.length
+			|| (character !== '\n' && character !== '\r'
+				&& rendered.length > maximumLineCharacters - lineCharacters)) {
+			return { text: visible, complete: false }
+		}
+		visible += rendered
+		lineCharacters = character === '\n' || character === '\r'
+			? 0
+			: lineCharacters + rendered.length
+	}
+	return { text: visible, complete: true }
+}
+
+export function displayMarkdownSource(source: string, maximumCharacters = Number.POSITIVE_INFINITY) {
+	return renderMarkdownSource(source, maximumCharacters).text
+}
+
+export function displayBoundedMarkdownSource(source: string) {
+	const input = sourcePrefix(source, LIMITS.maximumInputCharactersPerSide)
+	const visible = renderMarkdownSource(
+		input,
+		LIMITS.maximumVisibleCharactersPerSide,
+		LIMITS.maximumVisibleCharactersPerLine,
+	)
+	return {
+		text: visible.text,
+		truncated: input.length < source.length || !visible.complete,
+	}
+}

--- a/src/components/CollaborativeEditor.vue
+++ b/src/components/CollaborativeEditor.vue
@@ -804,7 +804,7 @@ export default defineComponent({
 		},
 
 		async save() {
-			await this.saveService.save()
+			return await this.saveService.save()
 		},
 
 		async saveWhenDirty() {

--- a/src/components/ComparisonEditorContent.vue
+++ b/src/components/ComparisonEditorContent.vue
@@ -1,0 +1,32 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<EditorContent
+		class="text-comparison__content"
+		role="document"
+		:editor="editor" />
+</template>
+
+<script setup lang="ts">
+import type { Plugin } from '@tiptap/pm/state'
+import type { Editor } from '@tiptap/vue-3'
+
+import { EditorContent } from '@tiptap/vue-3'
+import { nextTick, onMounted } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+const props = defineProps<{ editor: Editor, plugins: readonly Plugin[] }>()
+const emit = defineEmits<{ ready: [] }>()
+const editor = props.editor
+for (const plugin of props.plugins) {
+	editor.registerPlugin(plugin)
+}
+
+onMounted(async () => {
+	await nextTick()
+	emit('ready')
+})
+</script>

--- a/src/components/MarkdownContentComparison.vue
+++ b/src/components/MarkdownContentComparison.vue
@@ -1,0 +1,730 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<section
+		ref="root"
+		class="text-comparison"
+		:class="`text-comparison--${layoutMode}`"
+		:aria-label="t('text', 'Version comparison')">
+		<p class="text-comparison__sr-only" aria-live="polite" aria-atomic="true">
+			{{ announcement }}
+		</p>
+
+		<MarkdownSourceFallback v-if="failure" :beforeContent="beforeContent" :afterContent="afterContent" />
+		<template v-else>
+			<header class="comparison-header">
+				<div class="toolbar">
+					<div class="view-tabs" role="tablist" :aria-label="t('text', 'Comparison view')">
+						<button
+							v-for="tab in tabs"
+							:key="tab"
+							:ref="(element) => setTabRef(tab, element)"
+							type="button"
+							role="tab"
+							:aria-selected="view === tab"
+							:tabindex="view === tab ? 0 : -1"
+							@click="setView(tab)"
+							@keydown="onViewTabKeydown($event, tab)">
+							{{ tabLabels[tab] }}
+						</button>
+					</div>
+					<div v-if="view === 'documents' && activeIds.length" class="navigation" :aria-label="t('text', 'Change navigation')">
+						<NcButton
+							type="button"
+							variant="tertiary"
+							:aria-label="t('text', 'Previous change')"
+							:disabled="activeIds.length < 2"
+							@click="move(-1)">
+							{{ t('text', 'Previous') }}
+						</NcButton>
+						<span class="status" aria-hidden="true">{{
+							announcement
+						}}</span>
+						<NcButton
+							type="button"
+							variant="tertiary"
+							:aria-label="t('text', 'Next change')"
+							:disabled="activeIds.length < 2"
+							@click="move(1)">
+							{{ t('text', 'Next') }}
+						</NcButton>
+					</div>
+				</div>
+				<div v-if="view === 'changes'" class="changes-controls">
+					<p class="changes-count">
+						{{ n('text', '%n change', '%n changes', activeEdits.length) }}
+					</p>
+					<label v-if="formatCount" class="filter">
+						<input v-model="hideFormatting" type="checkbox">
+						<span>{{ t('text', 'Hide formatting-only changes') }}</span>
+						<small v-if="hideFormatting">{{
+							t('text', '{count} hidden', { count: formatCount })
+						}}</small>
+					</label>
+				</div>
+				<div v-if="view === 'documents' && hideFormatting && formatCount" class="hidden-formatting" role="status">
+					{{
+						n(
+							'text',
+							'%n formatting change hidden',
+							'%n formatting changes hidden',
+							formatCount,
+						)
+					}}
+					<NcButton type="button" variant="tertiary" @click="hideFormatting = false">
+						{{ t('text', 'Show') }}
+					</NcButton>
+				</div>
+			</header>
+
+			<section v-show="view === 'changes'" role="tabpanel" class="text-comparison__changes">
+				<div v-if="activeEdits.length" class="changes-content">
+					<ComparisonChangeList
+						:edits="activeEdits"
+						:currentId="currentId || undefined"
+						:beforeDocument="editors.before!.state.doc"
+						:afterDocument="editors.after!.state.doc"
+						@select="selectEdit"
+						@currentLabel="currentLabel = $event" />
+				</div>
+				<div v-else-if="model.edits.length" class="empty" role="status">
+					{{
+						t(
+							'text',
+							'All rendered changes are formatting-only and hidden by the current filter.',
+						)
+					}}
+				</div>
+				<div v-else-if="rawDifferent" class="empty" role="status">
+					<p>
+						{{
+							t('text', 'No rendered differences — Markdown syntax differs.')
+						}}
+					</p>
+				</div>
+				<p v-else class="empty" role="status">
+					{{ t('text', 'No differences.') }}
+				</p>
+			</section>
+
+			<section
+				v-if="showDocuments"
+				v-show="view === 'documents'"
+				role="tabpanel"
+				class="text-comparison__documents">
+				<div
+					v-if="layoutMode === 'single'"
+					class="side-tabs"
+					role="tablist"
+					:aria-label="t('text', 'Version to display')">
+					<button
+						v-for="side in sides"
+						:key="side"
+						:ref="(element) => setSideElement(side, 'tab', element)"
+						role="tab"
+						type="button"
+						:aria-selected="activeSide === side"
+						:tabindex="activeSide === side ? 0 : -1"
+						@click="setSide(side)"
+						@keydown="onSideKeydown">
+						{{ sideLabels[side] }}
+					</button>
+				</div>
+				<div class="text-comparison__document-grid">
+					<article
+						v-for="side in sides"
+						v-show="layoutMode === 'paired' || activeSide === side"
+						:key="side"
+						:ref="(element) => setSideElement(side, 'pane', element)"
+						class="text-comparison__document"
+						:class="`text-comparison__document--${side}`"
+						:aria-label="sideLabels[side]">
+						<header>
+							<div class="document-heading">
+								<span aria-hidden="true">{{ side === 'before' ? '−' : '+' }}</span>
+								<h2>{{ sideLabels[side] }}</h2>
+							</div>
+							<span class="document-legend" aria-hidden="true">{{ sideLegends[side] }}</span>
+						</header>
+						<div
+							:ref="(element) => setSideElement(side, 'scroller', element)"
+							class="text-comparison__document-scroller">
+							<ComparisonEditorContent :editor="editors[side]!" :plugins="plugins[side]" @ready="refreshDocuments" />
+						</div>
+					</article>
+				</div>
+			</section>
+		</template>
+	</section>
+</template>
+
+<script setup lang="ts">
+import type { ComponentPublicInstance as Public } from 'vue'
+import type { ComparisonEdit as Edit, ComparisonSide as Side } from '../comparison/markdownComparisonTypes.ts'
+
+import { getCurrentUser } from '@nextcloud/auth'
+import { n, t } from '@nextcloud/l10n'
+import { computed, nextTick, onBeforeUnmount, onErrorCaptured, onMounted, provide, ref, shallowRef, watch } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import ComparisonChangeList from './ComparisonChangeList.vue'
+import ComparisonEditorContent from './ComparisonEditorContent.vue'
+import MarkdownSourceFallback from './MarkdownSourceFallback.vue'
+import { currentIdAfterFilter, currentOrdinal, isPureFormatting, locateComparisonTarget as locateTarget, moveCurrentId, comparisonScrollBehavior as scrollBehavior, comparisonSideForKey as sideForKey } from '../comparison/comparisonNavigation.ts'
+import { createComparisonEditor as createEditor } from '../comparison/createComparisonEditor.ts'
+import { createComparisonDecorationPlugin as createDecoration, createMarkdownComparisonModel as createModel, exceedsRenderedComparisonLimit as exceedsLimit, ComparisonModelLimitError as ModelLimit, setComparisonDecorationState as setDecorations } from '../comparison/markdownComparison.ts'
+import AttachmentResolver from '../services/AttachmentResolver.js'
+import { ATTACHMENT_RESOLVER, EDITOR_UPLOAD } from './Editor.provider.ts'
+
+const props = defineProps<{
+	beforeContent: string
+	afterContent: string
+	fileId?: number
+	filePath?: string
+	shareToken?: string
+	noLazyImages?: boolean
+	openLinkHandler?: (href: string) => void
+}>()
+const emit = defineEmits<{ ready: [] }>()
+type View = 'changes' | 'documents'
+const tabs: readonly View[] = ['changes', 'documents']
+const sides: readonly Side[] = ['before', 'after']
+const tabLabels = { changes: t('text', 'Changes'), documents: t('text', 'Full documents') }
+const sideLabels = { before: t('text', 'Before'), after: t('text', 'After') }
+const sideLegends = { before: t('text', 'Removed'), after: t('text', 'Added') }
+const root = ref<HTMLElement | null>(null)
+const sideElements: Record<Side, Record<'pane' | 'scroller' | 'tab', HTMLElement | null>> = {
+	before: { pane: null, scroller: null, tab: null },
+	after: { pane: null, scroller: null, tab: null },
+}
+const tabRefs = new Map<View, HTMLButtonElement>()
+const layoutMode = ref<'paired' | 'single'>('paired')
+const activeSide = ref<Side>('before')
+const view = ref<View>('changes')
+const showDocuments = ref(false)
+const hideFormatting = ref(false)
+const currentId = ref<string | null>(null)
+const currentLabel = ref('')
+const failure = ref(false)
+let observer: ResizeObserver | null = null
+let didReady = false
+let destroyed = false
+
+const resolver = props.fileId
+	? new AttachmentResolver({
+			currentDirectory:
+				props.filePath?.split('/').slice(0, -1).join('/') ?? '/',
+			fileId: props.fileId,
+			session: undefined,
+			shareToken: props.shareToken,
+			user: getCurrentUser(),
+		})
+	: {
+			async resolve(src: string) {
+				return {
+					fullUrl: src,
+					isImage: true,
+					name: src.split('/').pop(),
+					previewUrl: src,
+				}
+			},
+		}
+provide(ATTACHMENT_RESOLVER, shallowRef(resolver))
+provide(EDITOR_UPLOAD, false)
+
+type ComparisonEditor = ReturnType<typeof createEditor>
+type Decoration = ReturnType<typeof createDecoration>
+const editors: Record<Side, ComparisonEditor | null> = { before: null, after: null }
+const plugins: Record<Side, Decoration['plugin'][]> = { before: [], after: [] }
+const pluginKeys: Record<Side, Decoration['key'] | null> = { before: null, after: null }
+let model = { edits: [] as readonly Edit[] }
+
+try {
+	if (exceedsLimit(props.beforeContent, props.afterContent)) {
+		throw new ModelLimit()
+	}
+	editors.before = createEditor(props.beforeContent, {
+		ariaLabel: t('text', 'Before document'),
+		filePath: props.filePath,
+		noLazyImages: props.noLazyImages,
+		openLink: props.openLinkHandler,
+	})
+	editors.after = createEditor(props.afterContent, {
+		ariaLabel: t('text', 'After document'),
+		filePath: props.filePath,
+		noLazyImages: props.noLazyImages,
+		openLink: props.openLinkHandler,
+		schema: editors.before.schema,
+	})
+	model = createModel(
+		editors.before.state.doc,
+		editors.after.state.doc,
+	)
+	currentId.value = model.edits[0]?.id ?? null
+	const descriptors = model.edits.flatMap(({ descriptors }) => descriptors)
+	const initial = decorationSelection(model.edits, currentId.value)
+	for (const side of sides) {
+		const decoration = createDecoration(descriptors, side, t('text', 'Changed content'), initial)
+		plugins[side] = [decoration.plugin]
+		pluginKeys[side] = decoration.key
+	}
+} catch {
+	activateFallback()
+}
+const activeEdits = computed(() => model.edits.filter((edit) => !hideFormatting.value || !isPureFormatting(edit)))
+const activeIds = computed(() => activeEdits.value.map(({ id }) => id))
+const formatCount = computed(() => model.edits.filter(isPureFormatting).length)
+const rawDifferent = computed(() => props.beforeContent !== props.afterContent)
+const announcement = computed(() => failure.value
+	? t('text', 'Detailed rendered comparison unavailable')
+	: activeIds.value.length
+		? t('text', 'Change {current} of {total}: {label}', {
+				current: currentOrdinal(activeIds.value, currentId.value),
+				total: activeIds.value.length,
+				label: currentLabel.value,
+			})
+		: t('text', 'No rendered changes'))
+
+watch(activeIds, (ids) => {
+	currentId.value = currentIdAfterFilter(
+		model.edits,
+		ids,
+		currentId.value,
+	)
+	updateDecorations()
+})
+watch(currentId, refreshDocuments)
+onErrorCaptured(() => {
+	activateFallback()
+	nextTick(ready)
+	return false
+})
+onMounted(() => {
+	if (typeof ResizeObserver !== 'undefined') {
+		observer = new ResizeObserver(([entry]) => {
+			const nextLayout
+				= (entry?.contentRect.width ?? root.value?.clientWidth ?? 760) < 760
+					? 'single'
+					: 'paired'
+			if (nextLayout === layoutMode.value) {
+				return
+			}
+			layoutMode.value = nextLayout
+			locateCurrent(true)
+		})
+	}
+	if (root.value) {
+		observer?.observe(root.value)
+	}
+	ready()
+})
+onBeforeUnmount(() => {
+	destroyed = true
+	observer?.disconnect()
+	observer = null
+	destroyEditors()
+})
+
+function decorationSelection(edits: readonly Edit[], current: string | null) {
+	const activeIds = edits.flatMap(({ descriptors }) => descriptors.map(({ id }) => id))
+	const selected = edits.find(({ id }) => id === current)
+	return {
+		activeIds,
+		currentIds: selected?.descriptors.map(({ id }) => id) ?? [],
+	}
+}
+function updateDecorations() {
+	if (
+		sides.some((side) => !editors[side] || !pluginKeys[side] || editors[side]?.isDestroyed)
+	) {
+		return
+	}
+	const selection = decorationSelection(activeEdits.value, currentId.value)
+	for (const side of sides) {
+		setDecorations(editors[side]!, pluginKeys[side]!, selection)
+	}
+}
+function refreshDocuments() {
+	updateDecorations()
+	locateCurrent(true)
+}
+function selectEdit(id: string) {
+	currentId.value = id
+	if (!isPureFormatting(model.edits.find((edit) => edit.id === id)!)) {
+		setView('documents')
+	}
+}
+function move(offset: number) {
+	currentId.value = moveCurrentId(
+		activeIds.value,
+		currentId.value,
+		offset,
+	)
+}
+function locateCurrent(selectVisibleSide = false) {
+	const edit = model.edits.find(({ id }) => id === currentId.value)
+	if (!edit) {
+		return
+	}
+	if (selectVisibleSide
+		&& layoutMode.value === 'single'
+		&& edit.descriptors.every((descriptor) => descriptor[activeSide.value].from === descriptor[activeSide.value].to)) {
+		const other = activeSide.value === 'before' ? 'after' : 'before'
+		if (edit.descriptors.some((descriptor) => descriptor[other].from !== descriptor[other].to)) {
+			activeSide.value = other
+		}
+	}
+	nextTick(() => {
+		for (const side of ['before', 'after'] as const) {
+			const editor = editors[side]
+			const { pane, scroller } = sideElements[side]
+			const range = edit.primary[side]
+			locateTarget(
+				pane,
+				scroller,
+				edit.primary.id,
+				scrollBehavior(),
+				() => {
+					if (!editor || editor.isDestroyed) {
+						return null
+					}
+					const rect = editor.view.coordsAtPos(range.from)
+					return { top: rect.top, height: Math.max(1, rect.bottom - rect.top) }
+				},
+			)
+		}
+	})
+}
+function ready() {
+	if (!didReady && !destroyed) {
+		didReady = true
+		emit('ready')
+	}
+}
+function activateFallback() {
+	failure.value = true
+	destroyEditors()
+}
+function destroyEditors() {
+	for (const side of sides) {
+		editors[side]?.destroy()
+		editors[side] = null
+	}
+}
+function setView(next: View) {
+	if (next === 'documents') {
+		showDocuments.value = true
+		locateCurrent(true)
+	}
+	view.value = next
+	nextTick(() => tabRefs.get(next)?.focus())
+}
+function setSide(side: Side) {
+	activeSide.value = side
+	locateCurrent()
+	nextTick(() => sideElements[side].tab?.focus())
+}
+function setSideElement(side: Side, key: 'pane' | 'scroller' | 'tab', element: Element | Public | null) {
+	sideElements[side][key] = element instanceof HTMLElement ? element : null
+}
+function setTabRef(tab: View, element: Element | Public | null) {
+	if (element instanceof HTMLButtonElement) {
+		tabRefs.set(tab, element)
+	}
+}
+function onViewTabKeydown(event: KeyboardEvent, tab: View) {
+	const index = tabs.indexOf(tab)
+	const direction = sideForKey(event.key)
+	if (!direction) {
+		return
+	}
+	event.preventDefault()
+	const next = event.key === 'Home'
+		? 0
+		: event.key === 'End'
+			? tabs.length - 1
+			: (index + (direction === 'before' ? -1 : 1) + tabs.length) % tabs.length
+	setView(tabs[next]!)
+}
+function onSideKeydown(event: KeyboardEvent) {
+	const side = sideForKey(event.key)
+	if (side) {
+		event.preventDefault()
+		setSide(side)
+	}
+}
+</script>
+
+<style lang="scss">
+@use './../css/prosemirror.scss';
+
+$g: var(--default-grid-baseline);
+$border: var(--color-border);
+$primary: var(--color-primary-element);
+
+.text-comparison-root,
+.text-comparison {
+	display: flex;
+	flex: 1;
+	min-inline-size: 0;
+	block-size: 100%;
+	min-block-size: 0;
+	overflow: hidden;
+}
+.text-comparison {
+	flex-direction: column;
+	.view-tabs,
+	.side-tabs {
+		display: flex;
+		gap: calc(2 * $g);
+	}
+	.toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: calc(2 * $g);
+		border-block-end: 1px solid $border;
+	}
+	.navigation {
+		display: grid;
+		align-items: center;
+		grid-template-columns: auto minmax(10rem, 1fr) auto;
+		gap: $g;
+	}
+	.status,
+	.changes-count,
+	.empty p,
+	.source-explanation {
+		margin: 0;
+	}
+	.status {
+		text-align: center;
+	}
+	.view-tabs,
+	.side-tabs {
+		button[role='tab'] {
+			margin: 0 !important;
+			border: 0 !important;
+			border-block-end: 2px solid transparent !important;
+			border-radius: 0 !important;
+			background: transparent !important;
+			&:focus-visible {
+				box-shadow: none !important;
+				outline: 2px solid $primary !important;
+				outline-offset: -2px;
+			}
+			&[aria-selected='true'] {
+				border-block-end-color: $primary !important;
+				font-weight: 700;
+			}
+		}
+	}
+	.changes-controls,
+	.changes-content {
+		box-sizing: border-box;
+		inline-size: min(calc(100% - 16px), 1040px);
+		margin-inline: auto;
+	}
+	.changes-controls {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: calc(2 * $g);
+		flex-wrap: wrap;
+		padding-block: calc(2 * $g);
+	}
+	.changes-count,
+	.filter,
+	.hidden-formatting,
+	.source-explanation {
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+	}
+	.filter,
+	.hidden-formatting {
+		display: flex;
+		align-items: center;
+		gap: calc(1.5 * $g);
+	}
+	.hidden-formatting {
+		justify-content: flex-end;
+		padding: $g calc(3 * $g);
+	}
+	&__changes {
+		flex: 1;
+		min-block-size: 0;
+		overflow: auto;
+	}
+	.changes-content {
+		padding-block-end: calc(8 * $g);
+	}
+	.empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: calc(3 * $g);
+		min-block-size: calc(40 * $g);
+		padding: calc(6 * $g);
+		text-align: center;
+	}
+	&__documents,
+	&__document,
+	.source {
+		display: flex;
+		flex-direction: column;
+		min-block-size: 0;
+		overflow: hidden;
+	}
+	&__documents,
+	.source {
+		flex: 1;
+	}
+	.side-tabs {
+		flex: none;
+		inline-size: fit-content;
+		margin: $g auto;
+	}
+	&__document-grid {
+		display: grid;
+		flex: 1;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		min-block-size: 0;
+		overflow: hidden;
+	}
+	&__document {
+		min-inline-size: 0;
+		> header {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: calc(2 * $g);
+			padding: calc(2 * $g) calc(4 * $g);
+			border-block-end: 1px solid $border;
+			background: var(--color-main-background);
+			flex-wrap: wrap;
+		}
+		.document-heading {
+			display: flex;
+			align-items: center;
+			gap: calc(1.5 * $g);
+			min-inline-size: 0;
+			h2 {
+				margin: 0;
+				font-size: var(--default-font-size);
+				font-weight: var(--font-weight-heading);
+				line-height: var(--default-line-height);
+			}
+			span {
+				inline-size: calc(4 * $g);
+				font-weight: var(--font-weight-heading);
+				line-height: 1;
+				text-align: center;
+			}
+		}
+		.document-legend {
+			margin-inline-start: auto;
+			color: var(--color-text-maxcontrast);
+			font-size: var(--font-size-small);
+			font-weight: var(--font-weight-element);
+			white-space: nowrap;
+		}
+		& + & {
+			border-inline-start: 1px solid $border;
+		}
+	}
+	&__document--before .document-heading > span { color: var(--color-error-text); }
+	&__document--after .document-heading > span { color: var(--color-success-text); }
+	&__document-scroller {
+		flex: 1;
+		min-block-size: 0;
+		padding-inline: calc(4 * $g);
+		overflow: auto;
+	}
+	&__content .ProseMirror {
+		inline-size: auto;
+		min-inline-size: 0;
+		min-block-size: 0;
+		padding: calc(3 * $g) calc(1.5 * $g) calc(9 * $g);
+		border: 0;
+		.text-comparison-change--removed {
+			--comparison-color: var(--color-error);
+			background: var(--color-error-hover);
+			text-decoration: line-through;
+		}
+		.text-comparison-change--added {
+			--comparison-color: var(--color-success);
+			background: var(--color-success-hover);
+			text-decoration: underline;
+		}
+		.text-comparison-change--formatting {
+			--comparison-color: var(--color-primary-element);
+			background: var(--color-primary-element-light);
+		}
+		.text-comparison-change--attribute {
+			box-shadow: inset 0 -2px var(--color-warning);
+		}
+		.text-comparison-change--move {
+			--comparison-color: var(--color-element-info);
+			box-shadow: inset 3px 0 var(--color-element-info);
+		}
+		.text-comparison-change--block {
+			box-shadow: inset 0 0 0 2px var(--color-warning);
+		}
+		.text-comparison-change--current {
+			outline: 2px solid $primary;
+			outline-offset: 2px;
+		}
+		[data-node-view-wrapper].text-comparison-change,
+		tr.text-comparison-change {
+			box-shadow: inset 0 0 0 3px var(--comparison-color, var(--color-warning));
+			&.text-comparison-change--current {
+				box-shadow: inset 0 0 0 4px $primary;
+			}
+		}
+	}
+	&__sr-only {
+		position: absolute;
+		inline-size: 1px;
+		block-size: 1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+	}
+	.source-explanation {
+		padding: calc(2 * $g) calc(3 * $g) 0;
+	}
+	&--single {
+		.toolbar {
+			flex-wrap: wrap;
+		}
+		.view-tabs {
+			flex: 1;
+		}
+		.view-tabs button {
+			flex: 1;
+		}
+		.navigation {
+			flex: 0 0 100%;
+			grid-template-columns: auto minmax(0, 1fr) auto;
+			inline-size: 100%;
+		}
+		.status { min-inline-size: 0; }
+		.text-comparison__document-grid {
+			display: block;
+		}
+		.text-comparison__document {
+			block-size: 100%;
+			border-inline-start: 0;
+		}
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.text-comparison * {
+		scroll-behavior: auto !important;
+		transition: none !important;
+	}
+}
+</style>

--- a/src/components/MarkdownSourceFallback.vue
+++ b/src/components/MarkdownSourceFallback.vue
@@ -1,0 +1,60 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<section class="text-source-fallback" data-comparison-source-fallback :aria-label="t('text', 'Complete Markdown source')">
+		<p>{{ t('text', 'Complete Markdown source is shown because a detailed comparison is unavailable.') }}</p>
+		<p v-if="before.truncated || after.truncated" role="status">
+			{{ t('text', 'Source preview was truncated to the display limit.') }}
+		</p>
+		<div class="text-source-fallback__documents">
+			<article>
+				<h2>{{ t('text', 'Before') }}</h2>
+				<pre tabindex="0"><code>{{ before.text }}</code></pre>
+			</article>
+			<article>
+				<h2>{{ t('text', 'After') }}</h2>
+				<pre tabindex="0"><code>{{ after.text }}</code></pre>
+			</article>
+		</div>
+	</section>
+</template>
+
+<script setup lang="ts">
+import { t } from '@nextcloud/l10n'
+import { computed } from 'vue'
+import { displayBoundedMarkdownSource } from '../comparison/markdownSourceDisplay.ts'
+
+const props = defineProps<{ beforeContent: string, afterContent: string }>()
+const before = computed(() => displayBoundedMarkdownSource(props.beforeContent))
+const after = computed(() => displayBoundedMarkdownSource(props.afterContent))
+</script>
+
+<style lang="scss">
+.text-source-fallback {
+	flex: 1 1 auto;
+	min-block-size: 0;
+	overflow: auto;
+	padding: 16px;
+	container-type: inline-size;
+
+	&__documents {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 16px;
+	}
+
+	pre {
+		min-block-size: 12rem;
+		overflow: auto;
+		white-space: pre;
+		user-select: text;
+	}
+
+	@container (max-width: 759px) {
+		&__documents { grid-template-columns: minmax(0, 1fr); }
+	}
+}
+</style>

--- a/src/createMarkdownContentComparison.ts
+++ b/src/createMarkdownContentComparison.ts
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createApp } from 'vue'
+import MarkdownSourceFallback from './components/MarkdownSourceFallback.vue'
+import { OPEN_LINK_HANDLER } from './composables/useOpenLinkHandler.ts'
+import { openLink } from './helpers/links.js'
+
+export interface MarkdownContentComparisonOptions {
+	el: HTMLElement
+	beforeContent: string
+	afterContent: string
+	fileId?: number
+	filePath?: string
+	shareToken?: string
+	noLazyImages?: boolean
+	openLinkHandler?: (href: string) => void
+	onLoaded?: () => void | Promise<void>
+}
+
+export interface MarkdownContentComparisonInstance {
+	destroy: () => void
+}
+
+export async function createMarkdownContentComparison(options: MarkdownContentComparisonOptions): Promise<MarkdownContentComparisonInstance> {
+	if (!(options?.el instanceof HTMLElement)) {
+		throw new TypeError('Comparison el must be an HTMLElement')
+	}
+	if (
+		typeof options.beforeContent !== 'string'
+		|| typeof options.afterContent !== 'string'
+	) {
+		throw new TypeError('beforeContent and afterContent must be strings')
+	}
+
+	const root = document.createElement('div')
+	root.className = 'text-comparison-root'
+	options.el.replaceChildren(root)
+	let app: ReturnType<typeof createApp> | null = null
+	let destroyed = false
+	let fallbackPromise: Promise<void> | null = null
+	let resolveReady!: () => void
+	const ready = new Promise<void>((resolve) => {
+		resolveReady = resolve
+	})
+	const onReady = () => {
+		if (!destroyed) {
+			resolveReady()
+		}
+	}
+	const provide = (nextApp: ReturnType<typeof createApp>) => nextApp.provide(OPEN_LINK_HANDLER, {
+		openLink: options.openLinkHandler ?? openLink,
+	})
+
+	const mountFallback = () => {
+		fallbackPromise ??= (async () => {
+			try {
+				app?.unmount()
+			} catch (error) {
+				void error
+			}
+			root.replaceChildren()
+			if (destroyed) {
+				return
+			}
+			app = provide(createApp(MarkdownSourceFallback, {
+				beforeContent: options.beforeContent,
+				afterContent: options.afterContent,
+			}))
+			app.mount(root)
+			onReady()
+		})()
+		return fallbackPromise
+	}
+
+	try {
+		const { default: MarkdownContentComparison }
+			= await import('./components/MarkdownContentComparison.vue')
+		if (destroyed) {
+			return { destroy() {} }
+		}
+		app = provide(createApp(MarkdownContentComparison, {
+			beforeContent: options.beforeContent,
+			afterContent: options.afterContent,
+			fileId: options.fileId,
+			filePath: options.filePath,
+			shareToken: options.shareToken,
+			noLazyImages: options.noLazyImages ?? false,
+			openLinkHandler: options.openLinkHandler ?? openLink,
+			onReady,
+		}))
+		app.config.errorHandler = () => {
+			void mountFallback()
+		}
+		app.mount(root)
+		await ready
+	} catch {
+		await mountFallback()
+		await ready
+	}
+	try {
+		await options.onLoaded?.()
+	} catch (error) {
+		void error
+	}
+
+	return {
+		destroy() {
+			if (destroyed) {
+				return
+			}
+			destroyed = true
+			try {
+				app?.unmount()
+			} finally {
+				root.remove()
+			}
+			app = null
+		},
+	}
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4,11 +4,12 @@
  */
 
 import { createCollaborativeEditor, createEditor, createMarkdownContentEditor } from './createEditor.ts'
+import { createMarkdownContentComparison } from './createMarkdownContentComparison.ts'
 import { createTable } from './createTable.ts'
 
 import 'vite/modulepreload-polyfill'
 
-const apiVersion = '1.4'
+const apiVersion = '1.5'
 
 window.OCA.Text = {
 	...window.OCA.Text,
@@ -18,4 +19,5 @@ window.OCA.Text.apiVersion = apiVersion
 window.OCA.Text.createEditor = createEditor
 window.OCA.Text.createCollaborativeEditor = createCollaborativeEditor
 window.OCA.Text.createMarkdownContentEditor = createMarkdownContentEditor
+window.OCA.Text.createMarkdownContentComparison = createMarkdownContentComparison
 window.OCA.Text.createTable = createTable

--- a/src/extensions/RichText.ts
+++ b/src/extensions/RichText.ts
@@ -95,7 +95,7 @@ export default Extension.create<RichTextOptions>({
 			Text,
 			Paragraph,
 			HardBreak,
-			Heading,
+			this.options.editing || !this.options.isEmbedded ? Heading : Heading.extend({ addProseMirrorPlugins: () => [] }),
 			Strong,
 			Highlight,
 			Italic,
@@ -123,7 +123,10 @@ export default Extension.create<RichTextOptions>({
 				isEmbedded: this.options.isEmbedded,
 			}),
 			Underline,
-			Image.configure({ noLazyImages: this.options.noLazyImages }),
+			Image.configure({
+				emitAttachmentEvents: this.options.editing,
+				noLazyImages: this.options.noLazyImages,
+			}),
 			ImageInline.configure({ noLazyImages: this.options.noLazyImages }),
 			Dropcursor.configure({
 				color: 'var(--color-primary-element)',
@@ -131,7 +134,7 @@ export default Extension.create<RichTextOptions>({
 			}),
 			Gapcursor,
 			KeepSyntax,
-			Keymap,
+			...(this.options.editing ? [Keymap] : []),
 			FrontMatter,
 			Mention.configure({
 				suggestion: MentionSuggestion({
@@ -141,7 +144,7 @@ export default Extension.create<RichTextOptions>({
 					},
 				}),
 			}),
-			Search,
+			...(this.options.editing ? [Search] : []),
 			Emoji.configure({
 				suggestion: EmojiSuggestion(),
 			}),
@@ -163,6 +166,7 @@ export default Extension.create<RichTextOptions>({
 				notAfter: ['paragraph', 'comments', 'footnotes'],
 			}),
 			TextDirection.configure({
+				inferTextDirectionOnParse: !this.options.editing,
 				types: [
 					'blockquote',
 					'callout',

--- a/src/extensions/TextDirection.ts
+++ b/src/extensions/TextDirection.ts
@@ -119,6 +119,7 @@ declare module '@tiptap/core' {
 export interface TextDirectionOptions {
 	types: string[]
 	defaultDirection: Direction | null
+	inferTextDirectionOnParse: boolean
 }
 
 export const TextDirection = Extension.create<TextDirectionOptions>({
@@ -128,6 +129,7 @@ export const TextDirection = Extension.create<TextDirectionOptions>({
 		return {
 			types: [],
 			defaultDirection: null,
+			inferTextDirectionOnParse: false,
 		}
 	},
 
@@ -138,7 +140,15 @@ export const TextDirection = Extension.create<TextDirectionOptions>({
 				attributes: {
 					dir: {
 						default: null,
-						parseHTML: (element) => element.dir || this.options.defaultDirection,
+						parseHTML: (element) => {
+							if (!this.options.inferTextDirectionOnParse) {
+								return element.dir || this.options.defaultDirection
+							}
+							const explicitDirection = element.dir as Direction
+							return validDirections.includes(explicitDirection)
+								? explicitDirection
+								: getTextDirection(element.textContent ?? '') ?? this.options.defaultDirection
+						},
 						renderHTML: (attributes) => {
 							if (attributes.dir === this.options.defaultDirection) {
 								return {}

--- a/src/nodes/DetailsView.vue
+++ b/src/nodes/DetailsView.vue
@@ -5,13 +5,17 @@
 
 <template>
 	<NodeViewWrapper data-text-el="details" class="details" as="div">
-		<NcButton variant="tertiary" size="small">
+		<NcButton
+			variant="tertiary"
+			size="small"
+			:aria-label="t('text', open ? 'Collapse details' : 'Expand details')"
+			:aria-expanded="open"
+			@click="toggleOpen">
 			<template #icon>
 				<TriangleSmallDownIcon
 					:size="20"
 					class="button-open"
-					:class="{ open: open }"
-					@click="toggleOpen" />
+					:class="{ open: open }" />
 			</template>
 		</NcButton>
 		<NodeViewContent class="details-container" :class="{ 'is-hidden': !open }" />
@@ -19,6 +23,7 @@
 </template>
 
 <script>
+import { t } from '@nextcloud/l10n'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/vue-3'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import TriangleSmallDownIcon from 'vue-material-design-icons/TriangleSmallDown.vue'
@@ -52,25 +57,30 @@ export default {
 	},
 
 	watch: {
-		'node.attrs.openDetails': function() {
-			this.openByAttr()
+		'node.attrs.openDetails': function(open) {
+			if (open) {
+				this.open = true
+				this.updateAttributes({ openDetails: false })
+			}
+		},
+
+		'node.attrs.open': function(open) {
+			this.open = open
 		},
 	},
 
 	beforeMount() {
-		this.openByAttr()
+		this.open = this.node.attrs.open || this.node.attrs.openDetails
+		if (this.node.attrs.openDetails) {
+			this.updateAttributes({ openDetails: false })
+		}
 	},
 
 	methods: {
+		t,
+
 		toggleOpen() {
 			this.open = !this.open
-		},
-
-		openByAttr() {
-			if (this.node.attrs.openDetails) {
-				this.open = true
-				this.updateAttributes({ openDetails: false })
-			}
 		},
 	},
 }

--- a/src/nodes/Image.ts
+++ b/src/nodes/Image.ts
@@ -17,6 +17,7 @@ const imageFileDropPluginKey = new PluginKey('imageFileDrop')
 const imageExtractAttachmentsKey = new PluginKey('imageExtractAttachments')
 
 interface ImageOptions extends TiptapImageOptions {
+	emitAttachmentEvents: boolean
 	noLazyImages: boolean
 }
 
@@ -53,6 +54,7 @@ const Image = TiptapImage.extend<ImageOptions>({
 	addOptions() {
 		return {
 			...this.parent?.() as ImageOptions,
+			emitAttachmentEvents: true,
 			noLazyImages: false,
 		}
 	},
@@ -120,31 +122,33 @@ const Image = TiptapImage.extend<ImageOptions>({
 					},
 				},
 			}),
-			new Plugin({
-				key: imageExtractAttachmentsKey,
-				state: {
-					init(_, { doc }) {
-						const attachmentSrcs = extractAttachmentSrcs(doc)
-						emit('text:editor:attachments:updated', { attachmentSrcs })
-						return { attachmentSrcs }
-					},
-					apply(tr, value, _oldState, newState) {
-						if (!tr.docChanged) {
-							return value
-						}
-						const attachmentSrcs = extractAttachmentSrcs(newState.doc)
-						if (
-							JSON.stringify(attachmentSrcs)
-							=== JSON.stringify(value?.attachmentSrcs)
-						) {
-							return value
-						}
+			...(this.options.emitAttachmentEvents
+				? [new Plugin({
+						key: imageExtractAttachmentsKey,
+						state: {
+							init(_, { doc }) {
+								const attachmentSrcs = extractAttachmentSrcs(doc)
+								emit('text:editor:attachments:updated', { attachmentSrcs })
+								return { attachmentSrcs }
+							},
+							apply(tr, value, _oldState, newState) {
+								if (!tr.docChanged) {
+									return value
+								}
+								const attachmentSrcs = extractAttachmentSrcs(newState.doc)
+								if (
+									JSON.stringify(attachmentSrcs)
+									=== JSON.stringify(value?.attachmentSrcs)
+								) {
+									return value
+								}
 
-						emit('text:editor:attachments:updated', { attachmentSrcs })
-						return { attachmentSrcs }
-					},
-				},
-			}),
+								emit('text:editor:attachments:updated', { attachmentSrcs })
+								return { attachmentSrcs }
+							},
+						},
+					})]
+				: []),
 		]
 	},
 

--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -24,8 +24,10 @@
 							v-if="isMediaAttachment"
 							contenteditable="false"
 							class="media">
-							<a
+							<button
+								type="button"
 								class="media-wrapper media-wrapper__attachment"
+								:aria-label="t('text', 'Open attachment {name}', { name: alt || attachment?.name || src })"
 								@click="handleAttachmentClick">
 								<img
 									v-show="loaded"
@@ -37,7 +39,7 @@
 									<span class="name">{{ alt }}</span>
 									<span class="size">{{ attachmentSize }}</span>
 								</div>
-							</a>
+							</button>
 							<div v-if="showDeleteIcon" class="buttons">
 								<NcButton
 									:aria-label="t('text', 'Delete this attachment')"
@@ -50,14 +52,18 @@
 							</div>
 						</div>
 						<div v-else contenteditable="false" class="media media__image">
-							<a class="media-wrapper" @click="handleImageClick">
+							<button
+								type="button"
+								class="media-wrapper"
+								:aria-label="t('text', 'Open image {name}', { name: alt || attachment?.name || src })"
+								@click="handleImageClick">
 								<img
 									v-show="loaded"
 									:src="imageUrl"
 									:alt="alt"
 									class="image__main"
 									@load="onLoaded">
-							</a>
+							</button>
 						</div>
 					</template>
 					<template v-else>
@@ -593,7 +599,11 @@ export default {
 
 	.media-wrapper {
 		display: flex;
-		// Overwrite some global rules for a elments
+		padding: 0;
+		border: 0;
+		background: transparent;
+		font: inherit;
+		cursor: pointer;
 		text-decoration: none;
 		color: var(--color-main-text);
 

--- a/src/services/AttachmentResolver.js
+++ b/src/services/AttachmentResolver.js
@@ -22,7 +22,6 @@ export default class AttachmentResolver {
 		this.#shareToken = shareToken
 		this.#currentDirectory = currentDirectory
 		this.#documentId = fileId ?? session.documentId
-		this.#initAttachmentListPromise = this.#updateAttachmentList()
 	}
 
 	async #updateAttachmentList() {
@@ -52,7 +51,7 @@ export default class AttachmentResolver {
 		if (src.match(directoryRegexp)) {
 			const imageFileName = decodeURIComponent(src.replace(directoryRegexp, '').split('?')[0])
 
-			// Wait until attachment list got fetched (initialized by constructor)
+			this.#initAttachmentListPromise ??= this.#updateAttachmentList()
 			await this.#initAttachmentListPromise
 			attachment = this.#findAttachment(imageFileName)
 

--- a/src/tests/comparison/MarkdownSourceComponent.spec.ts
+++ b/src/tests/comparison/MarkdownSourceComponent.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+	COMPLETE_SOURCE_DISPLAY_LIMITS,
+	displayBoundedMarkdownSource,
+	displayMarkdownSource,
+} from '../../comparison/markdownSourceDisplay.ts'
+
+describe('Markdown source component', () => {
+	const multilineSource = (length: number) => {
+		const line = `${'x'.repeat(COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerLine - 1)}\n`
+		return line.repeat(Math.floor(length / line.length)) + 'x'.repeat(length % line.length)
+	}
+
+	it.each([
+		COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerSide - 1,
+		COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerSide,
+	])('AUD-08 preserves complete source at the %i-character display boundary', (length) => {
+		const source = multilineSource(length)
+		expect(displayBoundedMarkdownSource(source)).toEqual({ text: source, truncated: false })
+	})
+
+	it('keeps supplementary characters well formed at the input boundary', () => {
+		const limit = COMPLETE_SOURCE_DISPLAY_LIMITS.maximumInputCharactersPerSide
+		const exact = `${multilineSource(limit - 2)}😀`
+		const crossingPrefix = multilineSource(limit - 1)
+		const crossing = `${crossingPrefix}😀`
+
+		expect(displayBoundedMarkdownSource(exact)).toEqual({ text: exact, truncated: false })
+		const result = displayBoundedMarkdownSource(crossing)
+		expect(result.text).toBe(crossingPrefix)
+		expect(result.text.length).toBeLessThanOrEqual(COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerSide)
+		expect(result.text.isWellFormed()).toBe(true)
+		expect(result.truncated).toBe(true)
+	})
+
+	it('keeps supplementary characters and visible controls intact at the output boundary', () => {
+		expect(displayMarkdownSource('abc😀', 5)).toBe('abc😀')
+		expect(displayMarkdownSource('abc😀', 4)).toBe('abc')
+		expect(displayMarkdownSource('\tremaining', 5)).toBe('⟦TAB⟧')
+	})
+
+	it.each([
+		['high', '\uD83D', '⟦U+D83D⟧'],
+		['low', '\uDE00', '⟦U+DE00⟧'],
+	])('renders a lone %s surrogate as an exact reversible token', (_name, source, expected) => {
+		const result = displayBoundedMarkdownSource(source)
+
+		expect(result).toEqual({ text: expected, truncated: false })
+		expect(result.text).not.toContain('\uFFFD')
+		expect(result.text.isWellFormed()).toBe(true)
+	})
+
+	it('reports expansion truncation instead of silently omitting a supplementary character', () => {
+		const result = displayBoundedMarkdownSource(`${'\t'.repeat(200_000)}😀`)
+
+		expect(result.truncated).toBe(true)
+		expect(result.text).toHaveLength(COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerLine)
+		expect(result.text).not.toContain('\uFFFD')
+		expect(result.text.isWellFormed()).toBe(true)
+		expect(result.text.length).toBeLessThanOrEqual(COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerLine)
+	})
+})

--- a/src/tests/comparison/MarkdownSourceFallback.spec.ts
+++ b/src/tests/comparison/MarkdownSourceFallback.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import MarkdownSourceFallback from '../../components/MarkdownSourceFallback.vue'
+
+vi.mock('../../comparison/markdownSourceComparison.ts', () => {
+	throw new Error('enhanced Source is unavailable')
+})
+
+describe('complete Markdown source fallback', () => {
+	it('always renders both complete snapshots as inert literal text with visible controls', () => {
+		const wrapper = mount(MarkdownSourceFallback, {
+			props: {
+				beforeContent: '<script>globalThis.pwned = true</script>\nzero\u200Bwidth',
+				afterContent: '<img src=x onerror=alert(1)>\nlast',
+			},
+		})
+		const sources = wrapper.findAll('pre code')
+		expect(sources).toHaveLength(2)
+		expect(sources[0]!.text()).toContain('<script>globalThis.pwned = true</script>')
+		expect(sources[0]!.text()).toContain('⟦ZWSP⟧')
+		expect(sources[1]!.text()).toContain('<img src=x onerror=alert(1)>')
+		expect(wrapper.find('script').exists()).toBe(false)
+		expect(wrapper.find('img').exists()).toBe(false)
+	})
+})

--- a/src/tests/comparison/comparisonDecorations.spec.ts
+++ b/src/tests/comparison/comparisonDecorations.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonDescriptor } from '../../comparison/markdownComparisonTypes.ts'
+
+import { EditorState } from '@tiptap/pm/state'
+import { schema } from 'prosemirror-schema-basic'
+import { describe, expect, it } from 'vitest'
+import { createComparisonDocumentIndex } from '../../comparison/comparisonDocumentIndex.ts'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import {
+	ComparisonProjectionError,
+	createComparisonDecorationPlugin,
+	prepareComparisonDecorations,
+} from '../../comparison/markdownComparison.ts'
+
+function descriptor(id: string, before: { from: number, to: number }, after = before): ComparisonDescriptor {
+	return {
+		id,
+		operation: 'replace',
+		detail: 'inline',
+		facets: ['text'],
+		before,
+		after,
+		context: { before: null, after: null },
+		preview: { before: null, after: null },
+		signals: [],
+	}
+}
+
+const doc = schema.node('doc', null, [schema.node('paragraph', null, schema.text('hello'))])
+
+describe('comparison decorations', () => {
+	it('does not infer a current descriptor without edit-owned selection', () => {
+		const change = descriptor('text', { from: 1, to: 4 })
+		const { key, plugin } = createComparisonDecorationPlugin([change], 'before', 'Changed')
+		const state = EditorState.create({ doc, plugins: [plugin] })
+		expect(key.getState(state)).toMatchObject({ activeIds: ['text'], currentIds: [] })
+	})
+
+	it('V04 projects non-empty ranges without creating any marker for a zero-length side', () => {
+		expect(prepareComparisonDecorations(doc, [descriptor('empty', { from: 2, to: 2 })], 'before')).toEqual([])
+		const projected = prepareComparisonDecorations(doc, [descriptor('text', { from: 1, to: 4 })], 'before')
+		expect(projected).toEqual([expect.objectContaining({ from: 1, to: 4, type: 'inline' })])
+	})
+
+	it('fails the complete projection when a non-empty range cannot be represented', () => {
+		const invalid = descriptor('invalid', { from: 99, to: 100 })
+		expect(() => prepareComparisonDecorations(doc, [invalid], 'before')).toThrow(ComparisonProjectionError)
+	})
+
+	it('AUD-04 decorates the enclosing list for a coarse nested-list range', () => {
+		const editor = createComparisonEditor('- outer\n  - first\n  - second')
+		try {
+			const index = createComparisonDocumentIndex(editor.state.doc)
+			const outerList = index.children[0]!
+			const nestedList = outerList.children[0]!.children[1]!
+			const firstItem = nestedList.children[0]!
+			const lastItem = nestedList.children.at(-1)!
+			const change = descriptor('nested-list', { from: firstItem.from, to: lastItem.to })
+			change.detail = 'block'
+			change.context.before = {
+				code: 'list-item',
+				path: firstItem.path,
+				from: firstItem.from,
+				to: firstItem.to,
+			}
+
+			expect(prepareComparisonDecorations(editor.state.doc, [change], 'before')).toEqual([
+				expect.objectContaining({ from: nestedList.from, to: nestedList.to, type: 'node' }),
+			])
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('invalidates prepared immutable decorations after a document transaction', () => {
+		const change = descriptor('text', { from: 1, to: 4 })
+		const { key, plugin } = createComparisonDecorationPlugin([change], 'before', 'Changed', {
+			activeIds: ['text'],
+			currentIds: ['text'],
+		})
+		const state = EditorState.create({ doc, plugins: [plugin] })
+		expect(key.getState(state)?.prepared).toHaveLength(1)
+		const changed = state.apply(state.tr.insertText('!', 1))
+		expect(key.getState(changed)).toMatchObject({ activeIds: [], currentIds: [], prepared: [] })
+	})
+})

--- a/src/tests/comparison/comparisonDocumentLocation.spec.ts
+++ b/src/tests/comparison/comparisonDocumentLocation.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { locateComparisonTarget } from '../../comparison/comparisonNavigation.ts'
+
+function scrollerIn(pane: HTMLElement) {
+	const scroller = document.createElement('div')
+	pane.append(scroller)
+	Object.defineProperties(scroller, {
+		clientHeight: { value: 300 },
+		scrollHeight: { value: 1200 },
+		scrollLeft: { value: 20 },
+		scrollTop: { value: 50 },
+	})
+	vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue({ height: 300, top: 100 } as DOMRect)
+	Object.defineProperty(scroller, 'scrollTo', { value: vi.fn() })
+	return scroller
+}
+
+describe('comparison document location', () => {
+	it('prefers the decorated DOM target', () => {
+		const pane = document.createElement('article')
+		const scroller = scrollerIn(pane)
+		const target = document.createElement('span')
+		target.dataset.comparisonChange = 'descriptor-1'
+		scroller.append(target)
+		vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({ height: 20, top: 700 } as DOMRect)
+		const fallback = vi.fn(() => ({ top: 900, height: 1 }))
+		expect(locateComparisonTarget(pane, scroller, 'descriptor-1', 'smooth', fallback)).toBe(true)
+		expect(fallback).not.toHaveBeenCalled()
+	})
+
+	it('V04 centers a supplied position rectangle for a marker-free zero-length side', () => {
+		const pane = document.createElement('article')
+		const scroller = scrollerIn(pane)
+		const fallback = vi.fn(() => ({ top: 700, height: 1 }))
+		expect(locateComparisonTarget(pane, scroller, 'missing', 'auto', fallback)).toBe(true)
+		expect(scroller.scrollTo).toHaveBeenCalledWith({ behavior: 'auto', left: 20, top: 500.5 })
+		expect(pane.querySelector('[data-comparison-change="missing"]')).toBeNull()
+	})
+
+	it('fails closed for invalid or hidden panes', () => {
+		const pane = document.createElement('article')
+		const scroller = scrollerIn(pane)
+		pane.hidden = true
+		expect(locateComparisonTarget(pane, scroller, 'missing', 'auto', () => ({ top: 1, height: 1 }))).toBe(false)
+		expect(locateComparisonTarget(null, scroller, 'missing', 'auto')).toBe(false)
+	})
+})

--- a/src/tests/comparison/comparisonEditorLifecycle.spec.ts
+++ b/src/tests/comparison/comparisonEditorLifecycle.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { PluginKey, Plugin as ProseMirrorPlugin } from '@tiptap/pm/state'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import ComparisonEditorContent from '../../components/ComparisonEditorContent.vue'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+
+describe('comparison editor lifecycle boundary', () => {
+	it('mounts the detached editor with its comparison plugin and node views', async () => {
+		const editor = createComparisonEditor('::: info\nBefore\n:::')
+		const plugin = new ProseMirrorPlugin({ key: new PluginKey('comparison') })
+		const wrapper = mount(ComparisonEditorContent, { props: { editor, plugins: [plugin] } })
+		try {
+			await vi.waitFor(() => expect(wrapper.emitted('ready')).toHaveLength(1))
+			const content = wrapper.get('.text-comparison__content')
+			expect(editor.view.dom.parentElement).toBe(content.element)
+			expect(content.find('[data-node-view-wrapper][data-text-el="callout"]').exists()).toBe(true)
+			expect(plugin.spec.key?.get(editor.state)).toBeDefined()
+		} finally {
+			wrapper.unmount()
+			editor.destroy()
+		}
+	})
+})

--- a/src/tests/comparison/comparisonNavigation.spec.ts
+++ b/src/tests/comparison/comparisonNavigation.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonDescriptor, ComparisonEdit } from '../../comparison/markdownComparisonTypes.ts'
+
+import { describe, expect, it } from 'vitest'
+import {
+	currentIdAfterFilter,
+	currentOrdinal,
+	isPureFormatting,
+	moveCurrentId,
+} from '../../comparison/comparisonNavigation.ts'
+
+function descriptor(id: string, facets: ComparisonDescriptor['facets'], operation: ComparisonDescriptor['operation'] = 'replace'): ComparisonDescriptor {
+	return {
+		id,
+		operation,
+		detail: 'inline',
+		facets,
+		before: { from: 0, to: 1 },
+		after: { from: 0, to: 1 },
+		context: { before: null, after: null },
+		preview: { before: null, after: null },
+		signals: [],
+	}
+}
+
+function edit(id: string, descriptors: ComparisonDescriptor[]): ComparisonEdit {
+	return { id, kind: 'content', primary: descriptors.at(-1)!, descriptors }
+}
+
+describe('edit-first comparison navigation', () => {
+	const edits = [
+		edit('e0', [descriptor('d0', ['text'])]),
+		edit('e1', [descriptor('d1', ['formatting'])]),
+		edit('e2', [descriptor('d2a', ['formatting']), descriptor('d2b', ['text', 'formatting'])]),
+		edit('e3', [descriptor('d3', ['attribute'])]),
+	]
+
+	it('requires every member to be formatting-only', () => {
+		expect(isPureFormatting(edits[1]!)).toBe(true)
+		expect(isPureFormatting(edits[2]!)).toBe(false)
+	})
+
+	it('V02 preserves the current edit or moves next then previous after filtering', () => {
+		expect(currentIdAfterFilter(edits, ['e0', 'e2', 'e3'], 'e2')).toBe('e2')
+		expect(currentIdAfterFilter(edits, ['e0', 'e2', 'e3'], 'e1')).toBe('e2')
+		expect(currentIdAfterFilter(edits, ['e0'], 'e1')).toBe('e0')
+		expect(currentIdAfterFilter(edits, [], 'e1')).toBeNull()
+	})
+
+	it('V01 wraps navigation and reports one ordinal per first-class edit', () => {
+		const active = ['e0', 'e2', 'e3']
+		expect(moveCurrentId(active, 'e0', -1)).toBe('e3')
+		expect(moveCurrentId(active, 'e3', 1)).toBe('e0')
+		expect(currentOrdinal(active, 'e2')).toBe(2)
+		expect(currentOrdinal([], null)).toBe(0)
+	})
+})

--- a/src/tests/comparison/comparisonPerformance.spec.ts
+++ b/src/tests/comparison/comparisonPerformance.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+
+import { describe, expect, it } from 'vitest'
+import {
+	alignComparisonAxis,
+	createComparisonWorkLedger,
+	DEFAULT_COMPARISON_TOKEN_LEDGER,
+} from '../../comparison/comparisonAlignment.ts'
+import { createHierarchicalMarkdownComparisonModel } from '../../comparison/hierarchicalMarkdownComparisonModel.ts'
+import { prepareComparisonDecorations } from '../../comparison/markdownComparison.ts'
+import { createComparisonTestEditor } from './comparisonTestEditor.ts'
+
+interface Item {
+	key: string
+	profile: readonly string[]
+}
+
+function items(count: number, side: string): Item[] {
+	return Array.from({ length: count }, (_value, index) => ({
+		key: `${side}:${index}`,
+		profile: [`item:${index}`, side],
+	}))
+}
+
+function options(work = createComparisonWorkLedger()) {
+	return {
+		work,
+		fingerprint: ({ key }: Item) => key,
+		profile: ({ profile }: Item) => profile,
+		compatible: () => true,
+	}
+}
+
+describe('bounded comparison performance fixtures', () => {
+	it('AUD-14 projects near-limit one-sided descriptors within a bounded candidate budget', () => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const headings = Array.from({ length: 6490 }, (_value, index) => (
+				editor.schema.nodes.heading!.create({ level: 1 }, editor.schema.text(`Section ${index}`))
+			))
+			const populated = editor.schema.nodes.doc!.create(null, headings)
+			const empty = editor.schema.nodes.doc!.create()
+			const model = createHierarchicalMarkdownComparisonModel(populated, empty)
+			const descriptors = model.edits.flatMap(({ descriptors: members }) => members)
+
+			const prepared = prepareComparisonDecorations(populated, descriptors, 'before')
+
+			expect(prepared).toHaveLength(headings.length)
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('P01 compares a near-6500-line exact-anchor document with negligible weighted work', () => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const headings = Array.from({ length: 6490 }, (_value, index) => (
+				editor.schema.nodes.heading!.create({ level: 1 }, editor.schema.text(`Section ${index}`))
+			))
+			const before = editor.schema.nodes.doc!.create(null, headings)
+			const changedHeading = editor.schema.nodes.heading!.create(
+				{ level: 1 },
+				editor.schema.text('Section 3245 edited'),
+			)
+			const after = editor.schema.nodes.doc!.create(null, headings.with(3245, changedHeading))
+
+			const model = createHierarchicalMarkdownComparisonModel(before, after)
+
+			expect(model.edits).toHaveLength(1)
+
+			const work = createComparisonWorkLedger()
+			const axis = Array.from({ length: 6490 }, (_value, index) => ({
+				key: `anchor:${index}`,
+				profile: [`anchor:${index}`],
+			}))
+			const changed = axis.with(3245, { key: 'changed:3245', profile: ['changed:3245'] })
+			alignComparisonAxis(axis, changed, options(work))
+			expect(work).toEqual(createComparisonWorkLedger())
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it.each(['insert', 'delete'] as const)('places a near-6500-line one-sided %s axis in linear time', (operation) => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const headings = Array.from({ length: 6490 }, (_value, index) => (
+				editor.schema.nodes.heading!.create({ level: 1 }, editor.schema.text(`Section ${index}`))
+			))
+			const empty = editor.schema.nodes.doc!.create()
+			const populated = editor.schema.nodes.doc!.create(null, headings)
+			const model = operation === 'insert'
+				? createHierarchicalMarkdownComparisonModel(empty, populated)
+				: createHierarchicalMarkdownComparisonModel(populated, empty)
+
+			expect(model.edits).toHaveLength(headings.length)
+			expect(model.edits.every(({ primary }) => primary.operation === operation)).toBe(true)
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('P04 shares the final token ledger across nested production nodes', () => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const firstBeforeCount = 100
+			const firstAfterCount = firstBeforeCount - 1
+			const firstProduct = firstBeforeCount * firstAfterCount
+			const firstLength = Math.floor(DEFAULT_COMPARISON_TOKEN_LEDGER / (4 * firstProduct))
+			const firstCharge = 2 * firstProduct * firstLength
+			const secondCount = 100
+			const secondLength = Math.floor((DEFAULT_COMPARISON_TOKEN_LEDGER - firstCharge) / (2 * secondCount ** 2)) + 1
+			const paragraphs = (count: number, character: string, length: number) => Array.from(
+				{ length: count },
+				() => editor.schema.nodes.paragraph!.create(null, editor.schema.text(character.repeat(length))),
+			)
+			const quote = (children: readonly Node[]) => (
+				editor.schema.nodes.blockquote!.create(null, children)
+			)
+			const anchor = editor.schema.nodes.paragraph!.create(null, editor.schema.text('exact nested boundary anchor'))
+			const before = editor.schema.nodes.doc!.create(null, [
+				quote(paragraphs(firstBeforeCount, 'a', firstLength)),
+				anchor,
+				quote(paragraphs(secondCount, 'c', secondLength)),
+			])
+			const after = editor.schema.nodes.doc!.create(null, [
+				quote(paragraphs(firstAfterCount, 'b', firstLength)),
+				anchor,
+				quote(paragraphs(secondCount, 'd', secondLength)),
+			])
+			const model = createHierarchicalMarkdownComparisonModel(before, after)
+
+			expect(2 * secondCount ** 2 * (secondLength - 1)).toBeLessThanOrEqual(DEFAULT_COMPARISON_TOKEN_LEDGER - firstCharge)
+			expect(2 * secondCount ** 2 * secondLength).toBeGreaterThan(DEFAULT_COMPARISON_TOKEN_LEDGER - firstCharge)
+			expect(model.edits.map(({ primary }) => primary.coarseReason)).toEqual([
+				'ambiguous-attribution',
+				'comparison-limit',
+			])
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('P03 bounds many aggregate maximal gaps with one comparison-wide ledger', () => {
+		const gapCount = 5
+		const gapSize = 200
+		const before: Item[] = []
+		const after: Item[] = []
+		for (let gap = 0; gap < gapCount; gap++) {
+			before.push(...items(gapSize, `before-${gap}`))
+			after.push(...items(gapSize, `after-${gap}`))
+			if (gap < gapCount - 1) {
+				const anchor = { key: `anchor-${gap}`, profile: [`anchor-${gap}`] }
+				before.push(anchor)
+				after.push(anchor)
+			}
+		}
+		const work = createComparisonWorkLedger()
+
+		const result = alignComparisonAxis(before, after, options(work))
+		const limited = result.filter((region) => 'coarseReason' in region && region.coarseReason === 'comparison-limit')
+
+		expect(work.remainingCells).toBe(0)
+		expect(limited).toHaveLength(gapCount - 1)
+	})
+})

--- a/src/tests/comparison/createComparisonEditor.spec.ts
+++ b/src/tests/comparison/createComparisonEditor.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+
+describe('comparison editor', () => {
+	it('creates a complete immutable detached Text editor with directional paragraphs', () => {
+		const editor = createComparisonEditor('English\n\nالعربية')
+		try {
+			expect(editor.options.element).toBeInstanceOf(HTMLElement)
+			expect((editor.options.element as HTMLElement).isConnected).toBe(false)
+			expect(editor.isEditable).toBe(false)
+			expect(editor.state.doc.textContent).toBe('Englishالعربية')
+			const directions: Array<string | null> = []
+			editor.state.doc.descendants((node) => {
+				if (node.type.name === 'paragraph') {
+					directions.push(node.attrs.dir as string | null)
+				}
+			})
+			expect(directions.slice(0, 2)).toEqual(['ltr', 'rtl'])
+		} finally {
+			editor.destroy()
+		}
+	})
+})

--- a/src/tests/comparison/createMarkdownContentComparison.spec.ts
+++ b/src/tests/comparison/createMarkdownContentComparison.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Editor } from '@tiptap/vue-3'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import * as markdownComparison from '../../comparison/markdownComparison.ts'
+import { createMarkdownContentComparison } from '../../createMarkdownContentComparison.ts'
+
+const originalScrollTo = HTMLElement.prototype.scrollTo
+
+beforeAll(async () => {
+	HTMLElement.prototype.scrollTo = vi.fn()
+	await Promise.all([
+		import('../../components/MarkdownContentComparison.vue'),
+		import('../../components/MarkdownSourceFallback.vue'),
+	])
+})
+
+afterAll(() => {
+	if (originalScrollTo) {
+		HTMLElement.prototype.scrollTo = originalScrollTo
+	} else {
+		delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo
+	}
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('Markdown comparison factory fallback and lifecycle', () => {
+	it('F05 remounts complete Source when rendered editor initialization fails', async () => {
+		vi.spyOn(Editor.prototype, 'mount').mockImplementation(() => {
+			throw new Error('forced mount failure')
+		})
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({ beforeContent: '<b>before</b>', afterContent: '<i>after</i>', el })
+		expect(el.querySelector('[data-comparison-source-fallback]')).not.toBeNull()
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(0)
+		expect(el.textContent).toContain('<b>before</b>')
+		expect(el.textContent).toContain('<i>after</i>')
+		instance.destroy()
+		instance.destroy()
+		expect(el.childElementCount).toBe(0)
+	})
+
+	it('F06 remounts complete Source without partial Documents when projection fails', async () => {
+		const originalSetAttribute = Element.prototype.setAttribute
+		vi.spyOn(Element.prototype, 'setAttribute').mockImplementation(function(this: Element, name, value) {
+			if (name === 'data-comparison-change') {
+				throw new Error('forced projection failure')
+			}
+			return originalSetAttribute.call(this, name, value)
+		})
+		const beforeContent = 'Complete projection before'
+		const afterContent = 'Complete projection after'
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({ beforeContent, afterContent, el })
+		const fullDocuments = [...el.querySelectorAll<HTMLButtonElement>('[role="tab"]')]
+			.find(({ textContent }) => textContent?.trim() === 'Full documents')
+
+		fullDocuments!.click()
+		await vi.waitFor(() => {
+			expect(el.querySelector('[data-comparison-source-fallback]')).not.toBeNull()
+		})
+		expect(el.querySelectorAll('.text-comparison__documents .ProseMirror')).toHaveLength(0)
+		expect(el.textContent).toContain(beforeContent)
+		expect(el.textContent).toContain(afterContent)
+		instance.destroy()
+	})
+
+	it('V12 can reopen the same pair after idempotent destroy without leaking root DOM', async () => {
+		const el = document.createElement('div')
+		for (let index = 0; index < 2; index++) {
+			const instance = await createMarkdownContentComparison({ beforeContent: 'Before', afterContent: 'After', el })
+			expect(el.querySelectorAll('.text-comparison-root')).toHaveLength(1)
+			instance.destroy()
+			instance.destroy()
+			expect(el.childElementCount).toBe(0)
+		}
+	})
+
+	it('keeps both document editors alive while switching views', async () => {
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({ beforeContent: 'Before', afterContent: 'After', el })
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(0)
+		expect(el.querySelectorAll('[data-comparison-source-fallback]')).toHaveLength(0)
+		const selectTab = async (label: string) => {
+			const tab = [...el.querySelectorAll<HTMLButtonElement>('[role="tab"]')]
+				.find(({ textContent }) => textContent?.trim() === label)
+			expect(tab).toBeDefined()
+			tab!.click()
+			await nextTick()
+		}
+
+		await selectTab('Full documents')
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(2)
+		await selectTab('Changes')
+		await selectTab('Full documents')
+
+		expect(el.querySelector('.text-comparison > [data-comparison-source-fallback]')).toBeNull()
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(2)
+		instance.destroy()
+	})
+
+	it('omits duplicate heading anchors from the two comparison documents', async () => {
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({
+			beforeContent: '# Shared heading\n\nBefore',
+			afterContent: '# Shared heading\n\nAfter',
+			el,
+		})
+		const documents = [...el.querySelectorAll<HTMLButtonElement>('[role="tab"]')]
+			.find(({ textContent }) => textContent?.trim() === 'Full documents')
+
+		documents!.click()
+		await nextTick()
+
+		await vi.waitFor(() => expect(el.querySelectorAll('.ProseMirror')).toHaveLength(2))
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		expect(el.querySelectorAll('.text-comparison__documents .heading-anchor[id]')).toHaveLength(0)
+		instance.destroy()
+	})
+
+	it('AUD-02 publishes the current selection when Documents mounts lazily', async () => {
+		const originalScrollTo = HTMLElement.prototype.scrollTo
+		const scrollTo = vi.fn()
+		HTMLElement.prototype.scrollTo = scrollTo
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({
+			beforeContent: 'Old first.\n\nOld second.',
+			afterContent: 'New first.\n\nNew second.',
+			el,
+		})
+		const secondEdit = el.querySelectorAll<HTMLButtonElement>('[data-comparison-select]')[1]
+
+		secondEdit!.click()
+		await vi.waitFor(() => {
+			expect(el.querySelectorAll('[data-comparison-change="change-1"][aria-current="true"]')).toHaveLength(2)
+		})
+		await vi.waitFor(() => expect(scrollTo).toHaveBeenCalled())
+		instance.destroy()
+		if (originalScrollTo) {
+			HTMLElement.prototype.scrollTo = originalScrollTo
+		} else {
+			delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo
+		}
+	})
+
+	it('AUD-11 locates the current edit on the newly visible side after a single-to-paired resize', async () => {
+		const originalResizeObserver = globalThis.ResizeObserver
+		const originalScrollTo = HTMLElement.prototype.scrollTo
+		const scrollTo = vi.fn()
+		let resizeTo!: (width: number) => void
+		HTMLElement.prototype.scrollTo = scrollTo
+		globalThis.ResizeObserver = class {
+			constructor(private readonly callback: ResizeObserverCallback) {}
+
+			observe(target: Element) {
+				resizeTo = (width) => this.callback([{ target, contentRect: { width } } as ResizeObserverEntry], this)
+				resizeTo(600)
+			}
+
+			disconnect() {}
+
+			unobserve() {}
+		} as typeof ResizeObserver
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({
+			beforeContent: 'Old first.\n\nOld second.',
+			afterContent: 'New first.\n\nNew second.',
+			el,
+		})
+		try {
+			el.querySelectorAll<HTMLButtonElement>('[data-comparison-select]')[1]!.click()
+			await vi.waitFor(() => expect(el.querySelector('.text-comparison--single')).not.toBeNull())
+			const afterScroller = el.querySelector<HTMLElement>('.text-comparison__document--after .text-comparison__document-scroller')!
+			await vi.waitFor(() => expect(scrollTo).toHaveBeenCalled())
+			expect(scrollTo.mock.contexts).not.toContain(afterScroller)
+
+			resizeTo(900)
+			await vi.waitFor(() => expect(el.querySelector('.text-comparison--paired')).not.toBeNull())
+
+			expect(scrollTo.mock.contexts).toContain(afterScroller)
+		} finally {
+			instance.destroy()
+			globalThis.ResizeObserver = originalResizeObserver
+			if (originalScrollTo) {
+				HTMLElement.prototype.scrollTo = originalScrollTo
+			} else {
+				delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo
+			}
+		}
+	})
+
+	it('keeps the working comparison when the loaded callback throws', async () => {
+		const el = document.createElement('div')
+		const creation = createMarkdownContentComparison({
+			beforeContent: 'Before',
+			afterContent: 'After',
+			el,
+			onLoaded: () => { throw new Error('callback failure') },
+		})
+		const instance = await Promise.race([
+			creation,
+			new Promise<null>((resolve) => setTimeout(() => resolve(null), 1000)),
+		])
+		expect(instance).not.toBeNull()
+		expect(el.querySelector('.text-comparison')).not.toBeNull()
+		expect(el.querySelector('[data-comparison-source-fallback]')).toBeNull()
+		instance?.destroy()
+	})
+
+	it('AUD-21 awaits a rejected loaded callback and keeps the working comparison', async () => {
+		const el = document.createElement('div')
+		let rejectLoaded!: (error: Error) => void
+		const onLoaded = vi.fn(() => new Promise<void>((_resolve, reject) => {
+			rejectLoaded = reject
+		}))
+		const creation = createMarkdownContentComparison({
+			beforeContent: 'Before',
+			afterContent: 'After',
+			el,
+			onLoaded,
+		})
+		let creationSettled = false
+		void creation.then(() => {
+			creationSettled = true
+		})
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(onLoaded).toHaveBeenCalledOnce()
+		expect(creationSettled).toBe(false)
+		rejectLoaded(new Error('async callback failure'))
+		const instance = await creation
+
+		expect(el.querySelector('.text-comparison')).not.toBeNull()
+		expect(el.querySelector('[data-comparison-source-fallback]')).toBeNull()
+		instance.destroy()
+	})
+
+	it('F07 routes a descriptor model limit to complete Source', async () => {
+		vi.spyOn(markdownComparison, 'createMarkdownComparisonModel').mockImplementation(() => {
+			throw new markdownComparison.ComparisonModelLimitError()
+		})
+		const beforeContent = '# Complete before snapshot\n\nBefore body\n'
+		const afterContent = '# Complete after snapshot\n\nAfter body\n'
+		const el = document.createElement('div')
+
+		const instance = await createMarkdownContentComparison({ beforeContent, afterContent, el })
+
+		expect(el.querySelector('[data-comparison-source-fallback]')).not.toBeNull()
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(0)
+		expect(el.textContent).toContain('Detailed rendered comparison unavailable')
+		expect(el.textContent).not.toContain('No rendered changes')
+		expect(el.textContent).toContain(beforeContent)
+		expect(el.textContent).toContain(afterContent)
+		instance.destroy()
+	})
+})

--- a/src/tests/comparison/renderedComparisonLimit.spec.ts
+++ b/src/tests/comparison/renderedComparisonLimit.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import { exceedsRenderedComparisonLimit, RENDERED_COMPARISON_LIMITS } from '../../comparison/markdownComparison.ts'
+
+describe('rendered comparison preflight', () => {
+	it('accepts each exact geometry ceiling and rejects the first excess', () => {
+		const chars = RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot
+		const lineChars = RENDERED_COMPARISON_LIMITS.maximumCharactersPerLine
+		const line = `${'a'.repeat(lineChars - 1)}\n`
+		const source = (length: number) => line.repeat(Math.floor(length / line.length)) + 'a'.repeat(length % line.length)
+		expect(exceedsRenderedComparisonLimit(source(chars), 'after')).toBe(false)
+		expect(exceedsRenderedComparisonLimit(source(chars + 1), 'after')).toBe(true)
+		expect(exceedsRenderedComparisonLimit('a'.repeat(lineChars), 'after')).toBe(false)
+		expect(exceedsRenderedComparisonLimit('a'.repeat(lineChars + 1), 'after')).toBe(true)
+		const lines = RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot
+		expect(exceedsRenderedComparisonLimit('x\n'.repeat(lines - 1), 'after')).toBe(false)
+		expect(exceedsRenderedComparisonLimit('x\r'.repeat(lines), 'after')).toBe(true)
+	})
+})

--- a/src/tests/nodes/DetailsViewAccessibility.spec.ts
+++ b/src/tests/nodes/DetailsViewAccessibility.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import DetailsView from '../../nodes/DetailsView.vue'
+
+function mountDetails(attrs: { open: boolean, openDetails: boolean }, updateAttributes = vi.fn()) {
+	return mount(DetailsView, {
+		props: { node: { attrs }, updateAttributes },
+		global: {
+			stubs: {
+				NodeViewWrapper: { template: '<div><slot /></div>' },
+				NodeViewContent: { template: '<div><slot /></div>' },
+				NcButton: {
+					emits: ['click'],
+					template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot name="icon" /></button>',
+				},
+				TriangleSmallDownIcon: true,
+			},
+		},
+	})
+}
+
+describe('DetailsView disclosure control', () => {
+	it('names the button and toggles details from the button', async () => {
+		const wrapper = mountDetails({ open: false, openDetails: false })
+		const button = wrapper.get('button')
+
+		expect(button.attributes('aria-label')).toBe('Expand details')
+		expect(button.attributes('aria-expanded')).toBe('false')
+
+		await button.trigger('click')
+
+		expect(button.attributes('aria-label')).toBe('Collapse details')
+		expect(button.attributes('aria-expanded')).toBe('true')
+	})
+
+	it('opens persisted native details without clearing the stored state', () => {
+		const updateAttributes = vi.fn()
+		const wrapper = mountDetails({ open: true, openDetails: false }, updateAttributes)
+
+		expect(wrapper.get('button').attributes('aria-label')).toBe('Collapse details')
+		expect(wrapper.get('button').attributes('aria-expanded')).toBe('true')
+		expect(updateAttributes).not.toHaveBeenCalled()
+	})
+})

--- a/src/tests/nodes/Image.spec.ts
+++ b/src/tests/nodes/Image.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Plugin } from '@tiptap/pm/state'
+
+import { getExtensionField } from '@tiptap/core'
+import { describe, expect, it } from 'vitest'
+import Image from '../../nodes/Image.ts'
+
+describe('Image plugins', () => {
+	it('omits attachment extraction when attachment events are disabled', () => {
+		const extension = Image.configure({ emitAttachmentEvents: false })
+		const addPlugins = getExtensionField(extension, 'addProseMirrorPlugins', { options: extension.options }) as () => Plugin[]
+
+		expect(addPlugins()).toHaveLength(1)
+	})
+})

--- a/src/tests/nodes/ImageViewAccessibility.spec.ts
+++ b/src/tests/nodes/ImageViewAccessibility.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { shallowRef } from 'vue'
+import ImageView from '../../nodes/ImageView.vue'
+import { ATTACHMENT_RESOLVER } from '../../components/Editor.provider.ts'
+
+type ImageViewProps = InstanceType<typeof ImageView>['$props']
+
+const attachment = {
+	alt: 'Diagram',
+	davPath: '/diagram.png',
+	fullUrl: '/diagram.png',
+	isImage: true,
+	metadata: null,
+	mimetype: 'image/png',
+	name: 'diagram.png',
+	previewUrl: '/preview.png',
+	size: 100,
+}
+
+beforeEach(() => {
+	vi.stubGlobal('ResizeObserver', class {
+		observe() {}
+		disconnect() {}
+	})
+	vi.stubGlobal('IntersectionObserver', class {
+		observe() {}
+		disconnect() {}
+	})
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+async function mountImage(isImage: boolean) {
+	const editor = { isEditable: false, off: vi.fn(), on: vi.fn() }
+	const wrapper = mount(ImageView, {
+		props: {
+			editor,
+			node: { attrs: { alt: 'Diagram', src: 'diagram.png' } },
+			decorations: [],
+			selected: false,
+			extension: { options: { noLazyImages: false } },
+			getPos: () => 0,
+			updateAttributes: vi.fn(),
+			deleteNode: vi.fn(),
+			view: {},
+			innerDecorations: {},
+			HTMLAttributes: {},
+		} as unknown as ImageViewProps,
+		global: {
+			provide: {
+				[ATTACHMENT_RESOLVER as symbol]: shallowRef({ resolve: vi.fn().mockResolvedValue({ ...attachment, isImage }) }),
+			},
+			stubs: {
+				NodeViewWrapper: { template: '<div><slot /></div>' },
+				ShowImageModal: true,
+			},
+		},
+	})
+	await wrapper.setData({ attachment: { ...attachment, isImage }, imageLoaded: true, loaded: true })
+	return wrapper
+}
+
+describe('ImageView read-only actions', () => {
+	it.each([
+		[true, 'Open image Diagram'],
+		[false, 'Open attachment Diagram'],
+	] as const)('AUD-18 renders a named native button when isImage is %s', async (isImage, label) => {
+		const wrapper = await mountImage(isImage)
+		const action = wrapper.find<HTMLButtonElement>('.media-wrapper')
+
+		expect(action.element.tagName).toBe('BUTTON')
+		expect(action.attributes('type')).toBe('button')
+		expect(action.attributes('aria-label')).toBe(label)
+		expect(action.element.tabIndex).toBe(0)
+	})
+
+	it('AUD-18 routes image button activation through the real modal handler', async () => {
+		const wrapper = await mountImage(true)
+		const view = wrapper.vm as unknown as { embeddedImageList: Array<typeof attachment & { src: string }> }
+		vi.spyOn(wrapper.vm, 'updateEmbeddedImageList').mockImplementation(async () => {
+			view.embeddedImageList = [{ ...attachment, src: 'diagram.png' }]
+		})
+
+		await wrapper.find<HTMLButtonElement>('.media-wrapper').trigger('click')
+
+		expect(wrapper.vm.imageIndex).toBe(0)
+		expect(wrapper.vm.showImageModal).toBe(true)
+	})
+
+	it('AUD-18 routes attachment button activation through the real Viewer action', async () => {
+		const open = vi.fn()
+		vi.stubGlobal('OCA', { Viewer: { file: null, mimetypes: ['image/png'], open } })
+		const wrapper = await mountImage(false)
+
+		await wrapper.find<HTMLButtonElement>('.media-wrapper').trigger('click')
+
+		expect(open).toHaveBeenCalledOnce()
+		expect(open).toHaveBeenCalledWith({ path: attachment.davPath })
+	})
+})

--- a/src/tests/services/AttachmentResolver.spec.js
+++ b/src/tests/services/AttachmentResolver.spec.js
@@ -36,11 +36,9 @@ function initAttachmentResolver(args) {
 			previewUrl: `http://nextcloud.local/apps/text/mediaPreview?documentId=${fileId}&sessionId=${sessionId}&sessionToken=${sessionToken}&mediaFileName=${a2name}"`,
 		},
 	]
-	const axiosSpy = vi
-		.spyOn(axios, 'post')
+	vi.spyOn(axios, 'post')
 		.mockReturnValue({ data: attachmentList })
 	const resolver = new AttachmentResolver(args)
-	expect(axiosSpy).toHaveBeenCalled()
 	return resolver
 }
 
@@ -54,6 +52,15 @@ describe('Image resolver', () => {
 		uid: 'user-uid',
 	}
 	const currentDirectory = '/parentDir'
+
+	it('does not request attachment metadata for a direct URL', async () => {
+		const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({ data: [] })
+		const resolver = new AttachmentResolver({ fileId })
+
+		await resolver.resolve('https://example.org/pic.jpg')
+
+		expect(axiosSpy).not.toHaveBeenCalled()
+	})
 
 	it('is a class with one constructor argument', () => {
 		const resolver = initAttachmentResolver({ fileId })


### PR DESCRIPTION
Part 3 of the version-comparison work for nextcloud/collectives#599: the Full documents view, so you can read both originals while seeing exactly what changed.

- Both originals rendered read-only, highlighted at the reported positions; paired navigation, independent scrolling, expandable gaps
- Three width-selected modes: wide, paired, and Before/After tabs on narrow screens
- A bounded fallback: rendered comparison rejects input lines above 20,000 characters and the literal-source display stops at a safe boundary, so oversized documents degrade without blocking the page

Depends on: #9048 (base review/structured-markdown-comparison-changes). Followed by #9050.

Full story, screenshots and the test matrix live in the #599 implementation update: https://github.com/nextcloud/collectives/issues/599#issuecomment-5295582982

AI disclosure: developed with OpenAI Codex (gpt-5.6-sol). Codex generated the implementation and tests under my direction; I reviewed, cleaned and verified the code, ran the full test and CI matrix, and signed the commits personally.
