### PR TITLE
fix(collaboration): override addProseMirrorPlugins to prevent default caret user

### DIFF
--- a/src/extensions/CollaborationCaret.ts
+++ b/src/extensions/CollaborationCaret.ts
@@ -5,6 +5,7 @@
 
 import { t } from '@nextcloud/l10n'
 import { CollaborationCaret as TiptapCollaborationCaret } from '@tiptap/extension-collaboration-caret'
+import { yCursorPlugin } from '@tiptap/y-tiptap'
 
 export interface AwarenessUser {
 	color: string
@@ -96,6 +97,16 @@ const CollaborationCaret = TiptapCollaborationCaret.extend({
 				lastUpdate: getTimestamp(),
 			})
 		}
+	},
+
+	// Override to stop tiptap from setting its own default user
+	addProseMirrorPlugins() {
+		return [
+			yCursorPlugin(this.options.provider.awareness, {
+				cursorBuilder: this.options.render,
+				selectionBuilder: this.options.selectionRender,
+			}),
+		]
 	},
 })
 


### PR DESCRIPTION
### 📝 Summary
Fixes the collaborator cursor showing a id (e.g.  `User: 123`) instead of the actual name in stable35.

## What happened
Tiptap sets its own default user when the caret feature is setup. Since a recent tiptap update (>= 3.24.0), which we use now with stable35, this happens later and ends up overwriting the name we set.

## Fix
Override tiptap's `addProseMirrorPlugins` in our caret extension so it no longer sets a default user, leaving our user data as the only source.

Related tiptap commit which introduced this incompatibility: 
https://github.com/ueberdosis/tiptap/commit/976b8e39a5d45e7141b7690aa58c18a6b45dbfdb

<!-- Write a summary of your change and some reasoning if needed -->

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] [Tests](https://github.com/nextcloud/text#-testing-the-app) (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/text/blob/main/README.md) or [documentation](https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_server/text_configuration.rst#L2)) has been updated or is not required

### 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI tools
- [ ] The AI-generated content was reviewed, comprehended and tested by a human
