### PR TITLE
fix[stable33]: add initial state for translation provider

### DIFF
--- a/lib/Service/InitialStateProvider.php
+++ b/lib/Service/InitialStateProvider.php
@@ -56,6 +56,12 @@ class InitialStateProvider {
 		);
 
 		$taskTypes = $this->taskProcessingManager->getAvailableTaskTypes();
+
+		$this->initialState->provideInitialState(
+			'translation_available',
+			isset($taskTypes['core:text2text:translate']),
+		);
+
 		$fromLanguages = $taskTypes['core:text2text:translate']['inputShapeEnumValues']['origin_language'] ?? [];
 		$toLanguages = $taskTypes['core:text2text:translate']['inputShapeEnumValues']['target_language'] ?? [];
 


### PR DESCRIPTION
Initial state for `translation_available` is missing in this branch for some reason, so the button doesn't appear
Follow up for #8753