### PR TITLE
Fix link bubble behaviour

### DIFF
--- a/src/components/Editor/PreviewOptions.vue
+++ b/src/components/Editor/PreviewOptions.vue
@@ -4,6 +4,7 @@
 -->
 <template>
 	<NcActions
+		ref="actions"
 		v-model="open"
 		data-text-link-options="select"
 		class="link-options"
@@ -16,7 +17,7 @@
 			data-text-preview-option="text-only"
 			name="preview-option"
 			value="text-only"
-			:modelValue="type"
+			:modelValue="selectedType"
 			@change="(e) => toggle(e.currentTarget.value)">
 			{{ t('text', 'Text only') }}
 		</NcActionRadio>
@@ -24,7 +25,7 @@
 			data-text-preview-option="link-preview"
 			name="preview-option"
 			value="link-preview"
-			:modelValue="type"
+			:modelValue="selectedType"
 			@change="(e) => toggle(e.currentTarget.value)">
 			{{ t('text', 'Show link preview') }}
 		</NcActionRadio>
@@ -116,6 +117,7 @@ export default {
 	data() {
 		return {
 			open: false,
+			selectedType: this.type,
 		}
 	},
 
@@ -125,13 +127,21 @@ export default {
 		},
 	},
 
+	watch: {
+		type(value) {
+			this.selectedType = value
+		},
+
+	},
+
 	methods: {
 		onOpen() {
 			this.$emit('open')
 		},
 
-		toggle(type) {
-			this.open = false
+		async toggle(type) {
+			this.selectedType = type
+			await this.$refs.actions?.closeMenu(false)
 			this.$emit('toggle', type)
 		},
 

--- a/src/plugins/links.ts
+++ b/src/plugins/links.ts
@@ -109,6 +109,11 @@ export function linkBubble(options: { editor: Editor }) {
 				) {
 					return false
 				}
+
+				// Only show the link bubble while editing.
+				if (!view.editable) {
+					return false
+				}
 				const { state, dispatch } = view
 				const resolved = state.doc.resolve(pos)
 				return setActiveLink(resolved)(state, dispatch)
@@ -184,6 +189,10 @@ export function linkClicking(openLink: (href: string) => void = (href) => {
 					}
 
 					if (event.button === 0) {
+						// In editing mode, let the link bubble handle the click
+						if (view.editable && !event.ctrlKey && !event.metaKey) {
+							return false
+						}
 						// Stop browser from opening the link
 						event.preventDefault()
 
@@ -196,8 +205,8 @@ export function linkClicking(openLink: (href: string) => void = (href) => {
 								target?.scrollIntoView({ block: 'start', behavior: 'smooth' })
 							}
 							window.history.replaceState({}, '', url.href)
-						} else if (event.ctrlKey || event.metaKey) {
-							// Open link directly on Ctrl/Cmd + left click
+						} else {
+							// Open link directly on left click
 							openLink(linkEl.href)
 						}
 					}


### PR DESCRIPTION
### 📝 Summary


* Resolves: -

This improves link interaction in read-only mode.

Previously, clicking a link in read-only mode could open the link bubble instead of directly navigating to the linked destination. This change makes links behave more naturally in read-only mode by opening the destination directly when clicked.

The existing link bubble behaviour in editing mode is preserved, including the ability to use the bubble for interacting with links without immediately navigating away.

While making this change, an issue was also encountered where toggling between the link display options could leave the context menu open and briefly show both options as selected. This was fixed as part of the same change so that the menu closes correctly after changing the link display option.

<s>Related to [nextcloud/collectives#1026](https://github.com/nextcloud/collectives/issues/1026).</s>

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="364" height="222" alt="image" src="https://github.com/user-attachments/assets/1315b84d-373e-4564-8bac-db067e0220bd" /><img width="239" height="148" alt="image" src="https://github.com/user-attachments/assets/d89fc475-37bc-41f4-9300-2d8c98b55ffe" /> <img width="740" height="247" alt="image" src="https://github.com/user-attachments/assets/7a6e1e65-38ee-4aac-b31b-cc61c4c6774a" />| <img width="364" height="222" alt="image" src="https://github.com/user-attachments/assets/1315b84d-373e-4564-8bac-db067e0220bd" /> <img width="740" height="247" alt="image" src="https://github.com/user-attachments/assets/7a6e1e65-38ee-4aac-b31b-cc61c4c6774a" />



### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

