### PR TITLE
chore(test): avoid duplicate extensions in testEditor

### DIFF
--- a/src/tests/testHelpers/testEditor.ts
+++ b/src/tests/testHelpers/testEditor.ts
@@ -49,7 +49,10 @@ export default baseTest.extend<{
 				}),
 			])
 		} else {
-			await use([Markdown, Document, Text, Paragraph, ...extensions])
+			const additionalExtensionNames = extensions.map((e) => e.name)
+			const defaultExtensions = [Markdown, Document, Text, Paragraph]
+				.filter((ext) => !additionalExtensionNames.includes(ext.name))
+			await use([...defaultExtensions, ...extensions])
 		}
 	},
 	markdownThroughEditor: async ({ editor, serializeMarkdown }, use) => {


### PR DESCRIPTION
Filter the default extensions by name so they can be replaced in the test.

Avoids warnings in footnotes and comments spec.

## Before

<img width="1207" height="345" alt="grafik" src="https://github.com/user-attachments/assets/3009db34-516b-4f48-961c-5213b77da232" />
