### PR TITLE
fix(updateFromContent): destroy editor at end of setContent()

### DIFF
--- a/src/helpers/updateFromContent.ts
+++ b/src/helpers/updateFromContent.ts
@@ -55,4 +55,5 @@ function setContent(
 				extensions: [Collaboration.configure({ document: doc })],
 			})
 	editor.commands.setContent(html)
+	editor.destroy()
 }


### PR DESCRIPTION
The hope is that this fixes vitest failures like the following:

> ReferenceError: document is not defined
> [...]
> This error originated in "src/tests/helpers/updateFromContent.spec.ts"
> test file. [...]

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The analysis of failing tests was done partly using AI tools