### PR TITLE
fix(Table): return Tab and Shift-Tab handler results to mark the even…

### DIFF
--- a/src/nodes/Table/Table.js
+++ b/src/nodes/Table/Table.js
@@ -353,8 +353,10 @@ export default Table.extend({
 				) {
 					return true
 				}
-				this.editor.commands.goToNextCell()
-				|| this.editor.commands.leaveTable()
+				return (
+					this.editor.commands.goToNextCell()
+					|| this.editor.commands.leaveTable()
+				)
 			},
 			/**
 			 * <Tab> inside a table cell
@@ -369,7 +371,7 @@ export default Table.extend({
 				) {
 					return true
 				}
-				this.editor.commands.goToPreviousCell()
+				return this.editor.commands.goToPreviousCell()
 			},
 		}
 	},


### PR DESCRIPTION
### 📝 Summary

**Bug**: When having a table in a text document and using the tab to go the next cell, and then typing, new columns are created for each letter.

**Solution**: Add missing `return`s to `Tab` and `Shift-Tab` handling. Without the return, `goToNextCell()` moved the selection, but the key event was treated as unhandled, so the browser's native Tab also ran and moved the DOM caret out of the cell. Typing afterwards then inserted a new column for every keystroke. And `goToPreviousCell()` also now works as expected on `Shift-Tab`.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
