### PR TITLE
fix(sync): do not mistake own save requests for outside changes

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -307,6 +307,7 @@ class DocumentService {
 
 	/**
 	 * @throws DocumentSaveConflictException
+	 * @throws DoesNotExistException
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
@@ -331,7 +332,16 @@ class DocumentService {
 		$fileChecksum = self::computeCheckSum($fileContent);
 
 		if ($storedChecksum !== $fileChecksum) {
-			throw new DocumentSaveConflictException('File changed in the meantime from outside');
+			// $document was loaded at the start of the request.
+			// A save request handled in the meantime is not reflected in it
+			// and would be mistaken for an outside change.
+			// Reload the document to compare against the latest saved state.
+			$document = $this->documentMapper->find($documentId);
+			if ($document->getChecksum() !== $fileChecksum) {
+				throw new DocumentSaveConflictException('File changed in the meantime from outside');
+			}
+			// The save request already stored the latest version info.
+			return;
 		}
 
 		$document->setLastSavedVersionTime($fileMtime);

--- a/tests/unit/Service/DocumentServiceTest.php
+++ b/tests/unit/Service/DocumentServiceTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Text\Tests;
+
+use OCA\Text\Db\Document;
+use OCA\Text\Db\DocumentMapper;
+use OCA\Text\Db\SessionMapper;
+use OCA\Text\Db\StepMapper;
+use OCA\Text\Exception\DocumentSaveConflictException;
+use OCA\Text\Service\DocumentService;
+use OCA\Text\Service\FileService;
+use OCA\Text\Service\LockService;
+use OCP\DirectEditing\IManager;
+use OCP\Files\Config\IUserMountCache;
+use OCP\Files\File;
+use OCP\Files\IAppData;
+use OCP\Files\IRootFolder;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+class DocumentServiceTest extends \PHPUnit\Framework\TestCase {
+	private DocumentService $documentService;
+
+	private DocumentMapper $documentMapper;
+	private FileService $fileService;
+	private ICache $cache;
+
+	public function setUp(): void {
+		$this->documentMapper = $this->createMock(DocumentMapper::class);
+		$this->fileService = $this->createMock(FileService::class);
+		$this->cache = $this->createMock(ICache::class);
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createDistributed')->willReturn($this->cache);
+		$request = $this->createMock(IRequest::class);
+		$request->method('getParam')->willReturn(null);
+
+		$this->fileService->method('isReadOnly')->willReturn(false);
+
+		$this->documentService = new DocumentService(
+			$this->documentMapper,
+			$this->fileService,
+			$this->createMock(StepMapper::class),
+			$this->createMock(SessionMapper::class),
+			$this->createMock(IAppData::class),
+			'admin',
+			$this->createMock(IRootFolder::class),
+			$cacheFactory,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(LockService::class),
+			$request,
+			$this->createMock(IManager::class),
+			$this->createMock(IUserMountCache::class),
+			$this->createMock(IConfig::class),
+		);
+	}
+
+	private function createDocument(string $etag, int $mtime, string $content): Document {
+		$document = new Document();
+		$document->setId(123);
+		$document->setLastSavedVersionEtag($etag);
+		$document->setLastSavedVersionTime($mtime);
+		$document->setChecksum(DocumentService::computeCheckSum($content));
+		return $document;
+	}
+
+	private function mockFile(string $etag, int $mtime, string $content): File {
+		$file = $this->createMock(File::class);
+		$file->method('getEtag')->willReturn($etag);
+		$file->method('getMtime')->willReturn($mtime);
+		$file->method('getContent')->willReturn($content);
+		return $file;
+	}
+
+	public function testNoConflictWhenVersionInfoMatches(): void {
+		$document = $this->createDocument('etag1', 1000, 'content');
+		$file = $this->mockFile('etag1', 1000, 'content');
+
+		$this->documentMapper->expects(self::never())->method('find');
+		$this->documentMapper->expects(self::never())->method('update');
+
+		$this->documentService->assertNoOutsideConflict($document, $file);
+	}
+
+	public function testRefreshesVersionInfoWhenContentMatches(): void {
+		$document = $this->createDocument('etag1', 1000, 'content');
+		$file = $this->mockFile('etag2', 2000, 'content');
+
+		$this->documentMapper->expects(self::never())->method('find');
+		$this->documentMapper->expects(self::once())
+			->method('update')
+			->with($document);
+
+		$this->documentService->assertNoOutsideConflict($document, $file);
+		self::assertSame('etag2', $document->getLastSavedVersionEtag());
+		self::assertSame(2000, $document->getLastSavedVersionTime());
+	}
+
+	public function testNoConflictWhenOwnSaveFinishedInTheMeantime(): void {
+		// Loaded at the start of the request - stale by now.
+		$document = $this->createDocument('etag1', 1000, 'old content');
+		// A save request updated the file in the meantime ...
+		$file = $this->mockFile('etag2', 2000, 'new content');
+		// ... and stored the new version info in the document.
+		$freshDocument = $this->createDocument('etag2', 2000, 'new content');
+
+		$this->documentMapper->expects(self::once())
+			->method('find')
+			->with(123)
+			->willReturn($freshDocument);
+		$this->documentMapper->expects(self::never())->method('update');
+
+		$this->documentService->assertNoOutsideConflict($document, $file);
+	}
+
+	public function testConflictWhenFileChangedFromOutside(): void {
+		$document = $this->createDocument('etag1', 1000, 'old content');
+		$file = $this->mockFile('etag2', 2000, 'outside content');
+		// The latest saved state does not match the file either.
+		$freshDocument = $this->createDocument('etag1', 1000, 'old content');
+
+		$this->documentMapper->expects(self::once())
+			->method('find')
+			->with(123)
+			->willReturn($freshDocument);
+
+		$this->expectException(DocumentSaveConflictException::class);
+		$this->documentService->assertNoOutsideConflict($document, $file);
+	}
+
+	public function testNoConflictWhileSaveLockIsHeld(): void {
+		$document = $this->createDocument('etag1', 1000, 'old content');
+		$file = $this->mockFile('etag2', 2000, 'new content');
+
+		$this->cache->method('get')
+			->with('document-save-lock-123')
+			->willReturn(true);
+		$this->documentMapper->expects(self::never())->method('find');
+		$this->documentMapper->expects(self::never())->method('update');
+
+		$this->documentService->assertNoOutsideConflict($document, $file);
+	}
+}


### PR DESCRIPTION
### 📝 Summary

The bug: whenever working on a Text document and after saving a couple of times, the conflict view would appear, although no other user edited the document.

The document is loaded at the start of each request. A sync request compares its etag and checksum against the file only after several other queries. If a save request finishes in between, the file has changed but the loaded document does not reflect that yet, so the sync request then returned 409 and the client showed the conflict view, even though nobody else edited the file.

Reload the document before raising the conflict to compare against the latest saved state. Genuine outside changes still mismatch after the reload and keep raising the conflict.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
