### PR TITLE
fix(avatars): prevent avatars from being squished

### DIFF
--- a/src/components/Editor/SessionList.vue
+++ b/src/components/Editor/SessionList.vue
@@ -11,6 +11,7 @@
 		<template #trigger="{ attrs }">
 			<div>
 				<NcButton
+					wide
 					:title="label"
 					:aria-label="label"
 					variant="tertiary"
@@ -132,8 +133,7 @@ export default {
 	height: var(--default-clickable-area);
 }
 
-/* Needs to be more specific than 0,2,0 (NcButton) */
-.button-vue--icon-only.avatar-list {
+.session-list .avatar-list {
 	width: min-content !important;
 	padding-inline: var(--default-grid-baseline);
 
@@ -143,8 +143,12 @@ export default {
 		width: min-content;
 
 		.avatar-wrapper {
-			margin: 3px -12px 3px 0;
+			margin: 3px 2px 3px 0;
 			z-index: 1;
+		}
+
+		.avatar-wrapper ~ .avatar-wrapper {
+			margin-right: -12px;
 		}
 	}
 }


### PR DESCRIPTION
### 📝 Summary

Fixes the collaborator avatar squish introduced by an incompatibility with the newer `@nextcloud/vue` pulled in by the vue3 migration

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="178" height="109" alt="35-avatar-before" src="https://github.com/user-attachments/assets/b73f1412-a39e-4475-863e-400797460738" />|<img width="178" height="109" alt="35-avatar-after" src="https://github.com/user-attachments/assets/1a53daff-3a19-43c8-87f8-4c4bc87e3b88" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI tools
- [ ] The AI-generated content was reviewed, comprehended and tested by a human
