### PR TITLE
fix(image): keep data: URI images on markdown round-trip

### DIFF
--- a/src/nodes/Image.ts
+++ b/src/nodes/Image.ts
@@ -54,6 +54,10 @@ const Image = TiptapImage.extend<ImageOptions>({
 		return {
 			...this.parent?.() as ImageOptions,
 			noLazyImages: false,
+			// Markdown files can legitimately contain base64 data: URI images.
+			// Parsing them is required, otherwise they are silently dropped on
+			// the next save (issue #9108).
+			allowBase64: true,
 		}
 	},
 

--- a/src/nodes/Image.ts
+++ b/src/nodes/Image.ts
@@ -35,12 +35,15 @@ const Image = TiptapImage.extend<ImageOptions>({
 	},
 
 	parseHTML() {
+		if (!this.options.allowBase64) {
+			return [{ tag: 'figure img[src]:not([src^="data:"])' }]
+		}
+		// With base64 parsing on, admit a data: URI only when its mime type is an
+		// image one. A data:text/html src then never becomes a node, so the parse
+		// rule does not have to rely on the content security policy alone.
 		return [
-			{
-				tag: this.options.allowBase64
-					? 'figure img[src]'
-					: 'figure img[src]:not([src^="data:"])',
-			},
+			{ tag: 'figure img[src]:not([src^="data:"])' },
+			{ tag: 'figure img[src^="data:image/"]' },
 		]
 	},
 

--- a/src/nodes/ImageInline.ts
+++ b/src/nodes/ImageInline.ts
@@ -49,6 +49,9 @@ const ImageInline = TiptapImage.extend<ImageOptions>({
 			...this.parent?.() as ImageOptions,
 			noLazyImages: false,
 			inline: true,
+			// See Image.ts: data: URI images must survive an edit round-trip
+			// instead of being dropped on save (issue #9108).
+			allowBase64: true,
 		}
 	},
 

--- a/src/nodes/ImageInline.ts
+++ b/src/nodes/ImageInline.ts
@@ -35,12 +35,15 @@ const ImageInline = TiptapImage.extend<ImageOptions>({
 	},
 
 	parseHTML() {
+		if (!this.options.allowBase64) {
+			return [{ tag: 'img[src]:not([src^="data:"])' }]
+		}
+		// With base64 parsing on, admit a data: URI only when its mime type is an
+		// image one. A data:text/html src then never becomes a node, so the parse
+		// rule does not have to rely on the content security policy alone.
 		return [
-			{
-				tag: this.options.allowBase64
-					? 'img[src]'
-					: 'img[src]:not([src^="data:"])',
-			},
+			{ tag: 'img[src]:not([src^="data:"])' },
+			{ tag: 'img[src^="data:image/"]' },
 		]
 	},
 

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -38,6 +38,13 @@ describe('Markdown though editor', () => {
 		expect(markdownThroughEditor('~~Test~~')).toBe('~~Test~~')
 		expect(markdownThroughEditor('Have an `inline code` element')).toBe('Have an `inline code` element')
 	})
+	test('images with data: URI survive a round-trip (#9108)', ({ markdownThroughEditor }) => {
+		const dataUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+		// standalone image (block level, wrapped in a figure)
+		expect(markdownThroughEditor(`![pixel](${dataUri})`)).toBe(`![pixel](${dataUri})`)
+		// inline image inside a paragraph
+		expect(markdownThroughEditor(`Before ![pixel](${dataUri}) after`)).toBe(`Before ![pixel](${dataUri}) after`)
+	})
 	test('ul', ({ markdownThroughEditor }) => {
 		expect(markdownThroughEditor('+ foo\n+ bar')).toBe('+ foo\n+ bar')
 		expect(markdownThroughEditor('* foo\n* bar')).toBe('* foo\n* bar')

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -45,6 +45,15 @@ describe('Markdown though editor', () => {
 		// inline image inside a paragraph
 		expect(markdownThroughEditor(`Before ![pixel](${dataUri}) after`)).toBe(`Before ![pixel](${dataUri}) after`)
 	})
+	test('a non image data: URI does not become an image node (#9108)', ({ markdownThroughEditor }) => {
+		// allowBase64 on its own admits any mime type. The parse rules narrow it to
+		// data:image/, so the syntax stays literal text instead of turning into an
+		// image whose src could never render. The user's characters are kept either
+		// way, which is the point of #9108.
+		const htmlUri = 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=='
+		expect(markdownThroughEditor(`![x](${htmlUri})`)).toBe(`\\![x](${htmlUri})`)
+		expect(markdownThroughEditor(`Before ![x](${htmlUri}) after`)).toBe(`Before \\![x](${htmlUri}) after`)
+	})
 	test('ul', ({ markdownThroughEditor }) => {
 		expect(markdownThroughEditor('+ foo\n+ bar')).toBe('+ foo\n+ bar')
 		expect(markdownThroughEditor('* foo\n* bar')).toBe('* foo\n* bar')


### PR DESCRIPTION
Fixes #9108.

Editing a markdown file that contains base64 images (data: URI) deleted those images from the file on the next save. The root cause sits in the image parse rules: both the block `Image` and `ImageInline` extensions exclude `img[src^=data:]` when the TipTap `allowBase64` option is false, and nothing in this app turns it on. markdown-it parses the data: URI fine, but the img never becomes a document node, so the save writes the file without it. That exclusion is the upstream TipTap default, not a decision this app ever made, and there is nothing in the git history suggesting it was deliberate here.

The change enables `allowBase64` on both extensions. The file content is the user's own and the editor's job is to preserve it, not to filter it. Rendering already goes through the `ImageView` node view, which handles the src as-is.

Regression test added in `markdown.spec.js`, covering both paths:

- a standalone data: URI image (block level, wrapped in a figure)
- an inline data: URI image inside a paragraph

Both round-trip through the editor byte-identical. Full unit suite: 1582/1582 across 50 files. Before the change the new test fails (the image is dropped), which is the reported data loss.
