### PR TITLE
[stable34] fix(FloatingButtons): hide btns until first mousemove

### DIFF
--- a/src/components/Editor/FloatingButtons.vue
+++ b/src/components/Editor/FloatingButtons.vue
@@ -68,6 +68,13 @@ export default {
 		},
 	},
 
+	mounted() {
+		// Start hidden until the drag handle plugin positions the buttons on
+		// first mousemove. The Vue 3 wrapper of @tiptap/extension-drag-handle
+		// does that internally, so this is not needed on NC v35 onwards.
+		this.$el.style.visibility = 'hidden'
+	},
+
 	methods: {
 		onNodeChange({ node, pos }) {
 			this.node = node


### PR DESCRIPTION
### 📝 Summary

Floating buttons overlapped the placeholder when opening Text editor on Android ~tablet-size. This fix hides them on mount until first mousemove. The Vue 3 wrapper of @tiptap/extension-drag-handle does that internally, so this is only needed for the stable branches.

The buttons only render when the viewport is >= 1024px: they are gated by `showFloatingButtons` in `ContentContainer.vue`, which uses `useIsMobile()`, a pure width check. The `DragHandle` plugin positions and reveals the buttons only in its `mousemove` handler. Until then they sit unpositioned at the editor's top-left corner, on top of the placeholder. Touch devices never fire `mousemove`, so on tablet-size touch screens (wide enough to pass the width check) the buttons stayed overlapping the placeholder permanently.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
<img width="2560" height="1600" alt="Attachment file 1 Bug7222980_1785523514966!screen1" src="https://github.com/user-attachments/assets/4aa07375-6cd9-4ff0-a42a-00c75e34d2fe" />
|
<img width="733" height="370" alt="Screenshot from 2026-08-25 09-20-15" src="https://github.com/user-attachments/assets/cd3b8b3b-98ac-4f44-90ac-840fa7f28554" />

B | A

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
