### PR TITLE
[stable35] Backport version comparison stack (#9047-#9050)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,17 +55,21 @@ jobs:
           npm run build --if-present
 
       - name: Install Playwright Browsers
-        run: npx playwright install chromium --only-shell
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Run Playwright tests
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        env:
+          TEXT_COMPARISON_E2E: '1'
 
       - name: Upload results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report_shard${{ matrix.shardIndex }}
-          path: test-results/
+          path: |
+            test-results/
+            blob-report/
           retention-days: 7
 
   summary:

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@tiptap/vue-3": "^3.30.5",
         "@vueuse/shared": "^14.4.0",
         "debounce": "^3.0.0",
+        "diff": "^8.0.4",
         "escape-html": "^1.0.3",
         "highlight.js": "^11.12.0",
         "katex": "^0.18.4",
@@ -90,6 +91,7 @@
         "yjs": "^13.6.32"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.13.0",
         "@nextcloud/babel-config": "^1.3.0",
         "@nextcloud/browserslist-config": "^3.1.2",
         "@nextcloud/e2e-test-server": "^0.5.1",
@@ -240,6 +242,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7362,6 +7377,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
@@ -9747,10 +9772,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
-      "dev": true,
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@tiptap/vue-3": "^3.30.5",
     "@vueuse/shared": "^14.4.0",
     "debounce": "^3.0.0",
+    "diff": "^8.0.4",
     "escape-html": "^1.0.3",
     "highlight.js": "^11.12.0",
     "katex": "^0.18.4",
@@ -108,6 +109,7 @@
     "yjs": "^13.6.32"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@nextcloud/babel-config": "^1.3.0",
     "@nextcloud/browserslist-config": "^3.1.2",
     "@nextcloud/e2e-test-server": "^0.5.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,10 +2,56 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+/* eslint-disable jsdoc/require-jsdoc */
 
 import type { ReporterDescription } from '@playwright/test'
 
 import { defineConfig, devices } from '@playwright/test'
+
+const COMPARISON_E2E = process.env.TEXT_COMPARISON_E2E === '1'
+const COMPARISON_TESTS = /playwright\/comparison\/.*\.spec\.ts/
+const COMPARISON_BASE_URL = process.env.TEXT_COMPARISON_BASE_URL || process.env.baseURL || 'http://localhost:8089/index.php/'
+const EXTERNAL_COMPARISON_SERVER = Boolean(process.env.TEXT_COMPARISON_BASE_URL || process.env.baseURL)
+
+function comparisonProjects() {
+	if (!COMPARISON_E2E) {
+		return []
+	}
+	return [{
+		name: 'comparison-chromium',
+		testMatch: COMPARISON_TESTS,
+		grepInvert: /@memory/,
+		use: {
+			...devices['Desktop Chrome'],
+			baseURL: COMPARISON_BASE_URL,
+			ignoreHTTPSErrors: true,
+			screenshot: 'only-on-failure' as const,
+			trace: 'retain-on-failure' as const,
+		},
+	}, {
+		name: 'comparison-webkit',
+		testMatch: COMPARISON_TESTS,
+		grepInvert: /@memory/,
+		use: {
+			...devices['Desktop Safari'],
+			baseURL: COMPARISON_BASE_URL,
+			ignoreHTTPSErrors: true,
+			screenshot: 'only-on-failure' as const,
+			trace: 'retain-on-failure' as const,
+		},
+	}, {
+		name: 'comparison-chromium-memory',
+		testMatch: COMPARISON_TESTS,
+		grep: /@memory/,
+		use: {
+			...devices['Desktop Chrome'],
+			baseURL: COMPARISON_BASE_URL,
+			ignoreHTTPSErrors: true,
+			screenshot: 'only-on-failure' as const,
+			trace: 'retain-on-failure' as const,
+		},
+	}]
+}
 
 /**
  * Used locally - i.e. if `CI` is not set as an environment variable.
@@ -24,12 +70,37 @@ const CI_CONFIG = {
 	// blob (so we can merge reports and download them for inspection),
 	// dot (so we have a quick overview in the logs while the tests are running)
 	// github (to have annotations in the PR)
-	reporter: [['blob'], ['line'], ['github']] as ReporterDescription[],
+	reporter: [
+		['blob'],
+		['json', { outputFile: 'test-results/results.json' }],
+		['line'],
+		['github'],
+	] as ReporterDescription[],
 	retries: 1,
 	timeout: 45_000,
 	// we shard to speed up the tests so no parallelism in workers
 	workers: 1,
 } as const
+
+function comparisonWebServer() {
+	if (EXTERNAL_COMPARISON_SERVER) {
+		return undefined
+	}
+	return {
+		command: 'npm run start:nextcloud',
+		gracefulShutdown: {
+			signal: 'SIGTERM' as const,
+			timeout: 10000,
+		},
+		reuseExistingServer: false,
+		stderr: 'pipe' as const,
+		stdout: 'pipe' as const,
+		timeout: 5 * 60 * 1000,
+		wait: {
+			stdout: /Nextcloud is now ready to use/,
+		},
+	}
+}
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -37,9 +108,10 @@ const CI_CONFIG = {
 export default defineConfig({
 	testDir: './playwright',
 	...(process.env.CI ? CI_CONFIG : LOCAL_CONFIG),
+	workers: COMPARISON_E2E ? 1 : undefined,
 	use: {
 		// Base URL to use in actions like `await page.goto('./')`.
-		baseURL: process.env.baseURL ?? 'http://localhost:8089/index.php/',
+		baseURL: COMPARISON_BASE_URL,
 		// record traces but only keep them when the test fails
 		trace: 'on-first-retry',
 	},
@@ -47,32 +119,13 @@ export default defineConfig({
 	projects: [
 		{
 			name: 'chromium',
+			testIgnore: COMPARISON_TESTS,
 			use: {
 				...devices['Desktop Chrome'],
 			},
 		},
+		...comparisonProjects(),
 	],
 
-	webServer: {
-		// Don't set `url` as it would take precedence over `wait.stdout` and tests start too early
-		// url: 'http://127.0.0.1:8089',
-		// Starts the Nextcloud docker container
-		command: 'npm run start:nextcloud',
-		// we use sigterm to notify the script to stop the container
-		// if it does not respond, we force kill it after 10 seconds
-		gracefulShutdown: {
-			signal: 'SIGTERM',
-			timeout: 10000,
-		},
-		// `start-nextcloud-server.mjs` only starts the server if not reachable yet.
-		reuseExistingServer: false,
-		stderr: 'pipe',
-		stdout: 'pipe',
-		// max. 5 minutes for creating the container
-		timeout: 5 * 60 * 1000,
-		wait: {
-			// we wait for this line to appear in the output of the webserver until consider it done
-			stdout: /Nextcloud is now ready to use/,
-		},
-	},
+	webServer: comparisonWebServer(),
 })

--- a/playwright/comparison/comparison.spec.ts
+++ b/playwright/comparison/comparison.spec.ts
@@ -1,0 +1,792 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { CDPSession, Page, TestInfo } from '@playwright/test'
+import type { ComparisonContents, ComparisonHarness, ComparisonMeasurement } from './support/comparisonHarness.ts'
+
+import { expect, test } from './fixtures.ts'
+
+const CELL_LEDGER = 40_000
+const MAXIMUM_SQUARE_AXIS = Math.floor(Math.sqrt(CELL_LEDGER))
+const CORE_LOGO = '/core/img/logo/logo.svg'
+const HIGH_CARDINALITY_CHANGES = 6_490
+const MAXIMUM_HIGH_CARDINALITY_HEAP_DELTA = 256_000_000
+
+const headingReplacement: ComparisonContents = {
+	before: 'A semantic block',
+	after: '# A semantic block',
+}
+const retainedTableCellEdit: ComparisonContents = {
+	before: '| Name | Value |\n| --- | --- |\n| retained | old value |\n| stable | same |',
+	after: '| Name | Value |\n| --- | --- |\n| retained | new value |\n| stable | same |',
+}
+
+test.describe('Text comparison production bundle acceptance', () => {
+	test('A12: the largest admitted square gap remains precise', async ({ comparison, page }) => {
+		test.setTimeout(180_000)
+		await mountMaximumSquare(comparison)
+
+		await expect(page.locator('.text-comparison > [data-comparison-source-fallback]')).toHaveCount(0)
+		await expect(page.locator('[data-comparison-select]')).toHaveCount(80)
+		await expect(page.getByRole('navigation', { name: 'Change pages' })).toContainText(`of ${MAXIMUM_SQUARE_AXIS}`)
+	})
+
+	test('T07: one edited retained table column is precise at cell altitude', async ({ comparison, page }) => {
+		await comparison.mount(retainedTableCellEdit)
+
+		const change = page.locator('[data-comparison-select]')
+		await expect(change).toHaveCount(1)
+		await change.click()
+		const changedCells = page.locator('td.text-comparison-change, td .text-comparison-change')
+		await expect(changedCells).toHaveCount(2)
+		await expect(page.locator('.text-comparison__document--before td').filter({ hasText: 'old value' })).toContainText('old value')
+		await expect(page.locator('.text-comparison__document--after td').filter({ hasText: 'new value' })).toContainText('new value')
+	})
+
+	test('T18: a later over-budget table coarsens without corrupting the admitted table plan', async ({ comparison, page }) => {
+		test.setTimeout(180_000)
+		await comparison.mount(tableLedgerFixture())
+
+		const changes = page.locator('[data-comparison-select]')
+		const pages = page.getByRole('navigation', { name: 'Change pages' })
+		await expect(changes).toHaveCount(80)
+		await expect(pages).toContainText('of 201')
+		await pages.getByRole('button', { name: 'Next' }).click()
+		await pages.getByRole('button', { name: 'Next' }).click()
+		await expect(changes).toHaveCount(41)
+		await expect(changes.last()).toContainText(/Structure changed|Table changed/)
+		await changes.last().click()
+		const current = page.locator('[data-comparison-change][aria-current="true"]')
+		await expect(current).toHaveCount(2)
+		expect(await current.evaluateAll((elements) => elements.every((element) => element.closest('table') === element.parentElement?.closest('table')))).toBe(true)
+	})
+
+	test('V01: one first-class edit owns one row, ordinal, identity, and complete target set', async ({ comparison, page }) => {
+		await comparison.mount(headingReplacement)
+
+		const row = page.locator('[data-comparison-select]')
+		await expect(row).toHaveCount(1)
+		await expect(row).toHaveAttribute('aria-current', 'true')
+		await expect(row).toHaveAttribute('aria-label', /Changed|Heading|Structure/)
+		await expect(page.locator('.text-comparison__sr-only')).toContainText('Change 1 of 1')
+		await row.click()
+		const identities = await page.locator('.text-comparison__documents [data-comparison-change]').evaluateAll((elements) => (
+			[...new Set(elements.map((element) => element.getAttribute('data-comparison-change')))]
+		))
+		expect(identities).toHaveLength(1)
+		await expect(page.locator('.text-comparison__documents [data-comparison-change]')).toHaveCount(2)
+	})
+
+	test('V02: filtering moves current selection next and then previous when needed', async ({ comparison, page }) => {
+		await assertFormattingFilterMove(comparison, page, {
+			before: 'Old first.\n\nFormatting only.\n\nOld last.',
+			after: 'New first.\n\n**Formatting only.**\n\nNew last.',
+		}, 'next')
+		await comparison.destroy()
+		await assertFormattingFilterMove(comparison, page, {
+			before: 'Old first.\n\nFormatting only.',
+			after: 'New first.\n\n**Formatting only.**',
+		}, 'previous')
+	})
+
+	test('V03: selecting a Changes row activates the identical edit in both Documents panes', async ({ comparison, page }) => {
+		await comparison.mount({ before: 'Old first.\n\nOld second.', after: 'New first.\n\nNew second.' })
+
+		const selectedEdit = page.locator('[data-comparison-select]').nth(1)
+		await selectedEdit.click()
+		const currentBySide: string[] = []
+		for (const side of ['before', 'after']) {
+			const current = page.locator(`.text-comparison__document--${side} [data-comparison-change][aria-current="true"]`)
+			await expect(current).toHaveCount(1)
+			currentBySide.push((await current.getAttribute('data-comparison-change')) ?? '')
+		}
+		expect(currentBySide[0]).toBe(currentBySide[1])
+	})
+
+	test('V04: an empty-side change has no synthetic marker and remains navigable', async ({ comparison, page }) => {
+		await comparison.mount({ before: '# Removed first\n\n# Removed second', after: '' })
+
+		await page.locator('[data-comparison-select]').first().click()
+		await expect(page.locator('.text-comparison__document--after [data-comparison-change]')).toHaveCount(0)
+		await expect(page.locator('.text-comparison__document--after [data-comparison-placeholder], .text-comparison__document--after .text-comparison-placeholder')).toHaveCount(0)
+		const announcement = page.locator('.text-comparison__sr-only')
+		const firstAnnouncement = await announcement.textContent()
+		await page.getByRole('button', { name: 'Next' }).click()
+		await expect(announcement).not.toHaveText(firstAnnouncement ?? '')
+		await expect(page.locator('.text-comparison__document--before [data-comparison-change][aria-current="true"]')).toHaveCount(1)
+	})
+
+	test('V05: paired Documents panes preserve independent scroll positions', async ({ comparison, page }) => {
+		const paragraphs = Array.from({ length: 100 }, (_, index) => `Paragraph ${index}.`).join('\n\n')
+		await comparison.mount({ before: `Old first.\n\n${paragraphs}\n\nOld tail.`, after: `New first.\n\n${paragraphs}\n\nNew tail.` })
+
+		await page.locator('[data-comparison-select]').first().click()
+		const beforeScroller = page.locator('.text-comparison__document--before .text-comparison__document-scroller')
+		const afterScroller = page.locator('.text-comparison__document--after .text-comparison__document-scroller')
+		await beforeScroller.evaluate((element) => {
+			element.scrollTop = 120
+		})
+		await afterScroller.evaluate((element) => {
+			element.scrollTop = 360
+		})
+		expect(await beforeScroller.evaluate(({ scrollTop }) => scrollTop)).not.toBe(await afterScroller.evaluate(({ scrollTop }) => scrollTop))
+		await page.getByRole('button', { name: 'Next' }).click()
+		expect(await beforeScroller.evaluate(({ scrollTop }) => scrollTop)).not.toBe(await afterScroller.evaluate(({ scrollTop }) => scrollTop))
+	})
+
+	test('V06: responsive single-pane Documents retain side and selection state', async ({ comparison, page }) => {
+		await comparison.mount({ before: 'Old first.\n\nOld second.', after: 'New first.\n\nNew second.', width: 620 })
+
+		await page.locator('[data-comparison-select]').nth(1).click()
+		await expect(page.locator('.text-comparison')).toHaveClass(/text-comparison--single/)
+		const sideTabs = page.getByRole('tablist', { name: 'Version to display' })
+		const beforeCurrent = page.locator('.text-comparison__document--before [data-comparison-change][aria-current="true"]')
+		await expect(beforeCurrent).toBeVisible()
+		const identity = await beforeCurrent.getAttribute('data-comparison-change')
+		await sideTabs.getByRole('tab', { name: 'After' }).click()
+		await expect(sideTabs.getByRole('tab', { name: 'After' })).toHaveAttribute('aria-selected', 'true')
+		const afterCurrent = page.locator('.text-comparison__document--after [data-comparison-change][aria-current="true"]')
+		await expect(afterCurrent).toBeVisible()
+		await expect(afterCurrent).toHaveAttribute('data-comparison-change', identity ?? '')
+		await page.locator('#text-comparison-harness').evaluate((element: HTMLElement) => {
+			element.style.inlineSize = '390px'
+		})
+		await expect.poll(() => page.locator('.toolbar').evaluate(({ clientWidth, scrollWidth }) => scrollWidth <= clientWidth)).toBe(true)
+		const viewTabsTop = await page.getByRole('tablist', { name: 'Comparison view' }).evaluate((element) => (element as HTMLElement).offsetTop)
+		const navigationTop = await page.getByLabel('Change navigation').evaluate((element) => (element as HTMLElement).offsetTop)
+		expect(navigationTop).toBeGreaterThan(viewTabsTop)
+	})
+
+	test('AUD-24: narrow Documents show the side that contains a one-sided edit', async ({ comparison, page }) => {
+		await comparison.mount({ before: '', after: '# Added first\n\n# Added second', width: 620 })
+
+		await page.locator('[data-comparison-select]').first().click()
+		const sideTabs = page.getByRole('tablist', { name: 'Version to display' })
+		await expect(sideTabs.getByRole('tab', { name: 'After' })).toHaveAttribute('aria-selected', 'true')
+		await expect(page.locator('.text-comparison__document--after [data-comparison-change][aria-current="true"]')).toBeVisible()
+		await expect(page.locator('.text-comparison__document--before')).toBeHidden()
+
+		await comparison.destroy()
+		await comparison.mount({ before: '# Removed first\n\n# Removed second', after: '', width: 620 })
+		await page.locator('[data-comparison-select]').first().click()
+		const deletionTabs = page.getByRole('tablist', { name: 'Version to display' })
+		await deletionTabs.getByRole('tab', { name: 'After' }).click()
+		await page.getByRole('tab', { name: 'Changes' }).click()
+		await page.locator('[data-comparison-select]').nth(1).click()
+		await expect(deletionTabs.getByRole('tab', { name: 'Before' })).toHaveAttribute('aria-selected', 'true')
+		await expect(page.locator('.text-comparison__document--before [data-comparison-change][aria-current="true"]')).toBeVisible()
+		await expect(page.locator('.text-comparison__document--after')).toBeHidden()
+	})
+
+	test('V06a: desktop comparison fills a flex mount host', async ({ comparison, page }) => {
+		await comparison.mount({ before: 'Old document.', after: 'New document.', width: 1100 })
+		await page.locator('#text-comparison-harness').evaluate((host) => {
+			host.style.display = 'flex'
+		})
+
+		await expect(page.locator('.text-comparison-root')).toHaveCSS('width', '1100px')
+		await expect(page.locator('.text-comparison')).toHaveClass(/text-comparison--paired/)
+	})
+
+	test('V06b: desktop Changes rows keep the reviewed full-width list presentation', async ({ comparison, page }) => {
+		await comparison.mount({ before: '# Old heading\n\nOld paragraph.', after: '# New heading\n\nNew paragraph.', width: 1100 })
+
+		const host = page.locator('#text-comparison-harness')
+		const section = page.locator('.text-comparison__section-toggle').first()
+		const row = page.locator('[data-comparison-select]').first()
+		const [hostBox, sectionBox, rowBox] = await Promise.all([host.boundingBox(), section.boundingBox(), row.boundingBox()])
+		expect(hostBox).not.toBeNull()
+		expect(sectionBox).not.toBeNull()
+		expect(rowBox).not.toBeNull()
+		expect(rowBox!.width).toBeGreaterThanOrEqual(900)
+		expect(sectionBox!.width).toBe(rowBox!.width)
+		expect(Math.abs(rowBox!.x + rowBox!.width / 2 - (hostBox!.x + hostBox!.width / 2))).toBeLessThan(2)
+		await expect(section).toHaveCSS('border-radius', '0px')
+		await expect(row).toHaveCSS('border-radius', '0px')
+	})
+
+	test('V07: tabs, navigation, focus, and announcements expose accessible state', async ({ comparison, page }) => {
+		await comparison.mount({ before: 'Old first.\n\nOld second.', after: 'New first.\n\nNew second.' })
+		await comparison.assertAccessibleComparison()
+
+		await page.locator('[data-comparison-select]').first().click()
+		const announcement = page.locator('.text-comparison__sr-only')
+		const initialAnnouncement = await announcement.textContent()
+		await page.getByRole('button', { name: 'Next' }).click()
+		await expect(announcement).not.toHaveText(initialAnnouncement ?? '')
+		await page.getByRole('button', { name: 'Previous' }).click()
+		await expect(announcement).toHaveText(initialAnnouncement ?? '')
+		const documentsTab = page.getByRole('tab', { name: 'Full documents' })
+		await documentsTab.press('End')
+		await expect(page.getByRole('tab', { name: 'Markdown source' })).toBeFocused()
+		await page.getByRole('tab', { name: 'Markdown source' }).press('Home')
+		await expect(page.getByRole('tab', { name: 'Changes' })).toBeFocused()
+		await expect(announcement).toHaveAttribute('aria-live', 'polite')
+		await expect(announcement).toHaveAttribute('aria-atomic', 'true')
+	})
+
+	test('V08: a changed real image node-view receives scoped visible treatment', async ({ comparison, page }, testInfo) => {
+		await comparison.mount({
+			before: `![Before logo](${CORE_LOGO})\n\nOld paragraph.`,
+			after: `![After logo](${CORE_LOGO})\n\nNew paragraph.`,
+		})
+		const changes = page.locator('[data-comparison-select]')
+		await expect(changes).toHaveCount(2)
+		await changes.first().click()
+
+		const wrappers = page.locator('[data-node-view-wrapper].text-comparison-change:has(img)')
+		await expect(wrappers).toHaveCount(2)
+		for (const wrapper of await wrappers.all()) {
+			await expect(wrapper.locator('figure[data-component="image-view"] img')).toHaveCount(1)
+			await expect(wrapper).toHaveClass(/text-comparison-change--current/)
+			const boxShadow = await wrapper.evaluate((element) => getComputedStyle(element).boxShadow)
+			expect(boxShadow).not.toBe('none')
+			expect(boxShadow).toMatch(/inset/)
+		}
+		await testInfo.attach('real-image-node-view.png', {
+			body: await page.locator('#text-comparison-harness').screenshot(),
+			contentType: 'image/png',
+		})
+
+		await page.getByRole('button', { name: 'Next' }).click()
+		for (const wrapper of await wrappers.all()) {
+			await expect(wrapper).not.toHaveClass(/text-comparison-change--current/)
+			const boxShadow = await wrapper.evaluate((element) => getComputedStyle(element).boxShadow)
+			expect(boxShadow).not.toBe('none')
+			expect(boxShadow).toMatch(/inset/)
+		}
+
+		await comparison.destroy()
+		await comparison.mount({
+			before: '| Name |\n| --- |\n| retained |\n| removed |',
+			after: '| Name |\n| --- |\n| retained |',
+		})
+		await page.locator('[data-comparison-select]').click()
+		const structuralRow = page.locator('tr.text-comparison-change')
+		await expect(structuralRow).toHaveCount(1)
+		const structuralTreatment = await structuralRow.evaluate((element) => getComputedStyle(element).boxShadow)
+		expect(structuralTreatment).not.toBe('none')
+		expect(structuralTreatment).toMatch(/inset/)
+	})
+
+	test('V09: syntax-only Markdown reports no semantic edit and opens Source', async ({ comparison, page }) => {
+		await comparison.mount({ before: '*same rendered text*', after: '_same rendered text_' })
+
+		await expect(page.getByRole('status')).toContainText('No rendered differences')
+		await expect(page.locator('[data-comparison-select]')).toHaveCount(0)
+		await page.getByRole('button', { name: 'Open Markdown source' }).click()
+		await expect(page.getByRole('tab', { name: 'Markdown source' })).toHaveAttribute('aria-selected', 'true')
+		await expect(page.locator('[data-source-hunk]')).toHaveCount(1)
+	})
+
+	test('V10: Source preserves literal EOL, tab, trailing-space, control, and final-newline differences', async ({ comparison, page }) => {
+		await comparison.mount({ before: 'first\tline  \r\nzero\u200Bwidth', after: 'first\tline \nzero\u200Cwidth\n' })
+		await page.getByRole('tab', { name: 'Markdown source' }).click()
+
+		const source = page.locator('.text-source-comparison')
+		for (const token of ['TAB', 'ZWSP', 'ZWNJ', 'CRLF', 'LF', 'TRAILING SPACE', 'No newline at end of file']) {
+			await expect(source).toContainText(token)
+		}
+		const sourceText = await source.textContent()
+		expect(sourceText).not.toContain('\u200B')
+		expect(sourceText).not.toContain('\u200C')
+	})
+
+	test('V11: Source processing limits retain complete before and after fallback text', async ({ comparison, page }) => {
+		const before = Array.from({ length: 3000 }, (_, index) => `before-${index}`).join('\n')
+		const after = Array.from({ length: 3000 }, (_, index) => `after-${index}`).join('\n')
+		await comparison.mount({ before, after })
+		await page.getByRole('tab', { name: 'Markdown source' }).click()
+
+		await expect(page.locator('[data-source-limited]')).toBeVisible()
+		const fallback = page.locator('[data-comparison-source-fallback]')
+		await expect(fallback).toContainText('before-0')
+		await expect(fallback).toContainText('before-2999')
+		await expect(fallback).toContainText('after-0')
+		await expect(fallback).toContainText('after-2999')
+	})
+
+	test('V12: repeated idempotent destroy leaves no editors, observers, or root DOM', async ({ comparison, page }) => {
+		await comparison.open()
+		const baseline = await comparison.observerCounts()
+
+		for (let iteration = 0; iteration < 2; iteration++) {
+			const measurement = await comparison.mount({ before: `Before ${iteration}`, after: `After ${iteration}` })
+			expect(measurement.rootCount).toBe(1)
+			expect(measurement.proseMirrorCount).toBe(0)
+			await page.getByRole('tab', { name: 'Full documents' }).click()
+			await expect(page.locator('.ProseMirror')).toHaveCount(2)
+			await comparison.destroy(2)
+			await expect(page.locator('#text-comparison-harness')).toBeEmpty()
+			expect(await comparison.observerCounts()).toEqual(baseline)
+		}
+	})
+
+	test('F05: editor initialization failure mounts complete literal Source for both snapshots', async ({ comparison, page }) => {
+		let fallbackChunkRequests = 0
+		await page.route('**/*MarkdownSourceFallback*', async (route) => {
+			fallbackChunkRequests++
+			await route.abort('failed')
+		})
+		await comparison.forceEditorInitializationFailure()
+		await comparison.mount({ before: '<b>complete before</b>', after: '<i>complete after</i>' })
+
+		const fallback = page.locator('[data-comparison-source-fallback]')
+		await expect(fallback).toContainText('<b>complete before</b>')
+		await expect(fallback).toContainText('<i>complete after</i>')
+		await expect(page.locator('.ProseMirror')).toHaveCount(0)
+		expect(fallbackChunkRequests).toBe(0)
+	})
+
+	test('F06: projection failure mounts Source without partial Documents', async ({ comparison, page }) => {
+		await comparison.forceProjectionFailure()
+		await comparison.mount({ before: 'Projection before', after: 'Projection after' })
+		await page.getByRole('tab', { name: 'Full documents' }).click()
+
+		const fallback = page.locator('[data-comparison-source-fallback]')
+		await expect(fallback).toContainText('Projection before')
+		await expect(fallback).toContainText('Projection after')
+		await expect(page.locator('.text-comparison__documents .ProseMirror')).toHaveCount(0)
+		await expect(page.locator('.text-comparison__documents [data-comparison-change]')).toHaveCount(0)
+	})
+
+	test('F11: normal comparison modes emit no unexplained browser or network failures', async ({ comparison, page }) => {
+		comparison.resetCapture()
+		await comparison.mount({ before: 'Old content.', after: '**New content.**' })
+		await page.locator('[data-comparison-select]').click()
+		await page.getByRole('tab', { name: 'Markdown source' }).click()
+		await expect(page.locator('[data-source-hunk]')).toBeVisible()
+
+		expect(comparison.failures).toEqual([])
+		expect(comparison.consoleMessages.filter(({ type }) => type === 'error')).toEqual([])
+		expect(comparison.network.filter(({ failure, status }) => failure || (status ?? 200) >= 400)).toEqual([])
+	})
+
+	test('P01: the near-line-floor one-change fixture stays precise with bounded readiness', async ({ comparison, page }, testInfo) => {
+		test.setTimeout(180_000)
+		const measurement = await comparison.mount(nearLineFloorFixture())
+
+		await expect(page.locator('[data-comparison-select]')).toHaveCount(1)
+		await attachMeasurement(testInfo, 'near-line-floor', measurement, { weightedDebit: 0 })
+	})
+
+	test('AUD-02: pre-mount selection and filtering initialize both Documents decoration plugins', async ({ comparison, page }) => {
+		for (const width of [1000, 620]) {
+			await comparison.mount({ before: 'Old first.\n\nOld second.', after: 'New first.\n\nNew second.', width })
+			await page.locator('[data-comparison-select]').nth(1).click()
+			for (const side of ['before', 'after']) {
+				await expect(page.locator(`.text-comparison__document--${side} [data-comparison-change="change-1"][aria-current="true"]`)).toHaveCount(1)
+			}
+			await comparison.destroy()
+
+			await comparison.mount({ before: 'Formatting only.\n\nOld content.', after: '**Formatting only.**\n\nNew content.', width })
+			await page.getByRole('checkbox', { name: 'Hide formatting-only changes' }).check()
+			await page.getByRole('tab', { name: 'Full documents' }).click()
+			await expect(page.locator('.text-comparison__documents .text-comparison-change--formatting')).toHaveCount(0)
+			for (const side of ['before', 'after']) {
+				await expect(page.locator(`.text-comparison__document--${side} [data-comparison-change][aria-current="true"]`)).toHaveCount(1)
+			}
+			await comparison.destroy()
+		}
+	})
+
+	test('AUD-05: Source visibly exposes side, operation, whitespace, EOL, control, and final-newline semantics', async ({ comparison, page }) => {
+		await comparison.mount({ before: 'old\t\u200B\r\ntrail  ', after: 'new\ntrail\n' })
+		await page.getByRole('tab', { name: 'Markdown source' }).click()
+
+		const source = page.locator('.text-source-comparison')
+		await expect(source.locator('[data-source-side="before"]')).toHaveText('Before')
+		await expect(source.locator('[data-source-side="after"]')).toHaveText('After')
+		await expect(source.locator('[data-source-operation="removed"]').first()).toHaveAttribute('aria-label', /Removed line/)
+		await expect(source.locator('[data-source-operation="added"]').first()).toHaveAttribute('aria-label', /Added line/)
+		await expect(source.locator('[data-source-operation="removed"] [data-source-cue]').first()).toHaveText('−')
+		await expect(source.locator('[data-source-operation="added"] [data-source-cue]').first()).toHaveText('+')
+		for (const token of ['TAB', 'ZWSP', 'CRLF', 'LF', '2 TRAILING SPACES', 'No newline at end of file']) {
+			await expect(source).toContainText(token)
+		}
+	})
+
+	test('AUD-09: settled image dialog focus is contained and restored on close', async ({ comparison, page }, testInfo) => {
+		await comparison.mount({ before: `![Before logo](${CORE_LOGO})`, after: `![After logo](${CORE_LOGO})` })
+		await page.locator('[data-comparison-select]').first().click()
+		const action = page.getByRole('button', { name: 'Open image Before logo' })
+		await action.focus()
+		await action.press('Enter')
+
+		const dialog = page.getByRole('dialog')
+		await expect(dialog).toBeVisible()
+		await expect.poll(() => page.evaluate(() => document.querySelector('[role="dialog"]')?.contains(document.activeElement) ?? false)).toBe(true)
+		if (testInfo.project.name.includes('chromium')) {
+			await page.keyboard.press('Tab')
+			await expect.poll(() => page.evaluate(() => document.querySelector('[role="dialog"]')?.contains(document.activeElement) ?? false)).toBe(true)
+		}
+		await page.keyboard.press('Escape')
+		await expect(dialog).toBeHidden()
+		await expect(action).toBeFocused()
+	})
+
+	test('AUD-10: Changes tokens wrap with spacing and selected tabs have visible treatment', async ({ comparison, page }) => {
+		await comparison.mount({ before: 'A short value.', after: '**A substantially longer changed value that must remain readable.**' })
+
+		const item = page.locator('.text-comparison__change-item')
+		const content = item.locator('.text-comparison__change-item-content')
+		const itemStyle = await item.evaluate((element) => {
+			const style = getComputedStyle(element)
+			return { columnGap: style.columnGap, display: style.display, rowGap: style.rowGap }
+		})
+		const contentStyle = await content.evaluate((element) => {
+			const style = getComputedStyle(element)
+			return { display: style.display, gap: style.gap, overflowWrap: style.overflowWrap }
+		})
+		expect(itemStyle.display).toBe('grid')
+		expect(itemStyle.columnGap).not.toBe('0px')
+		expect(contentStyle.display).toBe('flex')
+		expect(contentStyle.gap).not.toBe('0px')
+		expect(contentStyle.overflowWrap).toBe('anywhere')
+
+		const selectedTab = page.getByRole('tab', { name: 'Changes' })
+		const selectedStyle = await selectedTab.evaluate((element) => {
+			const style = getComputedStyle(element)
+			return {
+				borderRadius: style.borderRadius,
+				borderWidth: style.borderBottomWidth,
+				boxShadow: style.boxShadow,
+				fontWeight: style.fontWeight,
+			}
+		})
+		expect(selectedStyle.borderRadius).toBe('0px')
+		expect(Number.parseFloat(selectedStyle.borderWidth)).toBeGreaterThan(0)
+		expect(selectedStyle.boxShadow).toBe('none')
+		expect(Number.parseInt(selectedStyle.fontWeight, 10)).toBeGreaterThanOrEqual(700)
+
+		await comparison.destroy()
+		await comparison.mount({
+			before: '# B1 duplicate-body deletion\n\n| A | B | C |\n| --- | --- | --- |\n| x | x | x |\n| x | x | x |',
+			after: '# B1 duplicate-body deletion\n\n| A | B |\n| --- | --- |\n| x | x |\n| x | x |',
+			width: 340,
+		})
+		await expect(page.locator('.text-comparison')).toHaveClass(/text-comparison--single/)
+		const narrowItem = page.locator('.text-comparison__change-item').first()
+		const narrowLabel = narrowItem.getByText('Table column removed', { exact: true })
+		await expect(narrowLabel).toBeVisible()
+		await expect(narrowItem.locator('.badge')).toHaveCount(2)
+		expect(await narrowLabel.evaluate((element) => {
+			const range = document.createRange()
+			range.selectNodeContents(element)
+			return range.getClientRects().length
+		})).toBe(1)
+		expect(await narrowItem.locator('.title').evaluate((element) => {
+			const bounds = element.getBoundingClientRect()
+			return [...element.children].every((child) => {
+				const rect = child.getBoundingClientRect()
+				return rect.left >= bounds.left && rect.right <= bounds.right
+			})
+		})).toBe(true)
+		expect(await narrowItem.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true)
+	})
+
+	test('AUD-11: revealing a responsive hidden side locates the already-current edit', async ({ comparison, page }) => {
+		const middle = Array.from({ length: 120 }, (_, index) => `Stable paragraph ${index}.`).join('\n\n')
+		await comparison.mount({ before: `Old first.\n\n${middle}\n\nOld tail.`, after: `New first.\n\n${middle}\n\nNew tail.`, width: 620, height: 360 })
+		await page.locator('[data-comparison-select]').nth(1).click()
+
+		await expect(page.locator('.text-comparison')).toHaveClass(/text-comparison--single/)
+		await expect(page.locator('.text-comparison__document--after')).toBeHidden()
+		const afterScroller = page.locator('.text-comparison__document--after .text-comparison__document-scroller')
+		await afterScroller.evaluate((element) => {
+			element.scrollTop = 0
+		})
+		await page.locator('#text-comparison-harness').evaluate((element: HTMLElement) => {
+			element.style.inlineSize = '900px'
+		})
+		await expect(page.locator('.text-comparison')).toHaveClass(/text-comparison--paired/)
+		await expect(page.locator('.text-comparison__document--after [data-comparison-change][aria-current="true"]')).toBeVisible()
+		await expect.poll(() => afterScroller.evaluate(({ scrollTop }) => scrollTop)).toBeGreaterThan(0)
+	})
+
+	test('AUD-13: audited bidi and control characters render only as visible inert tokens', async ({ comparison, page }) => {
+		const controls = '\u061C\u00AD\u200E\u200F\u0085\u2028\u2029'
+		await comparison.mount({ before: `old${controls}`, after: 'new\n' })
+		await page.getByRole('tab', { name: 'Markdown source' }).click()
+
+		const source = page.locator('.text-source-comparison')
+		for (const token of ['ALM', 'SHY', 'LRM', 'RLM', 'NEL', 'LS', 'PS']) {
+			await expect(source).toContainText(token)
+		}
+		const text = await source.textContent()
+		for (const control of controls) {
+			expect(text).not.toContain(control)
+		}
+	})
+
+	test('AUD-14: high-cardinality Changes, Documents, and Source stay within explicit budgets', { tag: '@memory' }, async ({ comparison, page }, testInfo) => {
+		test.setTimeout(180_000)
+		expect(testInfo.project.name).toBe('comparison-chromium-memory')
+		const cdp = await page.context().newCDPSession(page)
+		await cdp.send('Performance.enable')
+		const heapBeforeBytes = await readChromiumHeap(cdp)
+		const before = Array.from({ length: HIGH_CARDINALITY_CHANGES }, (_, index) => `# Removed section ${index}`).join('\n')
+		const measurement = await comparison.mount({ before, after: '' })
+
+		await expect(page.locator('[data-comparison-select]')).toHaveCount(80)
+		const changesDomCount = await page.locator('.text-comparison__changes *').count()
+		expect(changesDomCount).toBeLessThanOrEqual(1_500)
+
+		const documentsStarted = await page.evaluate(() => performance.now())
+		await page.getByRole('tab', { name: 'Full documents' }).click()
+		await expect(page.locator('.text-comparison__document--before h1')).toHaveCount(HIGH_CARDINALITY_CHANGES)
+		const documentsMilliseconds = await page.evaluate((started) => performance.now() - started, documentsStarted)
+		const documentsDomCount = await page.locator('.text-comparison__documents *').count()
+		expect(documentsDomCount).toBeLessThanOrEqual(20_000)
+
+		const sourceStarted = await page.evaluate(() => performance.now())
+		await page.getByRole('tab', { name: 'Markdown source' }).click()
+		const source = page.locator('[data-comparison-source-fallback]')
+		await expect(source).toBeVisible()
+		const sourceMilliseconds = await page.evaluate((started) => performance.now() - started, sourceStarted)
+		const sourceDomCount = await source.locator('*').count()
+		const sourceCharacters = await source.evaluate((element) => element.textContent?.length ?? 0)
+		expect(sourceDomCount).toBeLessThanOrEqual(50)
+		expect(sourceCharacters).toBeLessThanOrEqual(2_000_000)
+
+		const heapAfterModes = await readChromiumHeap(cdp)
+		const heapDeltaBytes = heapAfterModes - heapBeforeBytes
+		expect(heapDeltaBytes).toBeLessThan(MAXIMUM_HIGH_CARDINALITY_HEAP_DELTA)
+		await testInfo.attach('high-cardinality-metrics.json', {
+			body: Buffer.from(JSON.stringify({ changesDomCount, documentsDomCount, documentsMilliseconds, heapAfterModes, heapBeforeBytes, heapDeltaBytes, memoryMetric: 'chromium-cdp/Performance.JSHeapUsedSize', mountMilliseconds: measurement.durationMilliseconds, sourceCharacters, sourceDomCount, sourceMilliseconds }, null, 2)),
+			contentType: 'application/json',
+		})
+	})
+
+	test('AUD-18: read-only image action is named, focusable, rendered, and operable with Enter', async ({ comparison, page }) => {
+		await comparison.mount({ before: `![Before logo](${CORE_LOGO})`, after: `![After logo](${CORE_LOGO})` })
+		await page.locator('[data-comparison-select]').first().click()
+		const action = page.getByRole('button', { name: 'Open image Before logo' })
+
+		await expect(action.locator('img')).toBeVisible()
+		await action.focus()
+		await expect(action).toBeFocused()
+		await action.press('Enter')
+		await expect(page.getByRole('dialog')).toBeVisible()
+	})
+
+	test('AUD-18: read-only attachment action retains its preview and operates with Space', async ({ comparison, page }) => {
+		const attachmentPath = '/Documents/document.pdf'
+		await page.route('**/apps/text/attachments', async (route) => route.fulfill({
+			json: [{ davPath: attachmentPath, fullUrl: '/document.pdf', isImage: false, metadata: null, mimetype: 'application/pdf', name: 'document.pdf', previewUrl: CORE_LOGO, size: 100 }],
+		}))
+		await page.evaluate(() => {
+			sessionStorage.removeItem('attachment-viewer-path')
+			Object.assign(window.OCA, {
+				Viewer: {
+					file: null,
+					mimetypes: ['application/pdf'],
+					open: ({ path }: { path: string }) => sessionStorage.setItem('attachment-viewer-path', path),
+				},
+			})
+		})
+		await comparison.mount({ before: '![Before document](.attachments.123/document.pdf)', after: '![After document](.attachments.123/document.pdf)', fileId: 123 })
+		await page.locator('[data-comparison-select]').first().click()
+		const action = page.getByRole('button', { name: 'Open attachment Before document' })
+
+		await expect(action.locator('img')).toBeVisible()
+		await action.focus()
+		await expect(action).toBeFocused()
+		await action.press('Space')
+		await expect.poll(() => page.evaluate(() => sessionStorage.getItem('attachment-viewer-path'))).toBe(attachmentPath)
+	})
+
+	test('AUD-21: a rejected loaded callback settles once and keeps the comparison', async ({ comparison, page }) => {
+		const measurement = await comparison.mount({ before: 'Before callback.', after: 'After callback.', rejectLoaded: true })
+
+		expect(measurement.loadedCallbackCalls).toBe(1)
+		await expect(page.locator('.text-comparison')).toBeVisible()
+		await expect(page.locator('[data-comparison-source-fallback]')).toHaveCount(0)
+		await expect(page.locator('[data-comparison-select]')).toHaveCount(1)
+		await expect(page.locator('.ProseMirror')).toHaveCount(0)
+	})
+
+	test('AUD-22: complete Source fallback responds to host width instead of viewport width', async ({ comparison, page }) => {
+		const oversized = Array.from({ length: 6501 }, (_, index) => `line ${index}`).join('\n')
+		await page.setViewportSize({ width: 1280, height: 800 })
+
+		for (const [width, columns] of [[620, 1], [900, 2]] as const) {
+			await comparison.mount({ before: oversized, after: `${oversized}\nchanged`, width })
+			const documents = page.locator('.text-source-fallback__documents')
+			await expect(documents).toBeVisible()
+			const tracks = await documents.evaluate((element) => getComputedStyle(element).gridTemplateColumns.split(' ').length)
+			expect(tracks).toBe(columns)
+			await comparison.destroy()
+		}
+	})
+
+	test('oversized source lines fall back without blocking the page', async ({ comparison, page }) => {
+		const before = `# Oversized source fallback\n\n\`\`\`\n${'\t'.repeat(200_000)}😀\n\`\`\``
+		const after = `${before}\n\ncurrent marker`
+		await comparison.mount({ before, after })
+		await expect(page.locator('[data-comparison-source-fallback]')).toBeVisible()
+		await expect(page.getByText('Source preview was truncated to the display limit.')).toBeVisible()
+	})
+
+	test('AUD-23: Source rows and navigation retain deliberate geometry', async ({ comparison, page }) => {
+		const middle = Array.from({ length: 10 }, (_, index) => `stable ${index}`).join('\n')
+		await comparison.mount({ before: `stable first\r\nold value  \r\n${middle}\r\nold tail`, after: `stable first\nnew value \n${middle}\nnew tail\n` })
+		await page.getByRole('tab', { name: 'Markdown source' }).click()
+
+		const source = page.locator('.text-source-comparison')
+		const changed = source.locator('[data-source-operation="removed"]').first()
+		const unchanged = source.locator('.text-source-comparison__line').filter({ hasText: 'stable first' }).first()
+		const changedGeometry = await changed.evaluate((element) => [...element.children].map((child) => {
+			const rect = child.getBoundingClientRect()
+			return { left: rect.left, top: rect.top }
+		}))
+		const unchangedGeometry = await unchanged.evaluate((element) => [...element.children].map((child) => child.getBoundingClientRect().left))
+		expect(changedGeometry).toHaveLength(5)
+		expect(new Set(changedGeometry.map(({ top }) => Math.round(top))).size).toBe(1)
+		expect(Math.round(changedGeometry[1]!.left)).toBe(Math.round(unchangedGeometry[0]!))
+		expect(Math.round(changedGeometry[2]!.left)).toBe(Math.round(unchangedGeometry[1]!))
+
+		const navigation = source.locator('.text-source-comparison__navigation')
+		const navigationCenters = await navigation.evaluate((element) => [...element.children].map((child) => {
+			const rect = child.getBoundingClientRect()
+			return rect.top + rect.height / 2
+		}))
+		expect(Math.max(...navigationCenters) - Math.min(...navigationCenters)).toBeLessThan(4)
+		for (const button of await navigation.getByRole('button').all()) {
+			await expect(button).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+		}
+		const sourceFontSize = await source.evaluate((element) => getComputedStyle(element).fontSize)
+		await expect(source.locator('[data-source-side="before"]')).toHaveCSS('font-size', sourceFontSize)
+		await expect(source.locator('[data-source-side="after"]')).toHaveCSS('font-size', sourceFontSize)
+		await expect(source.locator('[data-source-hunk]').first().getByRole('button')).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+		await navigation.getByRole('button', { name: 'Next' }).click()
+		await expect(navigation).toContainText('Source change 2 of 2')
+
+		await comparison.destroy()
+		await comparison.mount({ before: `old value  \r\n${middle}\r\nold tail`, after: `new value \n${middle}\nnew tail\n`, width: 390 })
+		await page.getByRole('tab', { name: 'Markdown source' }).click()
+		const narrowNavigation = source.locator('.text-source-comparison__navigation')
+		const narrowTops = await narrowNavigation.evaluate((element) => [...element.children].map((child) => Math.round(child.getBoundingClientRect().top)))
+		expect(narrowTops[0]).toBe(narrowTops[2])
+		expect(narrowTops[1]).toBeGreaterThan(narrowTops[0]!)
+		const sourceSideTabs = page.getByRole('tablist', { name: 'Source version to display' })
+		const removedLine = source.locator('[data-source-operation="removed"]').first()
+		const addedLine = source.locator('[data-source-operation="added"]').first()
+		await expect(removedLine).toBeVisible()
+		await expect(addedLine).toBeHidden()
+		await sourceSideTabs.getByRole('tab', { name: 'After' }).click()
+		await expect(removedLine).toBeHidden()
+		await expect(addedLine).toBeVisible()
+	})
+
+	test('AUD-24: Full document headings align in paired and single layouts', async ({ comparison, page }) => {
+		for (const width of [1100, 620]) {
+			await comparison.mount({ before: 'Old document.', after: 'New document.', width })
+			await page.getByRole('tab', { name: 'Full documents' }).click()
+			const sideTabs = page.getByRole('tablist', { name: 'Version to display' })
+			if (width === 1100) {
+				await expect(page.locator('.text-comparison__document--before')).toBeVisible()
+				await expect(page.locator('.text-comparison__document--after')).toBeVisible()
+				for (const button of await page.getByLabel('Change navigation').getByRole('button').all()) {
+					await expect(button).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+				}
+			}
+			for (const side of ['before', 'after']) {
+				if (width === 620) {
+					await sideTabs.getByRole('tab', { name: side === 'before' ? 'Before' : 'After' }).click()
+				}
+				const article = page.locator(`.text-comparison__document--${side}`)
+				await expect(article).toBeVisible()
+				const header = page.locator(`.text-comparison__document--${side} > header`)
+				const headings = header.locator('.document-heading > span, .document-heading > h2, .document-legend')
+				await expect(headings).toHaveCount(3)
+				await expect(header.getByRole('heading', { level: 2 })).toHaveCSS(
+					'font-size',
+					await article.evaluate((element) => getComputedStyle(element).fontSize),
+				)
+				const rectangles = await headings.evaluateAll((elements) => elements.map((element) => {
+					const rect = element.getBoundingClientRect()
+					return { width: rect.width, height: rect.height, center: rect.top + rect.height / 2 }
+				}))
+				expect(rectangles.every(({ width, height }) => width > 0 && height > 0)).toBe(true)
+				const centers = rectangles.map(({ center }) => center)
+				expect(Math.max(...centers) - Math.min(...centers)).toBeLessThan(4)
+			}
+			await comparison.destroy()
+		}
+	})
+})
+
+async function assertFormattingFilterMove(comparison: ComparisonHarness, page: Page, contents: ComparisonContents, direction: 'next' | 'previous') {
+	await comparison.mount(contents)
+	const rows = page.locator('[data-comparison-select]')
+	const formatting = rows.filter({ hasText: /Bold changed/ })
+	await expect(formatting).toHaveCount(1)
+	const ids = await rows.evaluateAll((elements) => elements.map((element) => element.getAttribute('data-comparison-select') ?? ''))
+	const formattingId = await formatting.getAttribute('data-comparison-select')
+	const formattingIndex = ids.indexOf(formattingId ?? '')
+	const expectedIndex = direction === 'next' ? formattingIndex + 1 : formattingIndex - 1
+	await formatting.click()
+	await page.getByRole('checkbox', { name: 'Hide formatting-only changes' }).check()
+	const current = page.locator('[data-comparison-select][aria-current="true"]')
+	await expect(current).toHaveCount(1)
+	await expect(current).toHaveAttribute('data-comparison-select', ids[expectedIndex]!)
+}
+
+async function mountMaximumSquare(comparison: ComparisonHarness) {
+	const maximumBefore = axis('maximum', MAXIMUM_SQUARE_AXIS, 'before')
+	const maximumAfter = axis('maximum', MAXIMUM_SQUARE_AXIS, 'after')
+	return comparison.mount(maximumSquareFixture(maximumBefore, maximumAfter))
+}
+
+async function attachMeasurement(testInfo: TestInfo, fixture: string, measurement: ComparisonMeasurement, work?: Record<string, number>) {
+	await testInfo.attach(`${fixture}-measurement.json`, {
+		body: Buffer.from(JSON.stringify({ measurement, work }, null, 2)),
+		contentType: 'application/json',
+	})
+}
+
+async function readChromiumHeap(cdp: CDPSession) {
+	const { metrics } = await cdp.send('Performance.getMetrics')
+	const heap = metrics.find(({ name }) => name === 'JSHeapUsedSize')?.value
+	if (typeof heap !== 'number' || !Number.isFinite(heap)) {
+		throw new Error('AUD-14 requires Chromium CDP Performance.JSHeapUsedSize memory evidence')
+	}
+	return heap
+}
+
+function nearLineFloorFixture(): ComparisonContents {
+	const before = Array.from({ length: 6490 }, (_, index) => `# fixed floor ${index}`).join('\n')
+	const after = before.replace('# fixed floor 3245', '# changed floor 3245')
+	return { before, after }
+}
+
+function maximumSquareFixture(maximumBefore: readonly string[], maximumAfter: readonly string[]): ComparisonContents {
+	const before = ['# exact start', ...maximumBefore, '# exact end'].join('\n\n')
+	const after = ['# exact start', ...maximumAfter, '# exact end'].join('\n\n')
+	return { before, after }
+}
+
+function tableLedgerFixture(): ComparisonContents {
+	return {
+		before: `${ledgerTable(200, 12, 'a')}\n\n# exact table separator\n\n${ledgerTable(10, 12, 'c')}`,
+		after: `${ledgerTable(200, 12, 'b')}\n\n# exact table separator\n\n${ledgerTable(10, 12, 'd')}`,
+	}
+}
+
+function ledgerTable(columns: number, textLength: number, suffix: string) {
+	const cell = (column: number) => {
+		const prefix = `000-${column.toString().padStart(3, '0')}-`
+		return `${prefix}${suffix.repeat(textLength - prefix.length)}`
+	}
+	const header = Array.from({ length: columns }, (_value, column) => ` ${cell(column)} `).join('|')
+	const divider = Array.from({ length: columns }, () => ' --- ').join('|')
+	return `|${header}|\n|${divider}|`
+}
+
+function axis(prefix: string, count: number, suffix: string) {
+	const axisId = prefix.match(/\d+/)?.[0] ?? prefix[0]
+	return Array.from({ length: count }, (_, index) => `${axisId}:${index.toString(36)}:${suffix[0]}`)
+}

--- a/playwright/comparison/fixtures.ts
+++ b/playwright/comparison/fixtures.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { test as base } from '@playwright/test'
+import { ComparisonHarness } from './support/comparisonHarness.ts'
+
+interface ComparisonFixtures {
+	comparison: ComparisonHarness
+}
+
+export const test = base.extend<ComparisonFixtures>({
+	comparison: async ({ page }, use, testInfo) => {
+		const comparison = new ComparisonHarness(page)
+		try {
+			await comparison.open()
+			await use(comparison)
+		} finally {
+			await comparison.attachEvidence(testInfo)
+			comparison.assertNoUnexpectedFailures()
+		}
+	},
+})
+
+export { expect } from '@playwright/test'

--- a/playwright/comparison/support/comparisonHarness.ts
+++ b/playwright/comparison/support/comparisonHarness.ts
@@ -1,0 +1,335 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ConsoleMessage, Page, Request, Response, TestInfo } from '@playwright/test'
+
+import AxeBuilder from '@axe-core/playwright'
+import { expect } from '@playwright/test'
+
+const HARNESS_PATH = '/index.php/login'
+
+export interface ComparisonContents {
+	before: string
+	after: string
+	fileId?: number
+	rejectLoaded?: boolean
+	width?: number
+	height?: number
+}
+
+export interface ComparisonMeasurement {
+	durationMilliseconds: number
+	loadedCallbackCalls: number
+	rootCount: number
+	proseMirrorCount: number
+}
+
+interface RuntimeFailure {
+	type: 'console' | 'pageerror' | 'requestfailed' | 'response'
+	message: string
+	url?: string
+	status?: number
+}
+
+interface ObserverCounts {
+	resize: number
+	mutation: number
+}
+
+export class ComparisonHarness {
+	readonly page: Page
+	readonly failures: RuntimeFailure[] = []
+	readonly consoleMessages: Array<{ type: string, text: string }> = []
+	readonly network: Array<{ method: string, status?: number, url: string, failure?: string }> = []
+	#allowedFailures: RegExp[] = []
+
+	constructor(page: Page) {
+		this.page = page
+		page.on('console', (message) => this.#captureConsole(message))
+		page.on('pageerror', (error) => this.failures.push({ type: 'pageerror', message: error.message }))
+		page.on('requestfailed', (request) => this.#captureFailedRequest(request))
+		page.on('response', (response) => this.#captureResponse(response))
+	}
+
+	async open() {
+		await this.page.route(`**${HARNESS_PATH}`, async (route) => {
+			const response = await route.fetch()
+			const headers = response.headers()
+			const policy = headers['content-security-policy'] ?? ''
+			if (policy && !policy.includes('worker-src')) {
+				headers['content-security-policy'] = `${policy}; worker-src 'self'`
+			}
+			await route.fulfill({ response, headers })
+		})
+		await this.page.goto(HARNESS_PATH, { waitUntil: 'domcontentloaded' })
+		await this.page.waitForFunction(() => Boolean(window.OC?.filePath && window.OCA))
+		const textRoot = (await this.page.evaluate(() => (
+			window as typeof window & { OC: { appswebroots: Record<string, string> } }
+		).OC.appswebroots.text)).replace(/\/$/, '')
+		const editorBundle = `${textRoot}/js/text-editor.mjs`
+		await this.page.evaluate(async ({ bundle, root }) => {
+			const entryUrl = new URL(`${root}/css/text-editor.css`, location.href)
+			const entryResponse = await fetch(entryUrl)
+			if (!entryResponse.ok) {
+				throw new Error('Could not load the Text editor stylesheet entry')
+			}
+			const imports = [...(await entryResponse.text()).matchAll(/@import\s+['"]([^'"]+)['"]/g)]
+			await Promise.all(imports.map(([, path]) => new Promise<void>((resolve, reject) => {
+				const stylesheet = document.createElement('link')
+				stylesheet.rel = 'stylesheet'
+				stylesheet.href = new URL(path, entryUrl).href
+				stylesheet.addEventListener('load', () => resolve(), { once: true })
+				stylesheet.addEventListener('error', () => reject(new Error('Could not load a Text editor stylesheet chunk')), { once: true })
+				document.head.append(stylesheet)
+			})))
+			await import(bundle)
+		}, { bundle: editorBundle, root: textRoot })
+		await expect.poll(() => this.page.evaluate(() => typeof window.OCA?.Text?.createMarkdownContentComparison), {
+			message: `The mounted production bundle ${editorBundle} must expose the public comparison factory`,
+		}).toBe('function')
+		await this.page.evaluate((root) => {
+			const appRoot = new URL(`${root}/`, location.href).href
+			document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')
+				.forEach((link) => !link.href.startsWith(appRoot) && link.remove())
+			const style = document.createElement('style')
+			style.textContent = `
+				html, body {
+					--color-element-info: #007aa3;
+					--color-error: #f0b5b5;
+					--color-error-hover: #fbeaea;
+					--color-main-background: #fff;
+					--color-main-text: #222;
+					--color-primary-element: #00679e;
+					--color-primary-element-light: #e5f2f8;
+					--color-success: #b5dfb8;
+					--color-success-hover: #eaf5eb;
+					--color-text-maxcontrast: #4a4a4a;
+					--color-warning: #8a6116;
+					block-size: 100%;
+					margin: 0;
+				}
+				body { background: var(--color-main-background); color: var(--color-main-text); }
+				#text-comparison-harness {
+					box-sizing: border-box;
+					color: var(--color-main-text);
+					margin: 0 auto;
+					overflow: hidden;
+				}
+			`
+			const host = document.createElement('main')
+			host.id = 'text-comparison-harness'
+			document.head.append(style)
+			document.body.removeAttribute('id')
+			document.body.removeAttribute('class')
+			document.body.replaceChildren(host)
+
+			const state = {
+				instances: [] as Array<{ destroy: () => void }>,
+				resizeObservers: new Set<ResizeObserver>(),
+				mutationObservers: new Set<MutationObserver>(),
+			}
+			Object.assign(window, { __textComparisonAcceptance: state })
+
+			if (typeof ResizeObserver !== 'undefined') {
+				const originalObserve = ResizeObserver.prototype.observe
+				const originalDisconnect = ResizeObserver.prototype.disconnect
+				ResizeObserver.prototype.observe = function(target, options) {
+					state.resizeObservers.add(this)
+					return originalObserve.call(this, target, options)
+				}
+				ResizeObserver.prototype.disconnect = function() {
+					state.resizeObservers.delete(this)
+					return originalDisconnect.call(this)
+				}
+			}
+			if (typeof MutationObserver !== 'undefined') {
+				const originalObserve = MutationObserver.prototype.observe
+				const originalDisconnect = MutationObserver.prototype.disconnect
+				MutationObserver.prototype.observe = function(target, options) {
+					state.mutationObservers.add(this)
+					return originalObserve.call(this, target, options)
+				}
+				MutationObserver.prototype.disconnect = function() {
+					state.mutationObservers.delete(this)
+					return originalDisconnect.call(this)
+				}
+			}
+		}, textRoot)
+		await this.page.waitForLoadState('networkidle')
+		await this.page.waitForTimeout(500)
+		this.resetCapture()
+	}
+
+	resetCapture() {
+		this.failures.splice(0)
+		this.consoleMessages.splice(0)
+		this.network.splice(0)
+		this.#allowedFailures = []
+	}
+
+	allowFailure(pattern: RegExp) {
+		this.#allowedFailures.push(pattern)
+	}
+
+	async mount(contents: ComparisonContents): Promise<ComparisonMeasurement> {
+		if (contents.rejectLoaded) {
+			this.allowFailure(/acceptance forced loaded callback failure/)
+		}
+		return this.page.evaluate(async ({ before, after, fileId, rejectLoaded = false, width = 1100, height = 760 }) => {
+			const state = window.__textComparisonAcceptance
+			const host = document.querySelector<HTMLElement>('#text-comparison-harness')!
+			host.style.inlineSize = `${width}px`
+			host.style.blockSize = `${height}px`
+			const started = performance.now()
+			let loadedCallbackCalls = 0
+			const instance = await window.OCA.Text.createMarkdownContentComparison({
+				afterContent: after,
+				beforeContent: before,
+				el: host,
+				fileId,
+				noLazyImages: true,
+				onLoaded: rejectLoaded
+					? async () => {
+						loadedCallbackCalls++
+						throw new Error('acceptance forced loaded callback failure')
+					}
+					: undefined,
+			})
+			const durationMilliseconds = performance.now() - started
+			state.instances.push(instance)
+			await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+			return {
+				durationMilliseconds,
+				loadedCallbackCalls,
+				rootCount: host.querySelectorAll('.text-comparison-root').length,
+				proseMirrorCount: host.querySelectorAll('.ProseMirror').length,
+			}
+		}, contents)
+	}
+
+	async destroy(times = 2) {
+		await this.page.evaluate((count) => {
+			const state = window.__textComparisonAcceptance
+			for (const instance of state.instances.splice(0)) {
+				for (let index = 0; index < count; index++) {
+					instance.destroy()
+				}
+			}
+		}, times)
+	}
+
+	async observerCounts(): Promise<ObserverCounts> {
+		return this.page.evaluate(() => ({
+			mutation: window.__textComparisonAcceptance.mutationObservers.size,
+			resize: window.__textComparisonAcceptance.resizeObservers.size,
+		}))
+	}
+
+	async forceEditorInitializationFailure() {
+		await this.page.evaluate(() => {
+			const descriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'innerHTML')!
+			Object.defineProperty(Element.prototype, 'innerHTML', {
+				...descriptor,
+				set(value: string) {
+					void value
+					Object.defineProperty(Element.prototype, 'innerHTML', descriptor)
+					throw new Error('acceptance forced editor initialization failure')
+				},
+			})
+		})
+		this.allowFailure(/acceptance forced editor initialization failure/)
+	}
+
+	async forceProjectionFailure() {
+		await this.page.evaluate(() => {
+			const original = Element.prototype.setAttribute
+			Element.prototype.setAttribute = function(name, value) {
+				if (name === 'data-comparison-change') {
+					Element.prototype.setAttribute = original
+					throw new Error('acceptance forced projection failure')
+				}
+				return original.call(this, name, value)
+			}
+		})
+		this.allowFailure(/acceptance forced projection failure/)
+	}
+
+	async assertAccessibleComparison() {
+		const violations = await this.page.locator('#text-comparison-harness').evaluate((root) => {
+			const visible = (element: HTMLElement) => Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+			const violations: string[] = []
+			const ids = [...root.querySelectorAll<HTMLElement>('[id]')].map(({ id }) => id)
+			for (const id of new Set(ids)) {
+				if (ids.filter((candidate) => candidate === id).length > 1) {
+					violations.push(`duplicate id: ${id}`)
+				}
+			}
+			for (const button of root.querySelectorAll<HTMLButtonElement>('button')) {
+				if (visible(button) && !(button.getAttribute('aria-label') || button.textContent?.trim() || button.title)) {
+					violations.push('visible button has no accessible name')
+				}
+			}
+			for (const tablist of root.querySelectorAll<HTMLElement>('[role="tablist"]')) {
+				const selected = [...tablist.querySelectorAll<HTMLElement>('[role="tab"]')].filter((tab) => tab.getAttribute('aria-selected') === 'true')
+				if (visible(tablist) && selected.length !== 1) {
+					violations.push('visible tablist must have exactly one selected tab')
+				}
+			}
+			const liveRegion = root.querySelector('[aria-live="polite"][aria-atomic="true"]')
+			if (!liveRegion) {
+				violations.push('comparison has no polite atomic live region')
+			}
+			return violations
+		})
+		expect(violations).toEqual([])
+		const axe = await new AxeBuilder({ page: this.page })
+			.include('#text-comparison-harness')
+			.analyze()
+		expect(axe.violations, 'axe accessibility violations').toEqual([])
+	}
+
+	async attachEvidence(testInfo: TestInfo) {
+		await testInfo.attach('comparison-console-network.json', {
+			body: Buffer.from(JSON.stringify({ console: this.consoleMessages, failures: this.failures, network: this.network }, null, 2)),
+			contentType: 'application/json',
+		})
+	}
+
+	assertNoUnexpectedFailures() {
+		const unexpected = this.failures.filter(({ message }) => !this.#allowedFailures.some((pattern) => pattern.test(message)))
+		expect(unexpected, 'unexpected browser console, page, or network failures').toEqual([])
+	}
+
+	#captureConsole(message: ConsoleMessage) {
+		this.consoleMessages.push({ type: message.type(), text: message.text() })
+		if (message.type() === 'error') {
+			this.failures.push({ type: 'console', message: message.text() })
+		}
+	}
+
+	#captureFailedRequest(request: Request) {
+		const failure = request.failure()?.errorText ?? 'request failed'
+		this.network.push({ method: request.method(), url: request.url(), failure })
+		this.failures.push({ type: 'requestfailed', message: failure, url: request.url() })
+	}
+
+	#captureResponse(response: Response) {
+		this.network.push({ method: response.request().method(), status: response.status(), url: response.url() })
+		if (response.status() >= 400) {
+			this.failures.push({ type: 'response', message: `HTTP ${response.status()}`, status: response.status(), url: response.url() })
+		}
+	}
+}
+
+declare global {
+	interface Window {
+		OC?: { filePath?: (...parts: string[]) => string }
+		__textComparisonAcceptance: {
+			instances: Array<{ destroy: () => void }>
+			resizeObservers: Set<ResizeObserver>
+			mutationObservers: Set<MutationObserver>
+		}
+	}
+}

--- a/src/comparison/comparisonAlignment.ts
+++ b/src/comparison/comparisonAlignment.ts
@@ -1,0 +1,392 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonCoarseReason as CoarseReason } from './markdownComparisonTypes.ts'
+
+export const DEFAULT_COMPARISON_CELL_LEDGER = 40_000
+export const DEFAULT_COMPARISON_TOKEN_LEDGER = 84_000_000
+
+export interface ComparisonWorkLedger {
+	remainingCells: number
+	remainingTokenComparisons: number
+}
+
+export interface ComparisonAlignmentOptions<T> {
+	work: ComparisonWorkLedger
+	fingerprint: (item: T) => string
+	profile: (item: T) => readonly string[]
+	compatible: (before: T, after: T) => boolean
+}
+
+export interface ComparisonAlignmentStep {
+	before: number | null
+	after: number | null
+}
+
+export interface ComparisonCoarseAlignmentRegion {
+	before: { from: number, to: number }
+	after: { from: number, to: number }
+	coarseReason: CoarseReason
+}
+
+export type ComparisonAlignmentRegion = ComparisonAlignmentStep | ComparisonCoarseAlignmentRegion
+
+export interface ExactComparisonPair {
+	before: number
+	after: number
+}
+type Options<T> = ComparisonAlignmentOptions<T>
+type Step = ComparisonAlignmentStep
+type Region = ComparisonAlignmentRegion
+type Pair = ExactComparisonPair
+type Ledger = ComparisonWorkLedger
+
+export function createComparisonWorkLedger(): Ledger {
+	return {
+		remainingCells: DEFAULT_COMPARISON_CELL_LEDGER,
+		remainingTokenComparisons: DEFAULT_COMPARISON_TOKEN_LEDGER,
+	}
+}
+
+export function forcedIncreasingPairs(pairs: readonly Pair[]): readonly Pair[] {
+	if (pairs.length < 2) {
+		return pairs
+	}
+	const ordered = pairs.toSorted((a, b) => a.before - b.before || a.after - b.after)
+	const left = increasingSubsequence(ordered.map(({ after }) => after)).lengths
+	const right = increasingSubsequence(ordered.toReversed().map(({ after }) => -after)).lengths.toReversed()
+	let maximum = 0
+	for (const length of left) {
+		if (length > maximum) {
+			maximum = length
+		}
+	}
+	const candidatesPerLevel = new Uint32Array(maximum + 1)
+	for (let index = 0; index < ordered.length; index++) {
+		if (left[index]! + right[index]! - 1 === maximum) {
+			candidatesPerLevel[left[index]!]++
+		}
+	}
+	return ordered.filter((_pair, index) => left[index]! + right[index]! - 1 === maximum
+		&& candidatesPerLevel[left[index]!] === 1)
+}
+
+export function increasingSubsequence(values: readonly number[]) {
+	const tails: number[] = []
+	const previous = new Int32Array(values.length).fill(-1)
+	const lengths = values.map((value, candidate) => {
+		let low = 0
+		let high = tails.length
+		while (low < high) {
+			const middle = (low + high) >>> 1
+			if (values[tails[middle]!]! < value) {
+				low = middle + 1
+			} else {
+				high = middle
+			}
+		}
+		if (low > 0) {
+			previous[candidate] = tails[low - 1]!
+		}
+		tails[low] = candidate
+		return low + 1
+	})
+	const indices: number[] = []
+	for (let index = tails.at(-1) ?? -1; index >= 0; index = previous[index]!) {
+		indices.push(index)
+	}
+	return { lengths, indices: indices.reverse() }
+}
+
+export function alignComparisonAxis<T>(before: readonly T[], after: readonly T[], options: Options<T>): readonly Region[] {
+	const beforeKeys = before.map(options.fingerprint)
+	const afterKeys = after.map(options.fingerprint)
+	return equalAxis(beforeKeys, afterKeys)
+		?? planAxis(before, after, beforeKeys, afterKeys, options, uniqueExactPairs(beforeKeys, afterKeys), true)
+}
+
+export function alignComparisonColumns<T>(before: readonly T[], after: readonly T[], options: Options<T>): readonly Region[] {
+	const beforeKeys = before.map(options.fingerprint)
+	const afterKeys = after.map(options.fingerprint)
+	return equalAxis(beforeKeys, afterKeys)
+		?? planAxis(before, after, beforeKeys, afterKeys, options, rankedExactPairs(beforeKeys, afterKeys), false)
+}
+
+function equalAxis(beforeKeys: readonly string[], afterKeys: readonly string[]) {
+	if (beforeKeys.length !== afterKeys.length
+		|| beforeKeys.some((key, index) => key !== afterKeys[index])) {
+		return null
+	}
+	return beforeKeys.map((_key, index) => ({ before: index, after: index }))
+}
+
+function planAxis<T>(before: readonly T[], after: readonly T[], beforeKeys: readonly string[], afterKeys: readonly string[], options: Options<T>, exactPairs: readonly Pair[], trimEdges: boolean): readonly Region[] {
+	const regions: Region[] = []
+	let beforeStart = 0
+	let afterStart = 0
+	for (const anchor of [...forcedIncreasingPairs(exactPairs), { before: before.length, after: after.length }]) {
+		let beforeEnd = anchor.before
+		let afterEnd = anchor.after
+		const suffix: Step[] = []
+		if (trimEdges) {
+			while (beforeStart < beforeEnd && afterStart < afterEnd
+				&& beforeKeys[beforeStart] === afterKeys[afterStart]) {
+				regions.push({ before: beforeStart++, after: afterStart++ })
+			}
+			while (beforeStart < beforeEnd && afterStart < afterEnd
+				&& beforeKeys[beforeEnd - 1] === afterKeys[afterEnd - 1]) {
+				suffix.unshift({ before: --beforeEnd, after: --afterEnd })
+			}
+		}
+		if (beforeEnd - beforeStart === 1 && afterEnd - afterStart === 1) {
+			if (options.compatible(before[beforeStart]!, after[afterStart]!)) {
+				regions.push({ before: beforeStart, after: afterStart })
+			} else {
+				regions.push({ before: beforeStart, after: null })
+				regions.push({ before: null, after: afterStart })
+			}
+			beforeStart++
+			afterStart++
+		} else if (beforeStart < beforeEnd && afterStart < afterEnd) {
+			const solved = solveWeightedGap(
+				before.slice(beforeStart, beforeEnd),
+				after.slice(afterStart, afterEnd),
+				options,
+			)
+			if ('coarseReason' in solved) {
+				regions.push({
+					before: { from: beforeStart, to: beforeEnd },
+					after: { from: afterStart, to: afterEnd },
+					coarseReason: solved.coarseReason,
+				})
+			} else {
+				regions.push(...solved.steps.map((step) => ({
+					before: step.before === null ? null : step.before + beforeStart,
+					after: step.after === null ? null : step.after + afterStart,
+				})))
+			}
+			beforeStart = beforeEnd
+			afterStart = afterEnd
+		}
+		for (let index = beforeStart; index < beforeEnd; index++) {
+			regions.push({ before: index, after: null })
+		}
+		for (let index = afterStart; index < afterEnd; index++) {
+			regions.push({ before: null, after: index })
+		}
+		regions.push(...suffix)
+		if (anchor.before < before.length) {
+			regions.push(anchor)
+		}
+		beforeStart = anchor.before + 1
+		afterStart = anchor.after + 1
+	}
+	return regions
+}
+
+function uniqueExactPairs(beforeKeys: readonly string[], afterKeys: readonly string[]) {
+	const beforeIndices = groupIndices(beforeKeys)
+	const afterIndices = groupIndices(afterKeys)
+	return beforeKeys.flatMap((key, index) => (
+		beforeIndices.get(key)!.length === 1 && afterIndices.get(key)?.length === 1
+			? [{ before: index, after: afterIndices.get(key)![0]! }]
+			: []
+	))
+}
+
+function uniqueCompatiblePairs<T>(before: readonly T[], after: readonly T[], compatible: (before: T, after: T) => boolean) {
+	const afterMatches = before.map((item) => after
+		.map((candidate, index) => compatible(item, candidate) ? index : -1)
+		.filter((index) => index >= 0))
+	const beforeMatches = after.map((item) => before
+		.map((candidate, index) => compatible(candidate, item) ? index : -1)
+		.filter((index) => index >= 0))
+	return afterMatches.flatMap((matches, beforeIndex) => {
+		const afterIndex = matches[0]
+		return matches.length === 1 && beforeMatches[afterIndex!]?.length === 1
+			? [{ before: beforeIndex, after: afterIndex! }]
+			: []
+	})
+}
+
+function rankedExactPairs(beforeKeys: readonly string[], afterKeys: readonly string[]) {
+	const beforeIndices = groupIndices(beforeKeys)
+	const afterIndices = groupIndices(afterKeys)
+	return [...beforeIndices].flatMap(([key, indices]) => {
+		const matches = afterIndices.get(key)
+		return matches?.length === indices.length
+			? indices.map((before, rank) => ({ before, after: matches[rank]! }))
+			: []
+	})
+}
+
+function groupIndices(keys: readonly string[]) {
+	const grouped = new Map<string, number[]>()
+	for (const [index, key] of keys.entries()) {
+		const indices = grouped.get(key)
+		if (indices) {
+			indices.push(index)
+		} else {
+			grouped.set(key, [index])
+		}
+	}
+	return grouped
+}
+
+interface RationalScore {
+	numerator: bigint
+	denominator: bigint
+}
+
+interface AlignmentState {
+	score: RationalScore
+	signatures: readonly number[]
+}
+
+export function solveWeightedGap<T>(before: readonly T[], after: readonly T[], options: Options<T>): { steps: readonly Step[] } | { coarseReason: CoarseReason } {
+	const cellCharge = before.length * after.length
+	if (cellCharge > options.work.remainingCells) {
+		return { coarseReason: 'comparison-limit' }
+	}
+	const beforeProfiles = before.map(options.profile)
+	const afterProfiles = after.map(options.profile)
+	const tokenCharge = weightedTokenCharge(beforeProfiles, afterProfiles)
+	if (tokenCharge > BigInt(options.work.remainingTokenComparisons)) {
+		return { coarseReason: 'comparison-limit' }
+	}
+	options.work.remainingCells -= cellCharge
+	options.work.remainingTokenComparisons -= Number(tokenCharge)
+	const structuralPairs = uniqueCompatiblePairs(before, after, options.compatible)
+	if (before.length === after.length
+		&& structuralPairs.length === before.length
+		&& structuralPairs.every((pair, index) => pair.before === index && pair.after === index)) {
+		return { steps: alignmentSteps(before.length, after.length, structuralPairs) }
+	}
+
+	const parents = [-1]
+	const beforeOf = [-1]
+	const afterOf = [-1]
+	const zero: AlignmentState = {
+		score: { numerator: 0n, denominator: 1n },
+		signatures: [0],
+	}
+	let previous = Array.from<AlignmentState>({ length: after.length + 1 }).fill(zero)
+	for (let beforeIndex = 1; beforeIndex <= before.length; beforeIndex++) {
+		const current = Array.from<AlignmentState>({ length: after.length + 1 })
+		current[0] = zero
+		for (let afterIndex = 1; afterIndex <= after.length; afterIndex++) {
+			let best = betterState(previous[afterIndex]!, current[afterIndex - 1]!)
+			const beforeItem = before[beforeIndex - 1]!
+			const afterItem = after[afterIndex - 1]!
+			if (options.compatible(beforeItem, afterItem)) {
+				const source = previous[afterIndex - 1]!
+				best = betterState(best, {
+					score: addScores(source.score, pairScore(
+						beforeProfiles[beforeIndex - 1]!,
+						afterProfiles[afterIndex - 1]!,
+						options.fingerprint(beforeItem) === options.fingerprint(afterItem),
+					)),
+					signatures: source.signatures.map((parent) => {
+						parents.push(parent)
+						beforeOf.push(beforeIndex - 1)
+						afterOf.push(afterIndex - 1)
+						return parents.length - 1
+					}),
+				})
+			}
+			current[afterIndex] = best
+		}
+		previous = current
+	}
+
+	const signatures = previous[after.length]!.signatures
+	if (signatures.length > 1) {
+		return { coarseReason: 'ambiguous-attribution' }
+	}
+	const matches: Pair[] = []
+	for (let id = signatures[0]!; id > 0; id = parents[id]!) {
+		matches.push({ before: beforeOf[id]!, after: afterOf[id]! })
+	}
+	return { steps: alignmentSteps(before.length, after.length, matches.reverse()) }
+}
+
+function betterState(a: AlignmentState, b: AlignmentState): AlignmentState {
+	const order = compareScores(a.score, b.score)
+	if (order > 0) {
+		return a
+	}
+	if (order < 0) {
+		return b
+	}
+	return {
+		score: a.score,
+		signatures: [...new Set([...a.signatures, ...b.signatures])].slice(0, 2),
+	}
+}
+
+function weightedTokenCharge(before: readonly (readonly string[])[], after: readonly (readonly string[])[]) {
+	let charge = 0n
+	for (const beforeProfile of before) {
+		for (const afterProfile of after) {
+			charge += BigInt(Math.min(beforeProfile.length, afterProfile.length))
+		}
+	}
+	return charge * 2n
+}
+
+function pairScore(before: readonly string[], after: readonly string[], exact: boolean): RationalScore {
+	if (exact) {
+		return { numerator: 3n, denominator: 1n }
+	}
+	let prefix = 0
+	while (prefix < before.length && prefix < after.length && before[prefix] === after[prefix]) {
+		prefix++
+	}
+	let suffix = 0
+	const maximumSuffix = Math.min(before.length, after.length) - prefix
+	while (suffix < maximumSuffix
+		&& before[before.length - suffix - 1] === after[after.length - suffix - 1]) {
+		suffix++
+	}
+	const denominator = BigInt(Math.max(before.length, after.length, 1))
+	return {
+		numerator: denominator + BigInt(prefix + suffix),
+		denominator,
+	}
+}
+
+function addScores(a: RationalScore, b: RationalScore): RationalScore {
+	return {
+		numerator: a.numerator * b.denominator + b.numerator * a.denominator,
+		denominator: a.denominator * b.denominator,
+	}
+}
+
+function compareScores(a: RationalScore, b: RationalScore) {
+	const difference = a.numerator * b.denominator - b.numerator * a.denominator
+	return difference < 0n ? -1 : difference > 0n ? 1 : 0
+}
+
+function alignmentSteps(beforeCount: number, afterCount: number, matches: readonly Pair[]) {
+	const steps: Step[] = []
+	let beforeIndex = 0
+	let afterIndex = 0
+	for (const match of matches) {
+		while (beforeIndex < match.before) {
+			steps.push({ before: beforeIndex++, after: null })
+		}
+		while (afterIndex < match.after) {
+			steps.push({ before: null, after: afterIndex++ })
+		}
+		steps.push({ before: beforeIndex++, after: afterIndex++ })
+	}
+	while (beforeIndex < beforeCount) {
+		steps.push({ before: beforeIndex++, after: null })
+	}
+	while (afterIndex < afterCount) {
+		steps.push({ before: null, after: afterIndex++ })
+	}
+	return steps
+}

--- a/src/comparison/comparisonDocumentIndex.ts
+++ b/src/comparison/comparisonDocumentIndex.ts
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonRange as Range } from './markdownComparisonTypes.ts'
+
+export interface LocatedComparisonNode {
+	node: Node
+	path: readonly number[]
+	index: number
+	from: number
+	to: number
+	parent: Location | null
+	children: readonly Location[]
+}
+type Location = LocatedComparisonNode
+
+export interface ComparisonDocumentIndex {
+	children: readonly Location[]
+	nodeAtPath: (path: readonly number[]) => Location
+}
+
+interface Mutable extends Omit<Location, 'children'> {
+	children: Mutable[]
+}
+
+const minimalRootsCache = new WeakMap<readonly Location[], readonly Location[]>()
+
+export function createComparisonDocumentIndex(doc: Node): ComparisonDocumentIndex {
+	const byPath = new Map<string, Mutable>()
+	const locateChildren = (
+		parentNode: Node,
+		parentLocation: Mutable | null,
+		parentPath: readonly number[],
+		contentFrom: number,
+	) => {
+		const children: Mutable[] = []
+		parentNode.forEach((node, offset, index) => {
+			const from = contentFrom + offset
+			const path = [...parentPath, index]
+			const location: Mutable = {
+				node,
+				path,
+				index,
+				from,
+				to: from + node.nodeSize,
+				parent: parentLocation,
+				children: [],
+			}
+			children.push(location)
+			byPath.set(pathKey(path), location)
+			if (!node.isLeaf) {
+				location.children = locateChildren(node, location, path, from + 1)
+			}
+		})
+		return children
+	}
+	const children = locateChildren(doc, null, [], 0)
+	return {
+		children,
+		nodeAtPath(path) {
+			const location = byPath.get(pathKey(path))
+			if (!location) {
+				throw new Error(`Comparison document path does not exist: ${path.join('.')}`)
+			}
+			return location
+		},
+	}
+}
+
+export function findComparisonNodes(range: Range, roots: readonly Location[]) {
+	const found = new Map<string, Location>()
+	const add = (location: Location) => found.set(pathKey(location.path), location)
+	const visit = (location: Location) => {
+		if (!touches(location, range)) {
+			return
+		}
+		add(location)
+		visitChildren(location.children, range, visit)
+	}
+	visitChildren(minimalRoots(roots), range, (root) => {
+		for (let ancestor = root.parent; ancestor; ancestor = ancestor.parent) {
+			add(ancestor)
+		}
+		visit(root)
+	})
+	return [...found.values()].toSorted((a, b) => a.from - b.from || a.path.length - b.path.length)
+}
+
+export function comparisonRangeText(range: Range, roots: readonly Location[]) {
+	if (range.from === range.to) {
+		return ''
+	}
+	return minimalRoots(roots)
+		.filter((root) => touches(root, range))
+		.map((root) => textFromRoot(root, range))
+		.join('\n')
+}
+
+function visitChildren(children: readonly Location[], range: Range, visit: (location: Location) => void) {
+	let lower = 0
+	let upper = children.length
+	while (lower < upper) {
+		const middle = (lower + upper) >>> 1
+		const beforeRange = range.from === range.to
+			? children[middle]!.to < range.from
+			: children[middle]!.to <= range.from
+		if (beforeRange) {
+			lower = middle + 1
+		} else {
+			upper = middle
+		}
+	}
+	for (let index = lower; index < children.length; index++) {
+		const child = children[index]!
+		if (range.from === range.to ? child.from > range.from : child.from >= range.to) {
+			break
+		}
+		visit(child)
+	}
+}
+
+function touches(location: Location, range: Range) {
+	return range.from === range.to
+		? range.from >= location.from && range.from <= location.to
+		: range.from < location.to && range.to > location.from
+}
+
+function minimalRoots(roots: readonly Location[]) {
+	const cached = minimalRootsCache.get(roots)
+	if (cached) {
+		return cached
+	}
+	const rootPaths = new Set(roots.map(({ path }) => pathKey(path)))
+	const minimal = roots.filter((root) => {
+		for (let ancestor = root.parent; ancestor; ancestor = ancestor.parent) {
+			if (rootPaths.has(pathKey(ancestor.path))) {
+				return false
+			}
+		}
+		return true
+	})
+	minimalRootsCache.set(roots, minimal)
+	return minimal
+}
+
+function textFromRoot(root: Location, range: Range) {
+	if (root.node.isText) {
+		return root.node.text?.slice(
+			Math.max(0, range.from - root.from),
+			Math.min(root.node.nodeSize, range.to - root.from),
+		) ?? ''
+	}
+	if (root.node.isLeaf) {
+		return '\ufffc'
+	}
+	const contentFrom = root.from + 1
+	return root.node.textBetween(
+		Math.max(0, range.from - contentFrom),
+		Math.min(root.node.content.size, range.to - contentFrom),
+		'\n',
+		'\ufffc',
+	)
+}
+function pathKey(path: readonly number[]) {
+	return path.join('.')
+}

--- a/src/comparison/comparisonNavigation.ts
+++ b/src/comparison/comparisonNavigation.ts
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonEdit as Edit, ComparisonSide as Side } from './markdownComparisonTypes.ts'
+
+export function isPureFormatting(edit: Edit) {
+	return edit.descriptors.every(({ facets }) => facets.length === 1 && facets[0] === 'formatting')
+}
+
+export function currentIdAfterFilter(
+	edits: readonly Edit[],
+	activeIds: readonly string[],
+	currentId: string | null,
+) {
+	const active = new Set(activeIds)
+	if (currentId && active.has(currentId)) {
+		return currentId
+	}
+	if (active.size === 0) {
+		return null
+	}
+	const currentIndex = edits.findIndex(({ id }) => id === currentId)
+	if (currentIndex >= 0) {
+		for (let index = currentIndex + 1; index < edits.length; index++) {
+			if (active.has(edits[index]!.id)) {
+				return edits[index]!.id
+			}
+		}
+		for (let index = currentIndex - 1; index >= 0; index--) {
+			if (active.has(edits[index]!.id)) {
+				return edits[index]!.id
+			}
+		}
+	}
+	return edits.find(({ id }) => active.has(id))?.id ?? null
+}
+
+export function moveCurrentId(activeIds: readonly string[], currentId: string | null, offset: number) {
+	if (activeIds.length === 0) {
+		return null
+	}
+	const current = Math.max(0, activeIds.indexOf(currentId ?? ''))
+	const next = ((current + offset) % activeIds.length + activeIds.length) % activeIds.length
+	return activeIds[next]!
+}
+
+export function currentOrdinal(activeIds: readonly string[], currentId: string | null) {
+	const index = currentId ? activeIds.indexOf(currentId) : -1
+	return index < 0 ? 0 : index + 1
+}
+
+export function comparisonSideForKey(key: string): Side | null {
+	if (key === 'ArrowLeft' || key === 'ArrowUp' || key === 'Home') {
+		return 'before'
+	}
+	return key === 'ArrowRight' || key === 'ArrowDown' || key === 'End' ? 'after' : null
+}
+export function comparisonScrollBehavior(): ScrollBehavior {
+	return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'
+}
+
+export function locateComparisonTarget(pane: HTMLElement | null, scroller: HTMLElement | null, id: string, behavior: ScrollBehavior, fallbackRect?: () => { top: number, height: number } | null) {
+	if (!pane || !scroller || !pane.contains(scroller) || pane.hidden || pane.style.display === 'none') {
+		return false
+	}
+	const target = [...pane.querySelectorAll<HTMLElement>('[data-comparison-change]')]
+		.find((element) => element.dataset.comparisonChange === id)
+	const targetRect = target?.getBoundingClientRect() ?? fallbackRect?.()
+	if (!targetRect) {
+		return false
+	}
+	const scrollerRect = scroller.getBoundingClientRect()
+	const centeredTop = scroller.scrollTop + targetRect.top - scrollerRect.top
+		- (scroller.clientHeight - targetRect.height) / 2
+	const maximumTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight)
+	scroller.scrollTo({
+		behavior,
+		left: scroller.scrollLeft,
+		top: Math.min(Math.max(0, centeredTop), maximumTop),
+	})
+	return true
+}

--- a/src/comparison/comparisonPresentation.ts
+++ b/src/comparison/comparisonPresentation.ts
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonAttributeCode as AttributeCode, ComparisonMarkCode as MarkCode, ComparisonSignal as Signal } from './markdownComparisonTypes.ts'
+
+import { t } from '@nextcloud/l10n'
+
+type Label = () => string
+const attributes: Record<AttributeCode, readonly [number, Label]> = {
+	'image-target': [219, () => t('text', 'Image changed')],
+	'image-alt': [218, () => t('text', 'Image description changed')],
+	'link-target': [217, () => t('text', 'Link target changed')],
+	link: [216, () => t('text', 'Link changed')],
+	'mention-identity': [215, () => t('text', 'Mention changed')],
+	mathematics: [214, () => t('text', 'Mathematics changed')],
+	'preview-target': [213, () => t('text', 'Link preview changed')],
+	'footnote-reference': [212, () => t('text', 'Footnote changed')],
+	'task-state': [211, () => t('text', 'Task state changed')],
+	'heading-level': [210, () => t('text', 'Heading level changed')],
+	'list-start': [209, () => t('text', 'List start changed')],
+	'code-language': [208, () => t('text', 'Code language changed')],
+	'text-direction': [207, () => t('text', 'Text direction changed')],
+	'table-span': [206, () => t('text', 'Table structure changed')],
+	'table-alignment': [205, () => t('text', 'Table alignment changed')],
+	'callout-type': [204, () => t('text', 'Callout type changed')],
+	'details-state': [203, () => t('text', 'Details state changed')],
+	'unknown-attribute': [202, () => t('text', 'Attribute changed')],
+}
+
+const marks: Record<MarkCode, readonly [number, Label]> = {
+	bold: [106, () => t('text', 'Bold')],
+	italic: [105, () => t('text', 'Italic')],
+	strike: [104, () => t('text', 'Strikethrough')],
+	highlight: [103, () => t('text', 'Highlight')],
+	underline: [102, () => t('text', 'Underline')],
+	'inline-code': [101, () => t('text', 'Inline code')],
+}
+
+export function selectComparisonSignal(signals: readonly Signal[]): Signal | undefined {
+	return signals.reduce<Signal | undefined>((selected, signal) => (
+		!selected || signalPriority(signal) > signalPriority(selected) ? signal : selected
+	), undefined)
+}
+
+export function comparisonSignalLabel(signal: Signal) {
+	if (signal.type === 'attribute') {
+		return attributes[signal.attribute][1]()
+	}
+	if (signal.type === 'mark') {
+		return t('text', '{formatting} changed', { formatting: marks[signal.mark][1]() })
+	}
+}
+
+function signalPriority(signal: Signal) {
+	if (signal.type === 'attribute') {
+		return attributes[signal.attribute][0]
+	}
+	if (signal.type === 'mark') {
+		return marks[signal.mark][0]
+	}
+	return 150
+}

--- a/src/comparison/comparisonSections.ts
+++ b/src/comparison/comparisonSections.ts
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonEdit } from './markdownComparisonTypes.ts'
+
+import { increasingSubsequence } from './comparisonAlignment.ts'
+
+export interface ComparisonHeading {
+	from: number
+	text: string
+}
+
+export interface ComparisonSection {
+	id: string
+	title: string
+	edits: readonly ComparisonEdit[]
+}
+type Heading = ComparisonHeading
+
+export function headingLocations(doc: Node): readonly Heading[] {
+	const headings: Heading[] = []
+	doc.forEach((node, from) => {
+		const text = node.textContent.trim()
+		if (node.type.name === 'heading' && text) {
+			headings.push({ from, text })
+		}
+	})
+	return headings
+}
+
+function nearestHeadingIndex(headings: readonly Heading[], position: number) {
+	let lower = 0
+	let upper = headings.length
+	while (lower < upper) {
+		const middle = Math.floor((lower + upper) / 2)
+		if (headings[middle]!.from <= position) {
+			lower = middle + 1
+		} else {
+			upper = middle
+		}
+	}
+	return lower - 1
+}
+export function nearestHeading(headings: readonly Heading[], position: number) {
+	return headings[nearestHeadingIndex(headings, position)]?.text ?? ''
+}
+
+interface HeadingIndex {
+	headings: readonly Heading[]
+	keys: readonly string[]
+}
+
+function indexByUniqueTitle(headings: readonly Heading[]) {
+	const indexes = new Map<string, number>()
+	const repeated = new Set<string>()
+	headings.forEach(({ text }, index) => {
+		if (indexes.has(text)) {
+			repeated.add(text)
+		} else {
+			indexes.set(text, index)
+		}
+	})
+	for (const text of repeated) {
+		indexes.delete(text)
+	}
+	return indexes
+}
+
+function headingAnchors(before: readonly Heading[], after: readonly Heading[]) {
+	const beforeIndexes = indexByUniqueTitle(before)
+	const afterIndexes = indexByUniqueTitle(after)
+	const pairs: Array<readonly [number, number]> = []
+	after.forEach(({ text }, afterIndex) => {
+		const beforeIndex = beforeIndexes.get(text)
+		if (beforeIndex !== undefined && afterIndexes.get(text) === afterIndex) {
+			pairs.push([beforeIndex, afterIndex])
+		}
+	})
+	return increasingSubsequence(pairs.map(([index]) => index)).indices.map((index) => pairs[index]!)
+}
+
+function correlateHeadings(before: readonly Heading[], after: readonly Heading[]) {
+	const beforeKeys: string[] = []
+	const afterKeys: string[] = []
+	let next = 0
+	let row = 0
+	let column = 0
+
+	function pairGap(rowEnd: number, columnEnd: number) {
+		const rowCount = rowEnd - row
+		const columnCount = columnEnd - column
+		if (rowCount !== columnCount || rowCount > 1) {
+			while (row < rowEnd) {
+				beforeKeys[row++] = `#${next++}`
+			}
+			while (column < columnEnd) {
+				afterKeys[column++] = `#${next++}`
+			}
+			return
+		}
+		while (row < rowEnd) {
+			const key = `#${next++}`
+			beforeKeys[row++] = key
+			afterKeys[column++] = key
+		}
+	}
+
+	for (const [anchorRow, anchorColumn] of headingAnchors(before, after)) {
+		pairGap(anchorRow, anchorColumn)
+		const key = `#${next++}`
+		beforeKeys[row++] = key
+		afterKeys[column++] = key
+	}
+	pairGap(before.length, after.length)
+	return { before: beforeKeys, after: afterKeys }
+}
+
+function resolveSection(edit: ComparisonEdit, before: HeadingIndex, after: HeadingIndex) {
+	const descriptor = edit.primary
+	const deleted = descriptor.operation === 'delete'
+	const side = deleted ? before : after
+	const position = deleted
+		? descriptor.context.before?.from ?? descriptor.before.from
+		: descriptor.context.after?.from ?? descriptor.after.from
+	return side.keys[nearestHeadingIndex(side.headings, position)] ?? ''
+}
+
+export function buildComparisonSections(edits: readonly ComparisonEdit[], beforeDocument: Node, afterDocument: Node): readonly ComparisonSection[] {
+	const beforeHeadings = headingLocations(beforeDocument)
+	const afterHeadings = headingLocations(afterDocument)
+	const correlation = correlateHeadings(beforeHeadings, afterHeadings)
+	const before: HeadingIndex = { headings: beforeHeadings, keys: correlation.before }
+	const after: HeadingIndex = { headings: afterHeadings, keys: correlation.after }
+	const titleByKey = new Map<string, string>()
+	beforeHeadings.forEach((heading, index) => titleByKey.set(correlation.before[index]!, heading.text))
+	afterHeadings.forEach((heading, index) => titleByKey.set(correlation.after[index]!, heading.text))
+
+	const sections: Array<{ id: string, key: string, title: string, edits: ComparisonEdit[] }> = []
+	for (const edit of edits) {
+		const key = resolveSection(edit, before, after)
+		const title = titleByKey.get(key) ?? ''
+		const current = sections.at(-1)
+		if (current?.key === key) {
+			current.edits.push(edit)
+		} else {
+			sections.push({ id: edit.id, key, title, edits: [edit] })
+		}
+	}
+	return sections.map(({ id, title, edits: sectionEdits }) => ({
+		id,
+		title,
+		edits: sectionEdits,
+	}))
+}

--- a/src/comparison/createComparisonEditor.ts
+++ b/src/comparison/createComparisonEditor.ts
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Schema } from '@tiptap/pm/model'
+
+import { Editor } from '@tiptap/vue-3'
+import { renderEditorContent } from '../composables/useEditorMethods.ts'
+import RichText from '../extensions/RichText.ts'
+
+interface ComparisonEditorOptions {
+	ariaLabel?: string
+	filePath?: string
+	noLazyImages?: boolean
+	openLink?: (href: string) => void
+	schema?: Schema
+}
+
+export function createComparisonEditor(content: string, options: ComparisonEditorOptions = {}) {
+	if (typeof content !== 'string') {
+		throw new TypeError('Comparison content must be a string')
+	}
+	const editor = new Editor({
+		content: renderEditorContent(content, true),
+		editable: false,
+		editorProps: options.ariaLabel ? { attributes: { 'aria-label': options.ariaLabel } } : {},
+		extensions: [RichText.configure({
+			editing: false,
+			extensions: [],
+			isEmbedded: true,
+			noLazyImages: options.noLazyImages ?? false,
+			openLink: options.openLink,
+			relativePath: options.filePath,
+		})],
+		onBeforeCreate: ({ editor }) => {
+			if (options.schema) {
+				editor.schema = options.schema
+				editor.extensionManager.schema = options.schema
+			}
+		},
+	})
+	return editor
+}

--- a/src/comparison/hierarchicalMarkdownComparisonModel.ts
+++ b/src/comparison/hierarchicalMarkdownComparisonModel.ts
@@ -1,0 +1,842 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonWorkLedger as Ledger, ComparisonAlignmentOptions as Options, ComparisonAlignmentRegion as Region, ComparisonAlignmentStep as Step } from './comparisonAlignment.ts'
+import type { ComparisonDocumentIndex as DocumentIndex, LocatedComparisonNode as Location } from './comparisonDocumentIndex.ts'
+import type { ReservedExactMovePair as MovePair } from './markdownComparisonMoves.ts'
+import type { ComparisonAttributeCode as Attr, ComparisonDescriptor as Descriptor, ComparisonEdit as Edit, ComparisonEditKind as EditKind, MarkdownComparisonModel as Model, ComparisonRange as Range, ComparisonCoarseReason as Reason, ComparisonSide as Side } from './markdownComparisonTypes.ts'
+
+import { ChangeSet, simplifyChanges } from '@tiptap/pm/changeset'
+import { StepMap } from '@tiptap/pm/transform'
+import { alignComparisonAxis as alignAxis, alignComparisonColumns as alignColumns, createComparisonWorkLedger as createLedger } from './comparisonAlignment.ts'
+import { createComparisonDocumentIndex as indexDocument, comparisonRangeText as rangeText } from './comparisonDocumentIndex.ts'
+import { classifyComparisonDescriptor as classify, classifyNodeMarkupDescriptor as classifyMarkup, compareCodeUnits, deepFreeze, nodeFingerprint as nodeKey, semanticTokenEncoder, stableSerialize as serialize } from './markdownComparisonClassification.ts'
+import { confirmReservedExactMoves as confirmMoves } from './markdownComparisonMoves.ts'
+
+export const MAX_INLINE_ENVELOPE_SIZE = 4500
+export const MAX_RENDERED_COMPARISON_DESCRIPTORS = 10_000
+export const MAX_TABLE_ROWS = 512
+export const MAX_TABLE_PHYSICAL_CELLS = 10_000
+
+export class ComparisonModelLimitError extends Error {
+	constructor() {
+		super('Rendered comparison change limit reached')
+		this.name = 'ComparisonModelLimitError'
+	}
+}
+interface ComparisonModelOptions {
+	maximumDescriptors?: number
+}
+type PendingEdit = Omit<Edit, 'id'>
+
+interface Builder {
+	originalBefore: Node
+	originalAfter: Node
+	originalBeforeIndex: DocumentIndex
+	originalAfterIndex: DocumentIndex
+	comparisonBefore: Node
+	edits: PendingEdit[]
+	descriptorCount: number
+	maximumDescriptors: number
+	work: Ledger
+}
+interface AxisEntry {
+	before: readonly Location[]
+	after: readonly Location[]
+	coarseReason?: Reason
+}
+interface TableRow {
+	location: Location
+	kind: 'header' | 'body'
+	cells: readonly Location[]
+}
+interface RowPair {
+	before: TableRow
+	after: TableRow
+	slot: number
+}
+interface Column {
+	index: number
+	fingerprint: string
+	profile: () => readonly string[]
+	cells: ReadonlyMap<number, Location>
+}
+interface AxisNode {
+	location: Location
+	fingerprint: string
+	profile: () => readonly string[]
+}
+const NODE_TOKEN = '\u0000'
+const CHARACTER_TOKEN = '\u0001'
+const PAIR_COUNT_TOKEN = '\u0002'
+const ORDINAL_TOKEN = '\u0003'
+const ROW_KIND_TOKEN = '\u0004'
+const COLUMN_TOKEN = '\u0005'
+const ABSENT_CELL_TOKEN = '\u0006'
+
+const profileCache = new WeakMap<Node, readonly string[]>()
+
+export function createHierarchicalMarkdownComparisonModel(originalBefore: Node, originalAfter: Node, options: ComparisonModelOptions = {}): Model {
+	const comparisonBefore = normalizeSchema(originalBefore, originalAfter)
+	const originalBeforeIndex = indexDocument(originalBefore)
+	const originalAfterIndex = indexDocument(originalAfter)
+	const comparisonBeforeIndex = comparisonBefore === originalBefore
+		? originalBeforeIndex
+		: indexDocument(comparisonBefore)
+	const builder: Builder = {
+		originalBefore,
+		originalAfter,
+		originalBeforeIndex,
+		originalAfterIndex,
+		comparisonBefore,
+		edits: [],
+		descriptorCount: 0,
+		maximumDescriptors: options.maximumDescriptors ?? MAX_RENDERED_COMPARISON_DESCRIPTORS,
+		work: createLedger(),
+	}
+	compareSiblingAxis(
+		builder,
+		comparisonBeforeIndex.children,
+		originalAfterIndex.children,
+		0,
+		comparisonBefore.content.size,
+		0,
+		originalAfter.content.size,
+		true,
+	)
+
+	return deepFreeze({ edits: finalizeEdits(builder.edits) })
+}
+function normalizeSchema(before: Node, after: Node) {
+	if (before.type.schema === after.type.schema) {
+		return before
+	}
+	const rebuilt = after.type.schema.nodeFromJSON(before.toJSON())
+	if (rebuilt.nodeSize !== before.nodeSize) {
+		throw new Error('Markdown comparison schema normalization changed document positions')
+	}
+	if (rebuilt.textBetween(0, rebuilt.content.size, '\n', '\ufffc')
+		!== before.textBetween(0, before.content.size, '\n', '\ufffc')) {
+		throw new Error('Markdown comparison schema normalization changed document content')
+	}
+	if (serialize(rebuilt.toJSON()) !== serialize(before.toJSON())) {
+		throw new Error('Markdown comparison schema normalization lost semantics')
+	}
+	return rebuilt
+}
+function compareSiblingAxis(builder: Builder, before: readonly Location[], after: readonly Location[], beforeStart: number, beforeEnd: number, afterStart: number, afterEnd: number, topLevel: boolean, excluded: readonly Attr[] = []) {
+	const entries = axisEntries(before, after, alignAxis(before, after, axisOptions(builder)))
+	const groups = topLevel ? confirmedMoveGroups(builder, entries) : []
+	const moved = new Set(groups.flat().flatMap(({ before: a, after: b }) => [a, b]))
+	const missingBefore = precomputeMissing(entries, 'before', beforeStart, beforeEnd)
+	const missingAfter = precomputeMissing(entries, 'after', afterStart, afterEnd)
+	for (const [index, entry] of entries.entries()) {
+		if (entry.coarseReason) {
+			emitCoarse(builder, entry.before, entry.after, entry.coarseReason, excluded)
+		} else if (entry.before[0] && entry.after[0]) {
+			compareNodes(builder, entry.before[0], entry.after[0], true, excluded)
+		} else if (entry.before[0] && !moved.has(entry.before[0])) {
+			const missing = missingAfter[index]!
+			emitBlock(builder, entry.before[0], null, missing, excluded)
+		} else if (entry.after[0] && !moved.has(entry.after[0])) {
+			const missing = missingBefore[index]!
+			emitBlock(builder, null, entry.after[0], missing, excluded)
+		}
+	}
+	for (const group of groups) {
+		emitMove(builder, group)
+	}
+}
+function axisEntries(before: readonly Location[], after: readonly Location[], regions: readonly Region[]): readonly AxisEntry[] {
+	return regions.map((region) => {
+		if ('coarseReason' in region) {
+			return {
+				before: before.slice(region.before.from, region.before.to),
+				after: after.slice(region.after.from, region.after.to),
+				coarseReason: region.coarseReason,
+			}
+		}
+		return {
+			before: region.before === null ? [] : [before[region.before]!],
+			after: region.after === null ? [] : [after[region.after]!],
+		}
+	})
+}
+function confirmedMoveGroups(builder: Builder, entries: readonly AxisEntry[]) {
+	const deleted = entries.filter((entry) => !entry.coarseReason && entry.before[0] && !entry.after[0])
+	const inserted = entries.filter((entry) => !entry.coarseReason && entry.after[0] && !entry.before[0])
+	const insertedByFingerprint = new Map(inserted.map((entry) => [
+		nodeKey(entry.after[0]!.node),
+		entry.after[0]!,
+	]))
+	const candidates: MovePair[] = []
+	for (const entry of deleted) {
+		const fingerprint = nodeKey(entry.before[0]!.node)
+		const match = insertedByFingerprint.get(fingerprint)
+		if (match) {
+			candidates.push({ before: entry.before[0]!, after: match, fingerprint })
+		}
+	}
+	const groups = confirmMoves(builder.comparisonBefore, builder.originalAfter, candidates).groups
+	const deletedNodes = new Map(deleted.map((entry) => [entry.before[0]!.index, entry.before[0]!]))
+	const insertedNodes = new Map(inserted.map((entry) => [entry.after[0]!.index, entry.after[0]!]))
+	return groups.map((group) => extendMovedHeadingGroup(group, deletedNodes, insertedNodes))
+}
+function extendMovedHeadingGroup(group: readonly MovePair[], deletedNodes: ReadonlyMap<number, Location>, insertedNodes: ReadonlyMap<number, Location>) {
+	const first = group[0]!
+	if (first.before.node.type.name !== 'heading' || first.after.node.type.name !== 'heading') {
+		return [...group]
+	}
+	const extended = [...group]
+	let beforeIndex = group.at(-1)!.before.index + 1
+	let afterIndex = group.at(-1)!.after.index + 1
+	while (true) {
+		const before = deletedNodes.get(beforeIndex)
+		const after = insertedNodes.get(afterIndex)
+		if (!before || !after) {
+			break
+		}
+		if (before.node.type.name === 'heading' || after.node.type.name === 'heading'
+			|| !before.node.eq(after.node)) {
+			break
+		}
+		extended.push({ before, after, fingerprint: nodeKey(before.node) })
+		beforeIndex++
+		afterIndex++
+	}
+	return extended
+}
+function precomputeMissing(entries: readonly AxisEntry[], side: Side, start: number, end: number) {
+	const previousAt: Array<Location | null> = new Array(entries.length)
+	let previous: Location | null = null
+	for (const [index, entry] of entries.entries()) {
+		previousAt[index] = previous
+		previous = entry[side].at(-1) ?? previous
+	}
+	const locations = new Array<number>(entries.length)
+	let next: Location | null = null
+	for (let index = entries.length - 1; index >= 0; index--) {
+		previous = previousAt[index]!
+		locations[index] = next?.from
+			?? previous?.to
+			?? Math.min(Math.max(start, 0), end)
+		next = entries[index]![side][0] ?? next
+	}
+	return locations
+}
+function compareNodes(builder: Builder, before: Location, after: Location, markup = true, excluded: readonly Attr[] = []) {
+	if (before.node.eq(after.node)) {
+		return
+	}
+	if (before.node.type.name === 'table' && after.node.type.name === 'table') {
+		compareTables(builder, before, after)
+		return
+	}
+	if (before.node.isTextblock && after.node.isTextblock) {
+		compareTextblocks(builder, before, after, markup, excluded)
+		return
+	}
+	if (before.node.isLeaf || after.node.isLeaf || before.node.isAtom || after.node.isAtom) {
+		emitBlock(builder, before, after)
+		return
+	}
+	const nestedExcludedAttributes = markup && !before.node.sameMarkup(after.node)
+		? [...new Set([...excluded, ...emitMarkup(builder, before, after)])]
+		: excluded
+	compareSiblingAxis(
+		builder,
+		before.children,
+		after.children,
+		before.from + 1,
+		before.to - 1,
+		after.from + 1,
+		after.to - 1,
+		false,
+		nestedExcludedAttributes,
+	)
+}
+function compareTextblocks(builder: Builder, before: Location, after: Location, markup = true, excluded: readonly Attr[] = []) {
+	const start = before.node.content.findDiffStart(after.node.content)
+	if (start === null) {
+		if (markup && !before.node.sameMarkup(after.node)) {
+			emitMarkup(builder, before, after)
+		}
+		return
+	}
+	const diffEnd = before.node.content.findDiffEnd(after.node.content)
+	if (!diffEnd) {
+		emitBlock(builder, before, after, 0, excluded)
+		return
+	}
+	let { a: endA, b: endB } = diffEnd
+	if (endA < start) {
+		endB += start - endA
+		endA = start
+	}
+	if (endB < start) {
+		endA += start - endB
+		endB = start
+	}
+	if ((endA - start) + (endB - start) > MAX_INLINE_ENVELOPE_SIZE) {
+		emitBlock(builder, before, after, 0, excluded)
+		return
+	}
+	const map = new StepMap([0, before.node.content.size, after.node.content.size])
+	const changes = simplifyChanges(
+		ChangeSet.create(before.node, undefined, semanticTokenEncoder)
+			.addSteps(after.node, [map], null)
+			.changes,
+		after.node,
+	)
+	const beforeRoot = originalLocation(builder, 'before', before)
+	const afterRoot = originalLocation(builder, 'after', after)
+	const inlineRanges = changes.map((change) => ({
+		before: { from: before.from + 1 + change.fromA, to: before.from + 1 + change.toA },
+		after: { from: after.from + 1 + change.fromB, to: after.from + 1 + change.toB },
+		local: change,
+	}))
+	const valid = inlineRanges.length > 0 && inlineRanges.every(({ before: beforeRange, after: afterRange, local }) => (
+		validLocalRange(local.fromA, local.toA, before.node.content.size)
+		&& validLocalRange(local.fromB, local.toB, after.node.content.size)
+		&& before.node.textBetween(local.fromA, local.toA, '\n', '\ufffc')
+		=== rangeText(beforeRange, [beforeRoot])
+		&& after.node.textBetween(local.fromB, local.toB, '\n', '\ufffc')
+		=== rangeText(afterRange, [afterRoot])
+	))
+	if (!valid) {
+		emitBlock(builder, before, after, 0, excluded)
+		return
+	}
+	const contentExcludedAttributes = markup && !before.node.sameMarkup(after.node)
+		? [...new Set([...excluded, ...emitMarkup(builder, before, after)])]
+		: excluded
+	for (const { before: beforeRange, after: afterRange } of inlineRanges) {
+		pushContent(builder, descriptorFor(
+			builder,
+			beforeRange,
+			afterRange,
+			[before],
+			[after],
+			'inline',
+			contentExcludedAttributes,
+		))
+	}
+}
+function validLocalRange(from: number, to: number, maximum: number) {
+	return Number.isInteger(from) && Number.isInteger(to) && from >= 0 && to >= from && to <= maximum
+}
+function tableShape(table: Location) {
+	const rows: TableRow[] = []
+	let physicalCells = 0
+	let index = table.children[0]?.node.type.name === 'tableCaption' ? 1 : 0
+	if (table.children[index]?.node.type.name !== 'tableHeadRow') {
+		return null
+	}
+	for (; index < table.children.length; index++) {
+		const child = table.children[index]!
+		const name = child.node.type.name
+		const header = rows.length === 0
+		if ((header ? name !== 'tableHeadRow' : name !== 'tableRow') || child.children.length === 0) {
+			return null
+		}
+		const expectedCell = header ? 'tableHeader' : 'tableCell'
+		for (const cell of child.children) {
+			if (cell.node.type.name !== expectedCell
+				|| (cell.node.attrs.colspan ?? 1) !== 1
+				|| (cell.node.attrs.rowspan ?? 1) !== 1) {
+				return null
+			}
+		}
+		physicalCells += child.children.length
+		rows.push({
+			location: child,
+			kind: header ? 'header' : 'body',
+			cells: child.children,
+		})
+		if (rows.length > MAX_TABLE_ROWS || physicalCells > MAX_TABLE_PHYSICAL_CELLS) {
+			return null
+		}
+	}
+	return rows
+}
+function compareTables(builder: Builder, before: Location, after: Location) {
+	const beforeRows = tableShape(before)
+	const afterRows = tableShape(after)
+	if (!beforeRows || !afterRows) {
+		emitCoarse(builder, [before], [after], 'unsupported-table')
+		return
+	}
+	const seedEntries = axisEntries(
+		before.children,
+		after.children,
+		alignAxis(before.children, after.children, axisOptions(builder)),
+	)
+	const coarse = seedEntries.find(({ coarseReason }) => coarseReason)
+	if (coarse) {
+		emitCoarse(builder, [before], [after], coarse.coarseReason!)
+		return
+	}
+	const beforeRowOf = new Map(beforeRows.map((row) => [row.location, row]))
+	const afterRowOf = new Map(afterRows.map((row) => [row.location, row]))
+	const seedRowPairs = pairedRows(seedEntries, beforeRowOf, afterRowOf)
+	const seedPlan = tablePlan(builder, seedRowPairs, seedEntries.length)
+	if ('coarseReason' in seedPlan) {
+		emitCoarse(builder, [before], [after], seedPlan.coarseReason)
+		return
+	}
+	const { beforeCols: seedBeforeColumns, afterCols: seedAfterColumns, steps: seedSteps } = seedPlan
+	if (seedSteps.every((step) => step.before !== null && step.after !== null)) {
+		if (exactEvidenceConflict(seedBeforeColumns, seedAfterColumns, seedSteps)) {
+			emitCoarse(builder, [before], [after], 'table-evidence-conflict')
+			return
+		}
+		emitTablePlan(
+			builder,
+			before,
+			after,
+			seedEntries,
+			seedRowPairs,
+			seedBeforeColumns,
+			seedAfterColumns,
+			seedSteps,
+		)
+		return
+	}
+	const beforeAxis = tableAxisRecords(before.children, beforeRowOf, seedSteps, 'before')
+	const afterAxis = tableAxisRecords(after.children, afterRowOf, seedSteps, 'after')
+	const entries = axisEntries(
+		before.children,
+		after.children,
+		alignAxis(beforeAxis, afterAxis, {
+			work: builder.work,
+			fingerprint: ({ fingerprint }) => fingerprint,
+			profile: ({ profile }) => profile(),
+			compatible: (left, right) => left.location.node.type === right.location.node.type,
+		}),
+	)
+	const sharedCoarse = entries.find(({ coarseReason }) => coarseReason)
+	if (sharedCoarse) {
+		emitCoarse(builder, [before], [after], tableConflictReason(sharedCoarse.coarseReason!))
+		return
+	}
+	const rowPairs = pairedRows(entries, beforeRowOf, afterRowOf)
+	const plan = tablePlan(builder, rowPairs, entries.length)
+	if ('coarseReason' in plan) {
+		emitCoarse(builder, [before], [after], tableConflictReason(plan.coarseReason))
+		return
+	}
+	const { beforeCols, afterCols, steps } = plan
+	if (!sameSteps(seedSteps, steps)
+		|| exactEvidenceConflict(beforeCols, afterCols, steps)) {
+		emitCoarse(builder, [before], [after], 'table-evidence-conflict')
+		return
+	}
+	emitTablePlan(builder, before, after, entries, rowPairs, beforeCols, afterCols, steps)
+}
+function tableConflictReason(reason: Reason): Reason {
+	return reason === 'comparison-limit' ? reason : 'table-evidence-conflict'
+}
+function pairedRows(entries: readonly AxisEntry[], beforeRows: ReadonlyMap<Location, TableRow>, afterRows: ReadonlyMap<Location, TableRow>) {
+	return entries.flatMap((entry, slot) => {
+		const before = entry.before[0] && beforeRows.get(entry.before[0])
+		const after = entry.after[0] && afterRows.get(entry.after[0])
+		return before && after ? [{ before, after, slot }] : []
+	})
+}
+function tablePlan(builder: Builder, rows: readonly RowPair[], slots: number) {
+	const beforeCols = columnRecords(rows, 'before', slots)
+	const afterCols = columnRecords(rows, 'after', slots)
+	const plan = tableColumnPlan(builder, beforeCols, afterCols)
+	return 'coarseReason' in plan ? plan : { beforeCols, afterCols, steps: plan.steps }
+}
+function tableColumnPlan(builder: Builder, beforeCols: readonly Column[], afterCols: readonly Column[]): { steps: readonly Step[] } | { coarseReason: Reason } {
+	const steps: Step[] = []
+	for (const region of alignColumns(beforeCols, afterCols, {
+		work: builder.work,
+		fingerprint: ({ fingerprint }) => fingerprint,
+		profile: ({ profile }) => profile(),
+		compatible: () => true,
+	})) {
+		if ('coarseReason' in region) {
+			return { coarseReason: region.coarseReason }
+		}
+		steps.push(region)
+	}
+	return { steps }
+}
+function columnRecords(rowPairs: readonly RowPair[], side: Side, slotCount: number): readonly Column[] {
+	let width = 0
+	for (const pair of rowPairs) {
+		const row = pair[side]
+		width = Math.max(width, row.cells.length)
+	}
+	const cellsByColumn = Array.from({ length: width }, () => new Map<number, Location>())
+	const rowKinds = new Map<number, TableRow['kind']>()
+	for (const pair of rowPairs) {
+		const row = pair[side]
+		rowKinds.set(pair.slot, row.kind)
+		for (const [index, cell] of row.cells.entries()) {
+			cellsByColumn[index]!.set(pair.slot, cell)
+		}
+	}
+	return cellsByColumn.map((cells, index) => {
+		const fingerprint = [
+			`${slotCount}`,
+			...[...cells].map(([slot, cell]) => `${slot}:${rowKinds.get(slot)!}:${nodeKey(cell.node)}`),
+		].join('|')
+		let materializedProfile: readonly string[] | undefined
+		const profile = () => materializedProfile ??= [
+			`${PAIR_COUNT_TOKEN}${slotCount}`,
+			...[...cells].flatMap(([slot, cell]) => [
+				`${ORDINAL_TOKEN}${slot}`,
+				`${ROW_KIND_TOKEN}${rowKinds.get(slot)!}`,
+				...[...cell.node.textContent.normalize('NFC')].map((character) => `${CHARACTER_TOKEN}${character}`),
+			]),
+		]
+		return { index, fingerprint, profile, cells }
+	})
+}
+function tableAxisRecords(locations: readonly Location[], rowOf: ReadonlyMap<Location, TableRow>, steps: readonly Step[], side: Side): readonly AxisNode[] {
+	const retainedColumns = steps.flatMap((step) => {
+		if (step.before === null || step.after === null) {
+			return []
+		}
+		return [side === 'before' ? step.before : step.after]
+	})
+	return locations.map((location) => {
+		const row = rowOf.get(location)
+		if (!row) {
+			return {
+				location,
+				fingerprint: nodeKey(location.node),
+				profile: () => nodeProfile(location.node),
+			}
+		}
+		const cells = retainedColumns.map((column) => row.cells[column])
+		const fingerprint = serialize([
+			row.kind,
+			...cells.map((cell) => cell ? nodeKey(cell.node) : null),
+		])
+		let materializedProfile: readonly string[] | undefined
+		const profile = () => materializedProfile ??= [
+			`${ROW_KIND_TOKEN}${row.kind}`,
+			...cells.flatMap((cell, column) => [
+				`${COLUMN_TOKEN}${column}`,
+				...(cell ? nodeProfile(cell.node) : [ABSENT_CELL_TOKEN]),
+			]),
+		]
+		return { location, fingerprint, profile }
+	})
+}
+function sameSteps(candidate: readonly Step[], refined: readonly Step[]) {
+	return candidate.length === refined.length
+		&& candidate.every((step, index) => (
+			step.before === refined[index]!.before && step.after === refined[index]!.after
+		))
+}
+function exactEvidenceConflict(beforeCols: readonly Column[], afterCols: readonly Column[], steps: readonly Step[]) {
+	const unmatchedColumns = { before: [] as string[], after: [] as string[] }
+	const unmatchedCells = { before: [] as string[], after: [] as string[] }
+	for (const step of steps) {
+		const columns = [
+			step.before === null ? null : beforeCols[step.before]!,
+			step.after === null ? null : afterCols[step.after]!,
+		] as const
+		if (!columns[0] || !columns[1]) {
+			const side = columns[0] ? 'before' : 'after'
+			const column = columns[0] ?? columns[1]!
+			unmatchedColumns[side].push(column.fingerprint)
+			unmatchedCells[side].push(...[...column.cells.values()].map(({ node }) => nodeKey(node)))
+			continue
+		}
+		if (columns[0].fingerprint !== columns[1].fingerprint) {
+			unmatchedColumns.before.push(columns[0].fingerprint)
+			unmatchedColumns.after.push(columns[1].fingerprint)
+		}
+		for (const ordinal of new Set([...columns[0].cells.keys(), ...columns[1].cells.keys()])) {
+			const cells = [columns[0].cells.get(ordinal), columns[1].cells.get(ordinal)] as const
+			const fingerprints = cells.map((cell) => cell && nodeKey(cell.node))
+			if (fingerprints[0] !== fingerprints[1]) {
+				if (fingerprints[0]) {
+					unmatchedCells.before.push(fingerprints[0])
+				}
+				if (fingerprints[1]) {
+					unmatchedCells.after.push(fingerprints[1])
+				}
+			}
+		}
+	}
+	return sharesValue(unmatchedColumns.before, unmatchedColumns.after)
+		|| sharesValue(unmatchedCells.before, unmatchedCells.after)
+}
+function sharesValue(before: readonly string[], after: readonly string[]) {
+	const known = new Set(before)
+	return after.some((value) => known.has(value))
+}
+function emitTablePlan(builder: Builder, before: Location, after: Location, entries: readonly AxisEntry[], rowPairs: readonly RowPair[], beforeCols: readonly Column[], afterCols: readonly Column[], steps: readonly Step[]) {
+	const pairedRows = new Set(rowPairs.map(({ before: row }) => row.location))
+	const missingBefore = precomputeMissing(entries, 'before', before.from + 1, before.to - 1)
+	const missingAfter = precomputeMissing(entries, 'after', after.from + 1, after.to - 1)
+	for (const [index, entry] of entries.entries()) {
+		if (entry.before[0] && entry.after[0]) {
+			if (!pairedRows.has(entry.before[0])) {
+				compareNodes(builder, entry.before[0], entry.after[0])
+			}
+		} else if (entry.before[0]) {
+			const missing = missingAfter[index]!
+			emitBlock(builder, entry.before[0], null, missing)
+		} else if (entry.after[0]) {
+			const missing = missingBefore[index]!
+			emitBlock(builder, null, entry.after[0], missing)
+		}
+	}
+	const slots = counterpartSlots(steps, beforeCols.length, afterCols.length)
+	for (const step of steps) {
+		if (step.before !== null && step.after !== null) {
+			comparePairedColumn(builder, rowPairs, beforeCols[step.before]!, afterCols[step.after]!)
+		} else if (step.before !== null) {
+			emitColumnEdit(builder, rowPairs, beforeCols[step.before]!, 'before', slots.after[step.before]!)
+		} else if (step.after !== null) {
+			emitColumnEdit(builder, rowPairs, afterCols[step.after]!, 'after', slots.before[step.after]!)
+		}
+	}
+}
+function counterpartSlots(steps: readonly Step[], beforeCount: number, afterCount: number) {
+	const after = new Array<number>(beforeCount).fill(afterCount)
+	const before = new Array<number>(afterCount).fill(beforeCount)
+	let pendingAfter = afterCount
+	let pendingBefore = beforeCount
+	for (const step of steps.toReversed()) {
+		if (step.after !== null) {
+			pendingAfter = step.after
+		} else if (step.before !== null) {
+			after[step.before] = pendingAfter
+		}
+		if (step.before !== null) {
+			pendingBefore = step.before
+		} else if (step.after !== null) {
+			before[step.after] = pendingBefore
+		}
+	}
+	return { before, after }
+}
+function comparePairedColumn(builder: Builder, rowPairs: readonly RowPair[], before: Column, after: Column) {
+	const pairedCells = rowPairs.flatMap((pair) => {
+		const beforeCell = before.cells.get(pair.slot)
+		const afterCell = after.cells.get(pair.slot)
+		return beforeCell && afterCell ? [{ pair, beforeCell, afterCell }] : []
+	})
+	const markup = pairedCells.flatMap(({ pair, beforeCell, afterCell }) => {
+		const descriptor = markupDescriptor(builder, beforeCell, afterCell)
+		return descriptor ? [{ descriptor, row: pair.before.kind }] : []
+	})
+	if (markup.length) {
+		const header = markup.findIndex(({ row }) => row === 'header')
+		pushEdit(
+			builder,
+			'content',
+			markup[header < 0 ? 0 : header]!.descriptor,
+			markup.map(({ descriptor }) => descriptor),
+		)
+	}
+	for (const pair of rowPairs) {
+		const beforeCell = before.cells.get(pair.slot)
+		const afterCell = after.cells.get(pair.slot)
+		if (beforeCell && afterCell) {
+			compareNodes(builder, beforeCell, afterCell, false, ['table-alignment'])
+		} else if (beforeCell) {
+			const slot = cellSlot(pair.after, after.index)
+			emitBlock(builder, beforeCell, null, slot)
+		} else if (afterCell) {
+			const slot = cellSlot(pair.before, before.index)
+			emitBlock(builder, null, afterCell, slot)
+		}
+	}
+}
+function emitColumnEdit(builder: Builder, rowPairs: readonly RowPair[], column: Column, side: Side, counterpart: number) {
+	const rowPairOf = new Map(rowPairs.map((pair) => [pair.slot, pair]))
+	const present = [...column.cells].flatMap(([slot, cell]) => {
+		const pair = rowPairOf.get(slot)
+		return pair ? [{ pair, cell }] : []
+	})
+	if (present.length === 0) {
+		return
+	}
+	const descriptors = present.map(({ pair, cell }) => {
+		const slot = cellSlot(side === 'before' ? pair.after : pair.before, counterpart)
+		return blockDescriptor(
+			builder,
+			side === 'before' ? cell : null,
+			side === 'before' ? null : cell,
+			slot,
+		)
+	})
+	const header = present.findIndex(({ pair }) => pair[side].kind === 'header')
+	pushEdit(builder, 'table-column', descriptors[header < 0 ? 0 : header]!, descriptors)
+}
+function cellSlot(row: TableRow, columnIndex: number) {
+	const cell = row.cells[columnIndex]
+	if (cell) {
+		return cell.from
+	}
+	return row.location.to - 1
+}
+function emitMarkup(builder: Builder, before: Location, after: Location) {
+	const descriptor = markupDescriptor(builder, before, after)
+	pushContent(builder, descriptor)
+	return descriptor?.signals.flatMap((signal) => signal.type === 'attribute' ? [signal.attribute] : []) ?? []
+}
+function emitBlock(builder: Builder, before: Location | null, after: Location | null, absentPosition = 0, excluded: readonly Attr[] = []) {
+	pushContent(builder, blockDescriptor(builder, before, after, absentPosition, excluded))
+}
+function blockDescriptor(builder: Builder, before: Location | null, after: Location | null, absentPosition: number, excluded: readonly Attr[] = []) {
+	return descriptorFor(
+		builder,
+		before ? rangeFor(before) : emptyRange(absentPosition),
+		after ? rangeFor(after) : emptyRange(absentPosition),
+		before ? [before] : [],
+		after ? [after] : [],
+		'block',
+		excluded,
+	)
+}
+function emitCoarse(builder: Builder, before: readonly Location[], after: readonly Location[], coarseReason: Reason, excluded: readonly Attr[] = []) {
+	pushContent(builder, {
+		...descriptorFor(
+			builder,
+			{ from: before[0]!.from, to: before.at(-1)!.to },
+			{ from: after[0]!.from, to: after.at(-1)!.to },
+			before,
+			after,
+			'block',
+			excluded,
+		),
+		coarseReason,
+	})
+}
+function emitMove(builder: Builder, group: readonly MovePair[]) {
+	const first = group[0]!
+	const last = group.at(-1)!
+	pushContent(builder, {
+		...descriptorFor(
+			builder,
+			{ from: first.before.from, to: last.before.to },
+			{ from: first.after.from, to: last.after.to },
+			group.map(({ before }) => before),
+			group.map(({ after }) => after),
+			'block',
+		),
+		operation: 'move',
+		facets: ['structure'],
+		signals: [{ type: 'node' }],
+	})
+}
+function pushContent(builder: Builder, descriptor: Descriptor | null) {
+	if (descriptor) {
+		pushEdit(builder, 'content', descriptor, [descriptor])
+	}
+}
+function pushEdit(builder: Builder, kind: EditKind, primary: Descriptor, descriptors: Descriptor[]) {
+	builder.descriptorCount += descriptors.length
+	if (builder.descriptorCount > builder.maximumDescriptors) {
+		throw new ComparisonModelLimitError()
+	}
+	builder.edits.push({ kind, primary, descriptors })
+}
+function finalizeEdits(pending: readonly PendingEdit[]): readonly Edit[] {
+	let descriptorCount = 0
+	return pending
+		.toSorted((a, b) => compareDescriptors(a.primary, b.primary))
+		.map((edit, index) => {
+			const identified = new Map(edit.descriptors
+				.toSorted(compareDescriptors)
+				.map((descriptor) => [descriptor, {
+					...descriptor,
+					id: `change-${(descriptorCount++).toString(36)}`,
+				}]))
+			return {
+				id: `edit-${index.toString(36)}`,
+				kind: edit.kind,
+				primary: identified.get(edit.primary)!,
+				descriptors: [...identified.values()],
+			}
+		})
+}
+function compareDescriptors(a: Descriptor, b: Descriptor) {
+	return a.after.from - b.after.from
+		|| a.before.from - b.before.from
+		|| a.after.to - b.after.to
+		|| a.before.to - b.before.to
+		|| compareCodeUnits(a.operation, b.operation)
+}
+function axisOptions(builder: Builder): Options<Location> {
+	return {
+		work: builder.work,
+		fingerprint: ({ node }) => nodeKey(node),
+		profile: ({ node }) => nodeProfile(node),
+		compatible: (before, after) => before.node.type === after.node.type
+			|| (before.node.isTextblock && after.node.isTextblock),
+	}
+}
+function nodeProfile(node: Node): readonly string[] {
+	const cached = profileCache.get(node)
+	if (cached !== undefined) {
+		return cached
+	}
+	const profile = node.isTextblock
+		? [...node.textContent.normalize('NFC').replace(/\s+/gu, ' ').trim()]
+		: structuralTokens(node, [])
+	profileCache.set(node, profile)
+	return profile
+}
+function structuralTokens(node: Node, tokens: string[]) {
+	node.forEach((child) => {
+		if (child.isText) {
+			for (const character of (child.text ?? '').normalize('NFC')) {
+				tokens.push(`${CHARACTER_TOKEN}${character}`)
+			}
+		} else {
+			tokens.push(`${NODE_TOKEN}${child.type.name}`)
+			structuralTokens(child, tokens)
+		}
+	})
+	return tokens
+}
+function descriptorFor(builder: Builder, before: Range, after: Range, beforeNodes: readonly Location[], afterNodes: readonly Location[], detail: Descriptor['detail'], excluded: readonly Attr[] = []) {
+	return classify(
+		builder.originalBefore,
+		builder.originalAfter,
+		before,
+		after,
+		originalLocations(builder, 'before', beforeNodes),
+		originalLocations(builder, 'after', afterNodes),
+		detail,
+		excluded,
+	)
+}
+function markupDescriptor(builder: Builder, before: Location, after: Location) {
+	return classifyMarkup(
+		builder.originalBefore,
+		builder.originalAfter,
+		rangeFor(before),
+		rangeFor(after),
+		originalLocation(builder, 'before', before),
+		originalLocation(builder, 'after', after),
+	)
+}
+function originalLocations(builder: Builder, side: Side, locations: readonly Location[]) {
+	return locations.map((location) => originalLocation(builder, side, location))
+}
+function originalLocation(builder: Builder, side: Side, location: Location) {
+	return (side === 'before' ? builder.originalBeforeIndex : builder.originalAfterIndex)
+		.nodeAtPath(location.path)
+}
+function rangeFor(node: Location): Range {
+	return { from: node.from, to: node.to }
+}
+function emptyRange(position: number): Range {
+	return { from: position, to: position }
+}

--- a/src/comparison/markdownComparison.ts
+++ b/src/comparison/markdownComparison.ts
@@ -1,0 +1,257 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Editor } from '@tiptap/core'
+import type { Node } from '@tiptap/pm/model'
+import type { PluginKey } from '@tiptap/pm/state'
+import type { LocatedComparisonNode as LocatedNode } from './comparisonDocumentIndex.ts'
+import type { ComparisonDescriptor as Descriptor, ComparisonSide as Side } from './markdownComparisonTypes.ts'
+
+import { Plugin, PluginKey as ProseMirrorPluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+import { createComparisonDocumentIndex, findComparisonNodes } from './comparisonDocumentIndex.ts'
+
+export { ComparisonModelLimitError, createHierarchicalMarkdownComparisonModel as createMarkdownComparisonModel } from './hierarchicalMarkdownComparisonModel.ts'
+export type * from './markdownComparisonTypes.ts'
+
+export interface ComparisonDecorationState {
+	activeIds: readonly string[]
+	currentIds: readonly string[]
+}
+
+export interface PreparedComparisonDecoration {
+	descriptor: Descriptor
+	from: number
+	to: number
+	type: 'inline' | 'node'
+}
+
+type State = ComparisonDecorationState
+type Prepared = PreparedComparisonDecoration
+interface PluginState extends State {
+	decorations: DecorationSet
+	prepared: readonly Prepared[]
+}
+
+export type ComparisonDecorationKey = PluginKey<PluginState>
+
+export const RENDERED_COMPARISON_LIMITS = Object.freeze({
+	maximumCharactersPerSnapshot: 210_000,
+	maximumCharactersPerLine: 20_000,
+	maximumLinesPerSnapshot: 6_500,
+})
+const LIMITS = RENDERED_COMPARISON_LIMITS
+
+export class ComparisonProjectionError extends Error {
+	constructor(id: string) {
+		super(`Comparison range cannot be projected: ${id}`)
+		this.name = 'ComparisonProjectionError'
+	}
+}
+
+export function exceedsRenderedComparisonLimit(before: string, after: string): boolean {
+	return [before, after].some((content) => {
+		if (content.length > LIMITS.maximumCharactersPerSnapshot) {
+			return true
+		}
+		let lines = content ? 1 : 0
+		let lineCharacters = 0
+		for (let index = 0; index < content.length; index++) {
+			if (content[index] === '\n' || (content[index] === '\r' && content[index + 1] !== '\n')) {
+				lines++
+				lineCharacters = 0
+				if (lines > LIMITS.maximumLinesPerSnapshot) {
+					return true
+				}
+			} else if (content[index] !== '\r' && ++lineCharacters > LIMITS.maximumCharactersPerLine) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+let pluginId = 0
+export function createComparisonDecorationPlugin(descriptors: readonly Descriptor[], side: Side, markerLabel: string, initialState: State = { activeIds: descriptors.map(({ id }) => id), currentIds: [] }) {
+	const key = new ProseMirrorPluginKey<PluginState>(`markdown-comparison-${side}-${pluginId++}`)
+	const plugin = new Plugin<PluginState>({
+		key,
+		state: {
+			init: (_, state) => createPluginState(state.doc, descriptors, side, initialState, markerLabel),
+			apply: (transaction, current) => {
+				if (transaction.docChanged) {
+					return { activeIds: [], currentIds: [], decorations: DecorationSet.empty, prepared: [] }
+				}
+				const update = transaction.getMeta(key) as State | undefined
+				if (!update) {
+					return current
+				}
+				const selection = normalizeDecorationState(descriptors, update)
+				return {
+					...selection,
+					prepared: current.prepared,
+					decorations: buildDecorationSet(transaction.doc, current.prepared, selection, side, markerLabel),
+				}
+			},
+		},
+		props: {
+			decorations: (state) => key.getState(state)?.decorations ?? DecorationSet.empty,
+		},
+	})
+	return { key, plugin }
+}
+
+export function setComparisonDecorationState(editor: Editor, key: ComparisonDecorationKey, state: State) {
+	editor.view.dispatch(editor.state.tr.setMeta(key, state))
+}
+
+function createPluginState(doc: Node, descriptors: readonly Descriptor[], side: Side, selection: State, markerLabel: string): PluginState {
+	const prepared = prepareComparisonDecorations(doc, descriptors, side)
+	const normalized = normalizeDecorationState(descriptors, selection)
+	return {
+		...normalized,
+		prepared,
+		decorations: buildDecorationSet(doc, prepared, normalized, side, markerLabel),
+	}
+}
+
+function normalizeDecorationState(descriptors: readonly Descriptor[], state: State): State {
+	const known = new Set(descriptors.map(({ id }) => id))
+	const activeIds = [...new Set(state.activeIds)].filter((id) => known.has(id))
+	const active = new Set(activeIds)
+	return {
+		activeIds,
+		currentIds: [...new Set(state.currentIds)].filter((id) => active.has(id)),
+	}
+}
+
+export function prepareComparisonDecorations(doc: Node, descriptors: readonly Descriptor[], side: Side) {
+	const index = createComparisonDocumentIndex(doc)
+	return descriptors.flatMap((descriptor): Prepared[] => {
+		const source = descriptor[side]
+		if (source.from === source.to) {
+			return []
+		}
+		const from = clamp(source.from, 0, doc.content.size)
+		const to = clamp(source.to, 0, doc.content.size)
+		if (from >= to) {
+			throw new ComparisonProjectionError(descriptor.id)
+		}
+		const candidates = findComparisonNodes({ from, to }, index.children)
+		const parts = descriptor.detail === 'block'
+			? projectBlock(descriptor, side, from, to, candidates)
+			: projectInline(descriptor, from, to, candidates)
+		if (parts.length > 0) {
+			return parts
+		}
+		const fallback = projectionFallback(candidates, descriptor, side, from, to)
+		if (!fallback) {
+			throw new ComparisonProjectionError(descriptor.id)
+		}
+		return [{ descriptor, ...fallback, type: 'node' }]
+	})
+}
+
+function projectBlock(descriptor: Descriptor, side: Side, from: number, to: number, nodes: readonly LocatedNode[]) {
+	const topLevel = nodes.filter(({ parent }) => parent === null)
+	const covered = topLevel
+		.filter((node) => from <= node.from && to >= node.to)
+		.map(({ from: nodeFrom, to: nodeTo }) => ({ descriptor, from: nodeFrom, to: nodeTo, type: 'node' as const }))
+	if (covered.length > 0) {
+		return covered
+	}
+	const enclosing = nodes
+		.filter(({ node, from: nodeFrom, to: nodeTo }) => !node.isText && nodeFrom <= from && nodeTo >= to)
+		.toSorted((a, b) => (a.to - a.from) - (b.to - b.from) || b.path.length - a.path.length)[0]
+	if (enclosing) {
+		return [{ descriptor, from: enclosing.from, to: enclosing.to, type: 'node' as const }]
+	}
+	const context = descriptor.context[side]
+	const exact = context && context.from < context.to
+		? nodes.find((node) => node.from === context.from && node.to === context.to)
+		: undefined
+	return exact ? [{ descriptor, from: exact.from, to: exact.to, type: 'node' as const }] : []
+}
+
+function projectInline(descriptor: Descriptor, from: number, to: number, nodes: readonly LocatedNode[]) {
+	const parts: Prepared[] = []
+	for (const { node, from: position, to: end } of nodes) {
+		if (node.isText) {
+			const partFrom = Math.max(from, position)
+			const partTo = Math.min(to, end)
+			if (partFrom < partTo) {
+				parts.push({ descriptor, from: partFrom, to: partTo, type: 'inline' })
+			}
+			continue
+		}
+		const fullyCovered = from <= position && to >= end
+		const edgeChanged = (from <= position && to > position && to <= position + 1)
+			|| (from < end && to >= end && from >= end - 1)
+		const semanticsChanged = descriptor.facets.some((facet) => facet !== 'text' && facet !== 'formatting')
+		if (node.isLeaf || (semanticsChanged && (fullyCovered || edgeChanged))) {
+			parts.push({ descriptor, from: position, to: end, type: 'node' })
+		}
+	}
+	return parts
+}
+
+function projectionFallback(nodes: readonly LocatedNode[], descriptor: Descriptor, side: Side, from: number, to: number) {
+	const context = descriptor.context[side]
+	if (context && context.from < context.to) {
+		const exact = nodes.find((node) => node.from === context.from && node.to === context.to)
+		if (exact) {
+			return { from: exact.from, to: exact.to }
+		}
+	}
+	const enclosing = nodes
+		.filter(({ node, from: nodeFrom, to: nodeTo }) => !node.isText && nodeFrom <= from && nodeTo >= to)
+		.toSorted((a, b) => (a.to - a.from) - (b.to - b.from) || b.path.length - a.path.length)[0]
+	return enclosing ? { from: enclosing.from, to: enclosing.to } : null
+}
+
+function buildDecorationSet(doc: Node, prepared: readonly Prepared[], state: State, side: Side, markerLabel: string) {
+	const active = new Set(state.activeIds)
+	const current = new Set(state.currentIds)
+	const decorations = prepared.flatMap((item): Decoration[] => {
+		if (!active.has(item.descriptor.id)) {
+			return []
+		}
+		const attributes = changeAttributes(item.descriptor, side, current.has(item.descriptor.id), markerLabel)
+		return [item.type === 'inline'
+			? Decoration.inline(item.from, item.to, attributes)
+			: Decoration.node(item.from, item.to, attributes)]
+	})
+	return DecorationSet.create(doc, decorations)
+}
+
+function changeAttributes(descriptor: Descriptor, side: Side, current: boolean, label: string) {
+	const pureFormatting = descriptor.facets.length === 1 && descriptor.facets[0] === 'formatting'
+	const coarse = descriptor.detail === 'block' && descriptor.operation === 'replace'
+	const treatment = coarse
+		? 'block'
+		: pureFormatting
+			? 'formatting'
+			: descriptor.operation === 'move'
+				? 'move'
+				: descriptor.facets.includes('attribute') && !descriptor.facets.includes('text')
+					? 'attribute'
+					: side === 'before' ? 'removed' : 'added'
+	const classes = ['text-comparison-change', `text-comparison-change--${treatment}`]
+	if (descriptor.detail === 'block' && !coarse) {
+		classes.push('text-comparison-change--block')
+	}
+	if (current) {
+		classes.push('text-comparison-change--current')
+	}
+	return {
+		class: classes.join(' '),
+		'data-comparison-change': descriptor.id,
+		'aria-label': label,
+		...(current ? { 'aria-current': 'true' } : {}),
+	}
+}
+function clamp(value: number, minimum: number, maximum: number) {
+	return Math.min(Math.max(value, minimum), maximum)
+}

--- a/src/comparison/markdownComparisonClassification.ts
+++ b/src/comparison/markdownComparisonClassification.ts
@@ -1,0 +1,540 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Mark, Node } from '@tiptap/pm/model'
+import type { LocatedComparisonNode as Location } from './comparisonDocumentIndex.ts'
+import type { ComparisonAttributeCode as Attr, ComparisonContext as Context, ComparisonContextCode as ContextCode, ComparisonContextLocation as ContextLocation, ComparisonDescriptor as Descriptor, ComparisonFacet as Facet, ComparisonMarkCode as MarkCode, ComparisonOperation as Operation, ComparisonPreviewAtom as Preview, ComparisonRange as Range, ComparisonSignal as Signal } from './markdownComparisonTypes.ts'
+
+import { getTextDirection } from '../extensions/TextDirection.ts'
+import { findComparisonNodes as findNodes, comparisonRangeText as rangeText } from './comparisonDocumentIndex.ts'
+
+interface AttributeRecord {
+	nodeName: string
+	attribute: string
+	value: unknown
+	textContent: string
+}
+const marksCache = new WeakMap<readonly Mark[], string>()
+const fingerprints = new WeakMap<Node, string>()
+const nodeShapeCache = new WeakMap<Node, string>()
+const graphemeSegmenter = typeof Intl.Segmenter === 'function'
+	? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+	: null
+
+const contextCodes: Record<string, ContextCode> = {
+	frontMatter: 'front-matter',
+	paragraph: 'paragraph',
+	heading: 'heading',
+	bulletList: 'list-item',
+	orderedList: 'list-item',
+	taskList: 'list-item',
+	listItem: 'list-item',
+	taskItem: 'task',
+	table: 'table',
+	tableRow: 'table-row',
+	tableHeadRow: 'table-row',
+	tableCell: 'table-cell',
+	tableHeader: 'table-cell',
+	codeBlock: 'code-block',
+	blockquote: 'quote',
+	callout: 'callout',
+	details: 'details',
+	detailsContent: 'details',
+	detailsSummary: 'details',
+	footnotes: 'footnote',
+	footnote: 'footnote',
+	footnoteReference: 'footnote-reference',
+	image: 'image',
+	imageInline: 'image',
+	mention: 'mention',
+	inlineMath: 'mathematics',
+	blockMath: 'mathematics',
+	preview: 'preview',
+}
+const contextPriority: Record<ContextCode, number> = {
+	'footnote-reference': 100,
+	image: 95,
+	mention: 95,
+	mathematics: 95,
+	preview: 95,
+	footnote: 90,
+	'table-cell': 85,
+	task: 80,
+	'list-item': 75,
+	'front-matter': 70,
+	'code-block': 70,
+	callout: 65,
+	details: 65,
+	quote: 60,
+	heading: 50,
+	paragraph: 40,
+	'table-row': 20,
+	table: 10,
+	unknown: 0,
+}
+const markCodes: Record<string, MarkCode> = {
+	strong: 'bold',
+	em: 'italic',
+	strike: 'strike',
+	highlight: 'highlight',
+	underline: 'underline',
+	code: 'inline-code',
+}
+const meaningfulAttributes: Record<string, Record<string, Attr>> = {
+	heading: { level: 'heading-level' },
+	orderedList: { start: 'list-start' },
+	taskItem: { checked: 'task-state' },
+	codeBlock: { language: 'code-language' },
+	image: { src: 'image-target', alt: 'image-alt' },
+	imageInline: { src: 'image-target', alt: 'image-alt' },
+	mention: { id: 'mention-identity', label: 'mention-identity' },
+	inlineMath: { latex: 'mathematics' },
+	blockMath: { latex: 'mathematics' },
+	preview: { href: 'preview-target' },
+	footnoteReference: { referenceId: 'footnote-reference' },
+	footnote: { referenceId: 'footnote-reference' },
+	callout: { type: 'callout-type' },
+	details: { open: 'details-state' },
+	tableCell: { align: 'table-alignment', colspan: 'table-span', rowspan: 'table-span' },
+	tableHeader: { align: 'table-alignment', colspan: 'table-span', rowspan: 'table-span' },
+}
+function serialize(value: unknown): string {
+	if (value === null || typeof value !== 'object') {
+		return JSON.stringify(value) ?? String(value)
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map(serialize).join(',')}]`
+	}
+	return `{${Object.entries(value)
+		.toSorted(([a], [b]) => compareCodeUnits(a, b))
+		.map(([key, child]) => `${JSON.stringify(key)}:${serialize(child)}`)
+		.join(',')}}`
+}
+export { serialize as stableSerialize }
+
+function fingerprint(node: Node) {
+	let value = fingerprints.get(node)
+	if (value === undefined) {
+		value = serialize(node.toJSON())
+		fingerprints.set(node, value)
+	}
+	return value
+}
+export { fingerprint as nodeFingerprint }
+
+export function compareCodeUnits(a: string, b: string) {
+	return a < b ? -1 : a > b ? 1 : 0
+}
+function encodeMarks(marks: readonly Mark[]) {
+	const cached = marksCache.get(marks)
+	if (cached !== undefined) {
+		return cached
+	}
+	const encoded = marks
+		.map((mark) => `${mark.type.name}:${serialize(mark.attrs)}`)
+		.toSorted()
+		.join('|')
+	marksCache.set(marks, encoded)
+	return encoded
+}
+export const semanticTokenEncoder = {
+	encodeCharacter(character: number, marks: readonly Mark[]) {
+		return `character:${character}:${encodeMarks(marks)}`
+	},
+	encodeNodeStart(node: Node) {
+		return `node-start:${node.type.name}:${serialize(node.attrs)}:${encodeMarks(node.marks)}`
+	},
+	encodeNodeEnd(node: Node) {
+		return `node-end:${node.type.name}`
+	},
+	compareTokens(a: string, b: string) {
+		return a === b
+	},
+}
+export function classifyComparisonDescriptor(beforeDoc: Node, afterDoc: Node, before: Range, after: Range, beforeRoots: readonly Location[], afterRoots: readonly Location[], detail: Descriptor['detail'] = 'inline', excluded: readonly Attr[] = []): Descriptor {
+	const safeBefore = boundedRange(before, beforeDoc.content.size)
+	const safeAfter = boundedRange(after, afterDoc.content.size)
+	const beforeNodes = findNodes(safeBefore, beforeRoots)
+	const afterNodes = findNodes(safeAfter, afterRoots)
+	const context: Context = {
+		before: resolveContext(beforeNodes, safeBefore),
+		after: resolveContext(afterNodes, safeAfter),
+	}
+	const facets = new Set<Facet>()
+	const signals: Signal[] = []
+	const beforeText = rangeText(safeBefore, beforeRoots)
+	const afterText = rangeText(safeAfter, afterRoots)
+
+	if (beforeText !== afterText) {
+		facets.add('text')
+	}
+	classifyMarks(beforeDoc, afterDoc, safeBefore, safeAfter, beforeNodes, afterNodes, facets, signals)
+	classifyNodes(beforeNodes, afterNodes, safeBefore, safeAfter, facets, signals)
+	classifyAttributes(beforeNodes, afterNodes, facets, signals, excluded)
+
+	if (facets.size === 0) {
+		facets.add('unknown')
+	}
+	return {
+		id: '',
+		operation: operationFor(safeBefore, safeAfter),
+		detail,
+		facets: orderedFacets(facets),
+		before: safeBefore,
+		after: safeAfter,
+		context,
+		preview: {
+			before: previewAtom(safeBefore, beforeText, beforeNodes),
+			after: previewAtom(safeAfter, afterText, afterNodes),
+		},
+		signals: deduplicateSignals(signals),
+	}
+}
+export function classifyNodeMarkupDescriptor(beforeDoc: Node, afterDoc: Node, before: Range, after: Range, beforeRoot: Location, afterRoot: Location): Descriptor | null {
+	const safeBefore = boundedRange(before, beforeDoc.content.size)
+	const safeAfter = boundedRange(after, afterDoc.content.size)
+	const beforeNodes = findNodes(safeBefore, [beforeRoot])
+	const afterNodes = findNodes(safeAfter, [afterRoot])
+	const facets = new Set<Facet>()
+	const signals: Signal[] = []
+	classifyDirectAttributes(beforeRoot.node, afterRoot.node, facets, signals)
+	classifyDirectMarks(beforeRoot.node, afterRoot.node, facets, signals)
+	if (beforeRoot.node.type.name !== afterRoot.node.type.name) {
+		facets.add('structure')
+		signals.push({ type: 'node' })
+	}
+	if (facets.size === 0) {
+		return null
+	}
+	return {
+		id: '',
+		operation: 'replace',
+		detail: 'block',
+		facets: orderedFacets(facets),
+		before: safeBefore,
+		after: safeAfter,
+		context: {
+			before: resolveContext(beforeNodes, safeBefore),
+			after: resolveContext(afterNodes, safeAfter),
+		},
+		preview: {
+			before: previewAtom(safeBefore, rangeText(safeBefore, [beforeRoot]), beforeNodes),
+			after: previewAtom(safeAfter, rangeText(safeAfter, [afterRoot]), afterNodes),
+		},
+		signals: deduplicateSignals(signals),
+	}
+}
+function operationFor(before: Range, after: Range): Operation {
+	const beforeEmpty = before.from === before.to
+	const afterEmpty = after.from === after.to
+	return beforeEmpty !== afterEmpty ? (beforeEmpty ? 'insert' : 'delete') : 'replace'
+}
+function classifyMarks(beforeDoc: Node, afterDoc: Node, before: Range, after: Range, beforeNodes: readonly Location[], afterNodes: readonly Location[], facets: Set<Facet>, signals: Signal[]) {
+	classifyMarkMaps(
+		collectMarks(beforeDoc, before, beforeNodes),
+		collectMarks(afterDoc, after, afterNodes),
+		false,
+		facets,
+		signals,
+	)
+}
+function classifyMarkMaps(previous: ReadonlyMap<string, unknown>, next: ReadonlyMap<string, unknown>, direct: boolean, facets: Set<Facet>, signals: Signal[]) {
+	const names = new Set([...previous.keys(), ...next.keys()])
+	for (const name of [...names].toSorted()) {
+		const before = previous.get(name)
+		const after = next.get(name)
+		if (serialize(before) === serialize(after)) {
+			continue
+		}
+		const change = before === undefined ? 'added' : after === undefined ? 'removed' : 'changed'
+		if (name === 'link') {
+			facets.add('attribute')
+			signals.push({
+				type: 'attribute',
+				attribute: direct || change === 'changed' ? 'link-target' : 'link',
+				change,
+			})
+		} else if (markCodes[name]) {
+			facets.add('formatting')
+			signals.push({ type: 'mark', mark: markCodes[name], change })
+		} else {
+			facets.add('unknown')
+		}
+	}
+}
+function classifyNodes(beforeNodes: readonly Location[], afterNodes: readonly Location[], before: Range, after: Range, facets: Set<Facet>, signals: Signal[]) {
+	if (structuralShape(beforeNodes, before) === structuralShape(afterNodes, after)) {
+		return
+	}
+	facets.add('structure')
+	signals.push({ type: 'node' })
+}
+function classifyAttributes(beforeNodes: readonly Location[], afterNodes: readonly Location[], facets: Set<Facet>, signals: Signal[], excluded: readonly Attr[]) {
+	const previous = collectAttributes(beforeNodes)
+	const next = collectAttributes(afterNodes)
+	const keys = [...previous.keys()].filter((key) => next.has(key)).toSorted()
+	for (const key of keys) {
+		const before = previous.get(key)!
+		const after = next.get(key)!
+		if (serialize(before.value) === serialize(after.value)) {
+			continue
+		}
+		if (before.nodeName !== after.nodeName) {
+			continue
+		}
+		if (after.attribute === 'dir' && isInferredDirectionTransition(
+			before.value,
+			after.value,
+			before.textContent,
+			after.textContent,
+		)) {
+			continue
+		}
+		const code = attributeCode(after.nodeName, after.attribute)
+		if (code && excluded.includes(code)) {
+			continue
+		}
+		addAttributeSignal(code, 'changed', facets, signals)
+	}
+}
+function classifyDirectAttributes(before: Node, after: Node, facets: Set<Facet>, signals: Signal[]) {
+	const names = new Set([...Object.keys(before.attrs), ...Object.keys(after.attrs)])
+	for (const attribute of [...names].toSorted()) {
+		const previous = before.attrs[attribute]
+		const next = after.attrs[attribute]
+		if (serialize(previous) === serialize(next)) {
+			continue
+		}
+		if (attribute === 'dir' && isInferredDirectionTransition(
+			previous,
+			next,
+			before.textContent,
+			after.textContent,
+		)) {
+			continue
+		}
+		addAttributeSignal(
+			attributeCode(after.type.name, attribute),
+			previous === undefined ? 'added' : next === undefined ? 'removed' : 'changed',
+			facets,
+			signals,
+		)
+	}
+}
+function attributeCode(nodeName: string, attribute: string) {
+	return attribute === 'dir' ? 'text-direction' : meaningfulAttributes[nodeName]?.[attribute]
+}
+function addAttributeSignal(code: Attr | undefined, change: 'added' | 'removed' | 'changed', facets: Set<Facet>, signals: Signal[]) {
+	facets.add('attribute')
+	if (!code) {
+		facets.add('unknown')
+	}
+	signals.push({ type: 'attribute', attribute: code ?? 'unknown-attribute', change })
+}
+function classifyDirectMarks(before: Node, after: Node, facets: Set<Facet>, signals: Signal[]) {
+	const previous = new Map(before.marks.map((mark) => [mark.type.name, serialize(mark.attrs)]))
+	const next = new Map(after.marks.map((mark) => [mark.type.name, serialize(mark.attrs)]))
+	classifyMarkMaps(previous, next, true, facets, signals)
+}
+function collectMarks(doc: Node, range: Range, nodes: readonly Location[]) {
+	const marks = new Map<string, string[]>()
+	const add = (mark: Mark) => {
+		const values = marks.get(mark.type.name) ?? []
+		const encoded = serialize(mark.attrs)
+		if (!values.includes(encoded)) {
+			values.push(encoded)
+			values.sort()
+		}
+		marks.set(mark.type.name, values)
+	}
+	if (range.from === range.to) {
+		for (const mark of doc.resolve(range.from).marks()) {
+			add(mark)
+		}
+	} else {
+		for (const { node } of nodes) {
+			for (const mark of node.marks) {
+				add(mark)
+			}
+		}
+	}
+	return marks
+}
+function resolveContext(nodes: readonly Location[], range: Range): ContextLocation | null {
+	const candidate = contextCandidates(nodes).toSorted((a, b) => compareContextCandidates(a, b, range))[0]
+	if (!candidate) {
+		return nodes[0]
+			? {
+					code: 'unknown',
+					path: nodes[0].path,
+					from: nodes[0].from,
+					to: nodes[0].to,
+				}
+			: null
+	}
+	return {
+		code: contextCodes[candidate.node.type.name]!,
+		path: candidate.path,
+		from: candidate.from,
+		to: candidate.to,
+	}
+}
+function contextCandidates(nodes: readonly Location[]) {
+	return nodes.filter(({ node }) => contextCodes[node.type.name] !== undefined)
+}
+function structuralShape(nodes: readonly Location[], range: Range) {
+	const contained = nodes.filter(({ node, from, to }) => !node.isText
+		&& range.from <= from
+		&& range.to >= to)
+	const containedNodes = new Set(contained)
+	const roots = contained.filter(({ parent }) => !parent || !containedNodes.has(parent))
+	return roots.map(({ node }) => nodeShape(node)).join('|')
+}
+function isInferredDirectionTransition(before: unknown, after: unknown, beforeText: string, afterText: string) {
+	return (!before || !after)
+		&& beforeText !== afterText
+		&& before === getTextDirection(beforeText)
+		&& after === getTextDirection(afterText)
+}
+function nodeShape(node: Node): string {
+	const cached = nodeShapeCache.get(node)
+	if (cached !== undefined) {
+		return cached
+	}
+	if (node.isText) {
+		return ''
+	}
+	const children: string[] = []
+	node.forEach((child) => {
+		const shape = nodeShape(child)
+		if (shape && children.at(-1) !== shape) {
+			children.push(shape)
+		}
+	})
+	const shape = `${node.type.name}(${children.join(',')})`
+	nodeShapeCache.set(node, shape)
+	return shape
+}
+function collectAttributes(nodes: readonly Location[]) {
+	const records = new Map<string, AttributeRecord>()
+	const topLevelIndices = [...new Set(nodes.map(({ path }) => path[0]).filter((index) => index !== undefined))]
+		.toSorted((a, b) => a - b)
+	const topLevelOrder = new Map(topLevelIndices.map((index, order) => [index, order]))
+	for (const { node, path } of nodes) {
+		if (node.isText) {
+			continue
+		}
+		const relativePath = path.length
+			? [topLevelOrder.get(path[0]!) ?? 0, ...path.slice(1)]
+			: []
+		for (const [attribute, value] of Object.entries(node.attrs)) {
+			records.set(`${relativePath.join('.')}:${node.type.name}:${attribute}`, {
+				nodeName: node.type.name,
+				attribute,
+				value,
+				textContent: node.textContent,
+			})
+		}
+	}
+	return records
+}
+function previewAtom(range: Range, rangeText: string, nodes: readonly Location[]): Preview | null {
+	if (range.from === range.to) {
+		return null
+	}
+	const text = frontMatterPreview(range, nodes)
+		|| normalizePreview(rangeText.replaceAll('\ufffc', ''))
+	if (text) {
+		return { kind: 'text', text: truncateGraphemes(text, 96) }
+	}
+	const contextNode = contextCandidates(nodes).toSorted(compareContextCandidates)[0] ?? nodes[0]
+	const contextText = normalizePreview(contextNode?.node.textContent ?? '')
+	if (contextText) {
+		return { kind: 'text', text: truncateGraphemes(contextText, 96) }
+	}
+	const nodeName = contextNode?.node.type.name
+	const node = nodeName === 'frontMatter'
+		? 'front-matter'
+		: nodeName === 'image' || nodeName === 'imageInline'
+			? 'image'
+			: nodeName === 'mention'
+				? 'mention'
+				: nodeName === 'inlineMath' || nodeName === 'blockMath'
+					? 'mathematics'
+					: nodeName === 'footnoteReference'
+						? 'footnote-reference'
+						: nodeName === 'horizontalRule'
+							? 'horizontal-rule'
+							: 'changed-content'
+	return { kind: 'node', node }
+}
+function frontMatterPreview(range: Range, nodes: readonly Location[]) {
+	const frontMatter = nodes.find(({ node, from, to }) => (
+		node.type.name === 'frontMatter' && range.from <= to && range.to >= from
+	))
+	if (!frontMatter) {
+		return ''
+	}
+	const content = frontMatter.node.textContent
+	const contentStart = frontMatter.from + 1
+	const from = clamp(range.from - contentStart, 0, content.length)
+	const to = clamp(range.to - contentStart, from, content.length)
+	const lineStart = content.lastIndexOf('\n', Math.max(0, from - 1)) + 1
+	const nextBreak = content.indexOf('\n', to)
+	return normalizePreview(content.slice(lineStart, nextBreak < 0 ? content.length : nextBreak))
+}
+function compareContextCandidates(a: Location, b: Location, range?: Range) {
+	const aCode = contextCodes[a.node.type.name]!
+	const bCode = contextCodes[b.node.type.name]!
+	return Number(coversRange(b, bCode, range)) - Number(coversRange(a, aCode, range))
+		|| contextPriority[bCode] - contextPriority[aCode]
+		|| b.path.length - a.path.length
+		|| a.from - b.from
+}
+function coversRange(location: Location, code: ContextCode, range: Range | undefined) {
+	return range !== undefined
+		&& (code === 'table' || code === 'table-row')
+		&& location.from === range.from
+		&& location.to === range.to
+}
+function normalizePreview(value: string) {
+	return value.replace(/\s+/gu, ' ').trim()
+}
+export function truncateGraphemes(value: string, maximum: number) {
+	let count = 0
+	let truncated = ''
+	const segments = graphemeSegmenter?.segment(value) ?? value
+	for (const item of segments) {
+		if (count++ === maximum) {
+			return `${truncated}…`
+		}
+		truncated += typeof item === 'string' ? item : item.segment
+	}
+	return value
+}
+function orderedFacets(facets: Set<Facet>) {
+	const order: Facet[] = ['text', 'formatting', 'attribute', 'structure', 'unknown']
+	return order.filter((facet) => facets.has(facet))
+}
+function deduplicateSignals(signals: Signal[]) {
+	const byValue = new Map(signals.map((signal) => [serialize(signal), signal]))
+	return [...byValue.values()].toSorted((a, b) => compareCodeUnits(serialize(a), serialize(b)))
+}
+function boundedRange(range: Range, maximum: number) {
+	const from = clamp(range.from, 0, maximum)
+	return { from, to: clamp(range.to, from, maximum) }
+}
+function clamp(value: number, minimum: number, maximum: number) {
+	return Math.min(Math.max(value, minimum), maximum)
+}
+export function deepFreeze<T>(value: T): T {
+	if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+		Object.freeze(value)
+		for (const child of Object.values(value)) {
+			deepFreeze(child)
+		}
+	}
+	return value
+}

--- a/src/comparison/markdownComparisonMoves.ts
+++ b/src/comparison/markdownComparisonMoves.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { LocatedComparisonNode as Location } from './comparisonDocumentIndex.ts'
+
+import { nodeFingerprint as keyFor } from './markdownComparisonClassification.ts'
+
+export interface ReservedExactMovePair {
+	before: Location
+	after: Location
+	fingerprint: string
+}
+type Pair = ReservedExactMovePair
+
+export function confirmReservedExactMoves(
+	before: Node,
+	after: Node,
+	candidates: readonly Pair[],
+) {
+	if (candidates.length === 0) {
+		return { groups: [] as Pair[][] }
+	}
+	const beforeCounts = documentFingerprintCounts(before)
+	const afterCounts = documentFingerprintCounts(after)
+	const confirmed = candidates.filter(({ fingerprint, before: beforeNode, after: afterNode }) => (
+		beforeCounts.get(fingerprint) === 1
+		&& afterCounts.get(fingerprint) === 1
+		&& beforeNode.node.eq(afterNode.node)
+	))
+
+	const groups: Pair[][] = []
+	for (const pair of confirmed.toSorted((a, b) => (
+		a.before.index - b.before.index || a.after.index - b.after.index
+	))) {
+		const previous = groups.at(-1)?.at(-1)
+		if (previous
+			&& pair.before.index === previous.before.index + 1
+			&& pair.after.index === previous.after.index + 1) {
+			groups.at(-1)!.push(pair)
+		} else {
+			groups.push([pair])
+		}
+	}
+	return { groups }
+}
+
+function documentFingerprintCounts(doc: Node) {
+	const counts = new Map<string, number>()
+	doc.descendants((node) => {
+		const fingerprint = keyFor(node)
+		counts.set(fingerprint, (counts.get(fingerprint) ?? 0) + 1)
+	})
+	return counts
+}

--- a/src/comparison/markdownComparisonTypes.ts
+++ b/src/comparison/markdownComparisonTypes.ts
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export type ComparisonOperation = 'insert' | 'delete' | 'replace' | 'move'
+
+export type ComparisonDetail = 'inline' | 'block'
+
+export type ComparisonFacet
+	= | 'text'
+		| 'formatting'
+		| 'attribute'
+		| 'structure'
+		| 'unknown'
+
+export interface ComparisonRange {
+	from: number
+	to: number
+}
+
+export type ComparisonContextCode
+	= | 'front-matter'
+		| 'paragraph'
+		| 'heading'
+		| 'list-item'
+		| 'task'
+		| 'table'
+		| 'table-row'
+		| 'table-cell'
+		| 'code-block'
+		| 'quote'
+		| 'callout'
+		| 'details'
+		| 'footnote'
+		| 'footnote-reference'
+		| 'image'
+		| 'mention'
+		| 'mathematics'
+		| 'preview'
+		| 'unknown'
+
+export interface ComparisonContextLocation {
+	code: ComparisonContextCode
+	path: readonly number[]
+	from: number
+	to: number
+}
+
+export interface ComparisonContext {
+	before: ComparisonContextLocation | null
+	after: ComparisonContextLocation | null
+}
+
+export type ComparisonPreviewNode
+	= | 'front-matter'
+		| 'image'
+		| 'mention'
+		| 'mathematics'
+		| 'footnote-reference'
+		| 'horizontal-rule'
+		| 'changed-content'
+
+export type ComparisonPreviewAtom
+	= | { kind: 'text', text: string }
+		| { kind: 'node', node: ComparisonPreviewNode }
+
+export interface ComparisonPreview {
+	before: ComparisonPreviewAtom | null
+	after: ComparisonPreviewAtom | null
+}
+
+export type ComparisonMarkCode
+	= | 'bold'
+		| 'italic'
+		| 'strike'
+		| 'highlight'
+		| 'underline'
+		| 'inline-code'
+
+export type ComparisonAttributeCode
+	= | 'link'
+		| 'link-target'
+		| 'heading-level'
+		| 'list-start'
+		| 'task-state'
+		| 'code-language'
+		| 'text-direction'
+		| 'image-target'
+		| 'image-alt'
+		| 'mention-identity'
+		| 'mathematics'
+		| 'preview-target'
+		| 'footnote-reference'
+		| 'callout-type'
+		| 'details-state'
+		| 'table-alignment'
+		| 'table-span'
+		| 'unknown-attribute'
+
+export type ComparisonSignal
+	= | {
+		type: 'mark'
+		mark: ComparisonMarkCode
+		change: 'added' | 'removed' | 'changed'
+	}
+	| {
+		type: 'attribute'
+		attribute: ComparisonAttributeCode
+		change: 'added' | 'removed' | 'changed'
+	}
+	| {
+		type: 'node'
+	}
+
+export type ComparisonCoarseReason
+	= | 'ambiguous-attribution'
+		| 'comparison-limit'
+		| 'table-evidence-conflict'
+		| 'unsupported-table'
+
+export interface ComparisonDescriptor {
+	id: string
+	operation: ComparisonOperation
+	detail: ComparisonDetail
+	facets: readonly ComparisonFacet[]
+	before: ComparisonRange
+	after: ComparisonRange
+	context: ComparisonContext
+	preview: ComparisonPreview
+	signals: readonly ComparisonSignal[]
+	coarseReason?: ComparisonCoarseReason
+}
+
+export type ComparisonEditKind = 'content' | 'table-column'
+
+export interface ComparisonEdit {
+	id: string
+	kind: ComparisonEditKind
+	primary: ComparisonDescriptor
+	descriptors: readonly ComparisonDescriptor[]
+}
+
+export interface MarkdownComparisonModel {
+	edits: readonly ComparisonEdit[]
+}
+
+export type ComparisonSide = 'before' | 'after'

--- a/src/comparison/markdownSourceComparison.ts
+++ b/src/comparison/markdownSourceComparison.ts
@@ -1,0 +1,526 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Change } from 'diff'
+import type { SourceComparisonWorkerRequest as WorkerRequest, SourceComparisonWorkerResponse as WorkerResponse } from './markdownSourceComparisonProtocol.ts'
+
+import { diffWordsWithSpace } from 'diff'
+import { compareMarkdownSourceLines } from './markdownSourceComparisonProtocol.ts'
+import { displayBoundedMarkdownSource } from './markdownSourceDisplay.ts'
+
+export type SourceEol = 'lf' | 'crlf' | 'cr' | 'none'
+export type SourceLineEnding = Exclude<SourceEol, 'none'> | 'mixed'
+
+export interface SourceDiffSegment {
+	text: string
+	changed: boolean
+}
+export interface SourceDiffLine {
+	number: number
+	text: string
+	eol: SourceEol
+	changed: boolean
+	segments: readonly SourceDiffSegment[]
+}
+export interface SourceDiffRow {
+	before?: SourceDiffLine
+	after?: SourceDiffLine
+}
+export interface SourceDiffHunk {
+	id: string
+	beforeStart: number
+	afterStart: number
+	rows: readonly SourceDiffRow[]
+}
+export interface SourceDiffGap {
+	id: string
+	slot: number
+	beforeFrom: number
+	beforeTo: number
+	afterFrom: number
+	afterTo: number
+	count: number
+}
+export interface SourceLineEndingChange {
+	before: SourceLineEnding
+	after: SourceLineEnding
+}
+export interface SourceDiffReadyModel {
+	status: 'ready'
+	hunks: readonly SourceDiffHunk[]
+	gaps: readonly SourceDiffGap[]
+	lineEndingChange: SourceLineEndingChange | null
+}
+export interface SourceDiffLimitedModel {
+	status: 'limited'
+	reason: 'size' | 'complexity'
+}
+export type SourceDiffModel = SourceDiffReadyModel | SourceDiffLimitedModel
+export type SourceGapMaterializer = typeof materializeSourceDiffGap
+
+type SourceLine = SourceDiffLine
+interface ChangedRun {
+	beforeFrom: number
+	beforeTo: number
+	afterFrom: number
+	afterTo: number
+}
+interface HunkRange extends ChangedRun {
+	beforeContextFrom: number
+	beforeContextTo: number
+	afterContextFrom: number
+	afterContextTo: number
+}
+
+export const SOURCE_DIFF_LIMITS = Object.freeze({
+	maximumCharacters: 2_000_000,
+	maximumLines: 60_000,
+	maximumEditLength: 50_000,
+	timeoutMilliseconds: 2_000,
+	contextLines: 3,
+	maximumDisplayedRows: 5_000,
+	maximumGapPageRows: 500,
+	maximumWordDiffLines: 20,
+	maximumWordDiffCharacters: 2_000,
+	maximumWordDiffMilliseconds: 100,
+	maximumWordDiffPairMilliseconds: 10,
+})
+const LIMITS = SOURCE_DIFF_LIMITS
+
+export async function createMarkdownSourceComparison(before: string, after: string, signal?: AbortSignal): Promise<SourceDiffModel> {
+	if (
+		before.length + after.length > LIMITS.maximumCharacters
+		|| sourceLineCount(before) + sourceLineCount(after)
+		> LIMITS.maximumLines
+		|| displayBoundedMarkdownSource(before).truncated
+		|| displayBoundedMarkdownSource(after).truncated
+	) {
+		return { status: 'limited', reason: 'size' }
+	}
+	checkAbort(signal)
+	const normalizedBefore = normalize(before)
+	const normalizedAfter = normalize(after)
+	const changes = await computeLineChanges(
+		normalizedBefore,
+		normalizedAfter,
+		signal,
+	)
+	if (!changes) {
+		return { status: 'limited', reason: 'complexity' }
+	}
+	checkAbort(signal)
+	return buildSourceModel(
+		before,
+		after,
+		normalizedBefore === normalizedAfter,
+		changes,
+	)
+}
+
+export function materializeSourceDiffGap(before: string, after: string, gap: SourceDiffGap, maximumRows: number = LIMITS.maximumGapPageRows, offset: number = 0) {
+	const finiteMaximum = Number.isFinite(maximumRows)
+		? Math.trunc(maximumRows)
+		: LIMITS.maximumGapPageRows
+	const rowLimit = Math.max(
+		0,
+		Math.min(finiteMaximum, LIMITS.maximumGapPageRows),
+	)
+	const finiteOffset = Number.isFinite(offset) ? Math.trunc(offset) : 0
+	const rowOffset = Math.max(0, Math.min(finiteOffset, gap.count))
+	const beforeFrom = Math.min(gap.beforeFrom + rowOffset, gap.beforeTo)
+	const afterFrom = Math.min(gap.afterFrom + rowOffset, gap.afterTo)
+	const beforeGap = splitRange(
+		before,
+		beforeFrom,
+		Math.min(beforeFrom + rowLimit, gap.beforeTo),
+		rowLimit,
+	)
+	const afterGap = splitRange(
+		after,
+		afterFrom,
+		Math.min(afterFrom + rowLimit, gap.afterTo),
+		rowLimit,
+	)
+	return pairSourceRows(beforeGap, afterGap)
+}
+
+async function computeLineChanges(before: string, after: string, signal?: AbortSignal) {
+	const request: WorkerRequest = {
+		before,
+		after,
+		maximumEditLength: LIMITS.maximumEditLength,
+		timeoutMilliseconds: LIMITS.timeoutMilliseconds,
+	}
+	if (typeof Worker === 'undefined') {
+		const response = compareMarkdownSourceLines(request)
+		return response.status === 'ready' ? response.changes : undefined
+	}
+	const worker = new Worker(
+		new URL('./markdownSourceComparison.worker.ts', import.meta.url),
+		{ type: 'module' },
+	)
+	return new Promise<Change[] | undefined>((resolve, reject) => {
+		let settled = false
+		const settle = (action: () => void) => {
+			if (settled) {
+				return
+			}
+			settled = true
+			signal?.removeEventListener('abort', abort)
+			try {
+				worker.terminate()
+			} finally {
+				action()
+			}
+		}
+		const fail = (error: unknown) => settle(() => reject(error))
+		function abort() {
+			fail(abortError())
+		}
+		const workerError = () => fail(new Error('Source comparison worker failed'))
+		worker.onmessage = ({ data }: MessageEvent<unknown>) => {
+			if (!isSourceComparisonWorkerResponse(data)) {
+				workerError()
+				return
+			}
+			settle(() => resolve(data.status === 'ready' ? data.changes : undefined))
+		}
+		worker.onerror = workerError
+		worker.onmessageerror = workerError
+		signal?.addEventListener('abort', abort, { once: true })
+		if (signal?.aborted) {
+			abort()
+			return
+		}
+		try {
+			worker.postMessage(request)
+		} catch (error) {
+			fail(error)
+		}
+	})
+}
+
+function isSourceComparisonWorkerResponse(response: unknown): response is WorkerResponse {
+	if (!response || typeof response !== 'object') {
+		return false
+	}
+	const candidate = response as { status?: unknown, changes?: unknown }
+	return (
+		candidate.status === 'limited'
+		|| (candidate.status === 'ready' && Array.isArray(candidate.changes))
+	)
+}
+
+function buildSourceModel(before: string, after: string, normalizedEqual: boolean, changes: Change[]): SourceDiffModel {
+	const beforeLines = splitRange(before)
+	const afterLines = splitRange(after)
+	const ranges = mergeRanges(changedRuns(changes).map((run) => withContext(run, beforeLines.length, afterLines.length)))
+	const displayedRows = ranges.reduce(
+		(total, range) => total
+			+ Math.max(0, range.beforeContextTo - range.beforeContextFrom)
+			+ Math.max(0, range.afterContextTo - range.afterContextFrom),
+		0,
+	)
+	if (displayedRows > LIMITS.maximumDisplayedRows) {
+		return { status: 'limited', reason: 'complexity' }
+	}
+	const hunks = ranges.map((range, index) => createHunk(range, beforeLines, afterLines, index))
+	return {
+		status: 'ready',
+		hunks,
+		gaps: createGaps(ranges, beforeLines, afterLines),
+		lineEndingChange: summarizeLineEndingChange(
+			beforeLines,
+			afterLines,
+			normalizedEqual,
+		),
+	}
+}
+
+function changedRuns(changes: Change[]) {
+	const runs: ChangedRun[] = []
+	let beforeLine = 0
+	let afterLine = 0
+	let current: ChangedRun | null = null
+	for (const change of changes) {
+		const count = change.count ?? sourceLineCount(change.value)
+		if (!change.added && !change.removed) {
+			if (current) {
+				runs.push(current)
+			}
+			current = null
+			beforeLine += count
+			afterLine += count
+			continue
+		}
+		current ??= {
+			beforeFrom: beforeLine,
+			beforeTo: beforeLine,
+			afterFrom: afterLine,
+			afterTo: afterLine,
+		}
+		if (change.removed) {
+			current.beforeTo += count
+			beforeLine += count
+		} else {
+			current.afterTo += count
+			afterLine += count
+		}
+	}
+	if (current) {
+		runs.push(current)
+	}
+	return runs
+}
+
+function withContext(run: ChangedRun, beforeLength: number, afterLength: number): HunkRange {
+	const context = (from: number, to: number, length: number) => ({
+		from: Math.max(0, from - LIMITS.contextLines),
+		to: Math.min(length, Math.max(to, from + 1) + LIMITS.contextLines),
+	})
+	const before = context(run.beforeFrom, run.beforeTo, beforeLength)
+	const after = context(run.afterFrom, run.afterTo, afterLength)
+	return {
+		...run,
+		beforeContextFrom: before.from,
+		beforeContextTo: before.to,
+		afterContextFrom: after.from,
+		afterContextTo: after.to,
+	}
+}
+
+function mergeRanges(ranges: HunkRange[]) {
+	const merged: HunkRange[] = []
+	for (const range of ranges) {
+		const previous = merged.at(-1)
+		if (
+			previous
+			&& range.beforeContextFrom <= previous.beforeContextTo
+			&& range.afterContextFrom <= previous.afterContextTo
+		) {
+			previous.beforeTo = Math.max(previous.beforeTo, range.beforeTo)
+			previous.afterTo = Math.max(previous.afterTo, range.afterTo)
+			previous.beforeContextTo = Math.max(
+				previous.beforeContextTo,
+				range.beforeContextTo,
+			)
+			previous.afterContextTo = Math.max(
+				previous.afterContextTo,
+				range.afterContextTo,
+			)
+		} else {
+			merged.push({ ...range })
+		}
+	}
+	return merged
+}
+
+function createHunk(range: HunkRange, before: SourceLine[], after: SourceLine[], index: number): SourceDiffHunk {
+	const select = (lines: SourceLine[], contextFrom: number, contextTo: number, from: number, to: number) => lines
+		.slice(contextFrom, contextTo)
+		.map((line, offset) => cloneLine(line, contextFrom + offset >= from && contextFrom + offset < to))
+	const beforeHunk = select(before, range.beforeContextFrom, range.beforeContextTo, range.beforeFrom, range.beforeTo)
+	const afterHunk = select(after, range.afterContextFrom, range.afterContextTo, range.afterFrom, range.afterTo)
+	addWordEmphasis(
+		beforeHunk.filter(({ changed }) => changed),
+		afterHunk.filter(({ changed }) => changed),
+	)
+	return {
+		id: `source-hunk-${index.toString(36)}`,
+		beforeStart: beforeHunk[0]?.number ?? 0,
+		afterStart: afterHunk[0]?.number ?? 0,
+		rows: pairSourceRows(beforeHunk, afterHunk),
+	}
+}
+
+function pairSourceRows(before: readonly SourceLine[], after: readonly SourceLine[]) {
+	const rows: SourceDiffRow[] = []
+	let left = 0
+	let right = 0
+	while (left < before.length || right < after.length) {
+		if (before[left]?.changed || after[right]?.changed) {
+			const removed: SourceLine[] = []
+			const added: SourceLine[] = []
+			while (before[left]?.changed) {
+				removed.push(before[left++]!)
+			}
+			while (after[right]?.changed) {
+				added.push(after[right++]!)
+			}
+			for (
+				let index = 0;
+				index < Math.max(removed.length, added.length);
+				index++
+			) {
+				rows.push({ before: removed[index], after: added[index] })
+			}
+		} else {
+			rows.push({ before: before[left++], after: after[right++] })
+		}
+	}
+	return rows
+}
+
+function addWordEmphasis(before: SourceLine[], after: SourceLine[]) {
+	const count = Math.min(
+		before.length,
+		after.length,
+		LIMITS.maximumWordDiffLines,
+	)
+	const deadline = Date.now() + LIMITS.maximumWordDiffMilliseconds
+	for (
+		let index = 0;
+		index < count;
+		index++
+	) {
+		const left = before[index]!
+		const right = after[index]!
+		if (
+			left.text.length + right.text.length
+			> LIMITS.maximumWordDiffCharacters
+			|| Date.now() > deadline
+		) {
+			continue
+		}
+		const pairDeadline
+			= Date.now() + LIMITS.maximumWordDiffPairMilliseconds
+		const words = diffWordsWithSpace(left.text, right.text)
+		if (Date.now() > pairDeadline) {
+			continue
+		}
+		left.segments = words
+			.filter(({ added }) => !added)
+			.map(({ value, removed }) => ({ text: value, changed: Boolean(removed) }))
+		right.segments = words
+			.filter(({ removed }) => !removed)
+			.map(({ value, added }) => ({ text: value, changed: Boolean(added) }))
+	}
+}
+
+function createGaps(ranges: HunkRange[], before: SourceLine[], after: SourceLine[]) {
+	const gaps: SourceDiffGap[] = []
+	for (let slot = 0; slot <= ranges.length; slot++) {
+		const beforeFrom = slot === 0 ? 0 : ranges[slot - 1]!.beforeContextTo
+		const beforeTo
+			= slot === ranges.length ? before.length : ranges[slot]!.beforeContextFrom
+		const afterFrom = slot === 0 ? 0 : ranges[slot - 1]!.afterContextTo
+		const afterTo
+			= slot === ranges.length ? after.length : ranges[slot]!.afterContextFrom
+		const beforeCount = beforeTo - beforeFrom
+		const afterCount = afterTo - afterFrom
+		if (beforeCount || afterCount) {
+			gaps.push({
+				id: `source-gap-${slot.toString(36)}`,
+				slot,
+				beforeFrom,
+				beforeTo,
+				afterFrom,
+				afterTo,
+				count: Math.max(beforeCount, afterCount),
+			})
+		}
+	}
+	return gaps
+}
+
+function splitRange(source: string, from = 0, to = Number.POSITIVE_INFINITY, maximumLines = Number.POSITIVE_INFINITY) {
+	if (!source || from >= to || maximumLines <= 0) {
+		return []
+	}
+	const lines: SourceLine[] = []
+	const pattern = /([^\r\n]*)(\r\n|\n|\r|$)/gu
+	let lineIndex = 0
+	let match: RegExpExecArray | null
+	while ((match = pattern.exec(source))) {
+		if (!match[1] && !match[2] && match.index === source.length) {
+			break
+		}
+		if (lineIndex >= to || lines.length >= maximumLines) {
+			break
+		}
+		if (lineIndex >= from) {
+			lines.push(createSourceLine(match[1]!, match[2]!, lineIndex + 1))
+		}
+		lineIndex++
+		if (!match[2]) {
+			break
+		}
+	}
+	return lines
+}
+
+function createSourceLine(text: string, rawEol: string, number: number): SourceLine {
+	const eol: SourceEol
+		= rawEol === '\r\n'
+			? 'crlf'
+			: rawEol === '\n'
+				? 'lf'
+				: rawEol === '\r'
+					? 'cr'
+					: 'none'
+	return {
+		number,
+		text,
+		eol,
+		changed: false,
+		segments: [{ text, changed: false }],
+	}
+}
+function cloneLine(line: SourceLine, changed: boolean): SourceLine {
+	return { ...line, changed, segments: [{ text: line.text, changed: false }] }
+}
+
+function summarizeLineEndingChange(before: SourceLine[], after: SourceLine[], normalizedEqual: boolean): SourceLineEndingChange | null {
+	if (
+		before.length === after.length
+		&& before.every(({ eol }, index) => eol === after[index]!.eol)
+	) {
+		return null
+	}
+	const left = lineEndingConvention(before)
+	const right = lineEndingConvention(after)
+	return left && right && (normalizedEqual || left !== right)
+		? { before: left, after: right }
+		: null
+}
+
+function lineEndingConvention(lines: SourceLine[]): SourceLineEnding | null {
+	const endings = new Set(lines
+		.map(({ eol }) => eol)
+		.filter((eol): eol is Exclude<SourceEol, 'none'> => eol !== 'none'))
+	return endings.size === 0
+		? null
+		: endings.size === 1
+			? [...endings][0]!
+			: 'mixed'
+}
+function normalize(source: string) {
+	return source.replace(/\r\n?|\n/gu, '\n')
+}
+
+function sourceLineCount(source: string) {
+	if (!source) {
+		return 0
+	}
+	let count = 1
+	for (let index = 0; index < source.length; index++) {
+		if (
+			source[index] === '\n'
+			|| (source[index] === '\r' && source[index + 1] !== '\n')
+		) {
+			count++
+		}
+	}
+	return count
+}
+function abortError() {
+	return new DOMException('Source comparison aborted', 'AbortError')
+}
+
+function checkAbort(signal?: AbortSignal) {
+	if (signal?.aborted) {
+		throw abortError()
+	}
+}

--- a/src/comparison/markdownSourceComparison.worker.ts
+++ b/src/comparison/markdownSourceComparison.worker.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { SourceComparisonWorkerRequest } from './markdownSourceComparisonProtocol.ts'
+
+import { compareMarkdownSourceLines } from './markdownSourceComparisonProtocol.ts'
+
+addEventListener('message', ({ data }: MessageEvent<SourceComparisonWorkerRequest>) => {
+	postMessage(compareMarkdownSourceLines(data))
+})

--- a/src/comparison/markdownSourceComparisonProtocol.ts
+++ b/src/comparison/markdownSourceComparisonProtocol.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Change } from 'diff'
+
+import { diffLines } from 'diff'
+
+export interface SourceComparisonWorkerRequest {
+	before: string
+	after: string
+	maximumEditLength: number
+	timeoutMilliseconds: number
+}
+
+export type SourceComparisonWorkerResponse = { status: 'ready', changes: Change[] } | { status: 'limited' }
+
+export function compareMarkdownSourceLines(request: SourceComparisonWorkerRequest): SourceComparisonWorkerResponse {
+	const changes = diffLines(request.before, request.after, {
+		stripTrailingCr: false,
+		maxEditLength: request.maximumEditLength,
+		timeout: request.timeoutMilliseconds,
+	})
+	return changes ? { status: 'ready', changes } : { status: 'limited' }
+}

--- a/src/comparison/markdownSourceDisplay.ts
+++ b/src/comparison/markdownSourceDisplay.ts
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const visibleControlNames: Readonly<Record<string, string>> = {
+	'\t': 'TAB',
+	'\u00AD': 'SHY',
+	'\u061C': 'ALM',
+	'\u0085': 'NEL',
+	'\u200B': 'ZWSP',
+	'\u200C': 'ZWNJ',
+	'\u200D': 'ZWJ',
+	'\u200E': 'LRM',
+	'\u200F': 'RLM',
+	'\u2060': 'WORD JOINER',
+	'\uFEFF': 'BOM',
+	'\u2028': 'LS',
+	'\u2029': 'PS',
+	'\u202A': 'LRE',
+	'\u202B': 'RLE',
+	'\u202C': 'PDF',
+	'\u202D': 'LRO',
+	'\u202E': 'RLO',
+	'\u2066': 'LRI',
+	'\u2067': 'RLI',
+	'\u2068': 'FSI',
+	'\u2069': 'PDI',
+}
+
+export const COMPLETE_SOURCE_DISPLAY_LIMITS = Object.freeze({
+	maximumInputCharactersPerSide: 1_000_000,
+	maximumVisibleCharactersPerSide: 1_000_000,
+	maximumVisibleCharactersPerLine: 20_000,
+})
+const LIMITS = COMPLETE_SOURCE_DISPLAY_LIMITS
+
+function sourcePrefix(value: string, maximumCharacters: number) {
+	let prefix = value.slice(0, Math.max(0, maximumCharacters))
+	const finalCodeUnit = prefix.charCodeAt(prefix.length - 1)
+	const nextCodeUnit = value.charCodeAt(prefix.length)
+	if (finalCodeUnit >= 0xD800 && finalCodeUnit <= 0xDBFF
+		&& nextCodeUnit >= 0xDC00 && nextCodeUnit <= 0xDFFF) {
+		prefix = prefix.slice(0, -1)
+	}
+	return prefix
+}
+
+function renderMarkdownSource(source: string, maximumCharacters: number, maximumLineCharacters = Number.POSITIVE_INFINITY) {
+	let visible = ''
+	let lineCharacters = 0
+	for (const character of source) {
+		const named = visibleControlNames[character]
+		const code = character.codePointAt(0)!
+		let rendered = character
+		if (named) {
+			rendered = `⟦${named}⟧`
+		} else if (character.length === 1 && code >= 0xD800 && code <= 0xDFFF) {
+			rendered = `⟦U+${code.toString(16).toUpperCase()}⟧`
+		} else if ((code < 0x20 && character !== '\n' && character !== '\r') || code === 0x7F) {
+			rendered = `⟦U+${code.toString(16).toUpperCase().padStart(4, '0')}⟧`
+		}
+		if (rendered.length > maximumCharacters - visible.length
+			|| (character !== '\n' && character !== '\r'
+				&& rendered.length > maximumLineCharacters - lineCharacters)) {
+			return { text: visible, complete: false }
+		}
+		visible += rendered
+		lineCharacters = character === '\n' || character === '\r'
+			? 0
+			: lineCharacters + rendered.length
+	}
+	return { text: visible, complete: true }
+}
+
+export function displayMarkdownSource(source: string, maximumCharacters = Number.POSITIVE_INFINITY) {
+	return renderMarkdownSource(source, maximumCharacters).text
+}
+
+export function displayBoundedMarkdownSource(source: string) {
+	const input = sourcePrefix(source, LIMITS.maximumInputCharactersPerSide)
+	const visible = renderMarkdownSource(
+		input,
+		LIMITS.maximumVisibleCharactersPerSide,
+		LIMITS.maximumVisibleCharactersPerLine,
+	)
+	return {
+		text: visible.text,
+		truncated: input.length < source.length || !visible.complete,
+	}
+}

--- a/src/components/CollaborativeEditor.vue
+++ b/src/components/CollaborativeEditor.vue
@@ -804,7 +804,7 @@ export default defineComponent({
 		},
 
 		async save() {
-			await this.saveService.save()
+			return await this.saveService.save()
 		},
 
 		async saveWhenDirty() {

--- a/src/components/ComparisonChangeList.vue
+++ b/src/components/ComparisonChangeList.vue
@@ -1,0 +1,474 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<nav
+		v-if="edits.length > PAGE_SIZE"
+		class="text-comparison__change-pages"
+		:aria-label="t('text', 'Change pages')">
+		<NcButton
+			type="button"
+			variant="tertiary"
+			:disabled="pageStart === 0"
+			@click="movePage(-1)">
+			{{ t('text', 'Previous') }}
+		</NcButton>
+		<span aria-live="polite">
+			{{
+				t('text', 'Showing changes {from}–{to} of {total}', {
+					from: pageStart + 1,
+					to: pageEnd,
+					total: edits.length,
+				})
+			}}
+		</span>
+		<NcButton
+			type="button"
+			variant="tertiary"
+			:disabled="pageEnd === edits.length"
+			@click="movePage(1)">
+			{{ t('text', 'Next') }}
+		</NcButton>
+	</nav>
+	<ol class="text-comparison__change-list">
+		<li v-for="section in sections" :key="section.id">
+			<h3 :id="`${listId}-${section.id}-heading`" class="section-heading">
+				<button
+					type="button"
+					class="text-comparison__section-toggle"
+					:aria-controls="`${listId}-${section.id}-group`"
+					:aria-expanded="!collapsed.has(section.id)"
+					:data-comparison-section="section.id"
+					@click="toggle(section.id)">
+					<span class="caret" aria-hidden="true">
+						{{ collapsed.has(section.id) ? '▸' : '▾' }}
+					</span>
+					<span class="section-title">
+						{{ section.title || t('text', 'Document start') }}
+					</span>
+					<span class="count">
+						{{ n('text', '%n change', '%n changes', section.edits.length) }}
+					</span>
+				</button>
+			</h3>
+			<ul
+				v-if="!collapsed.has(section.id)"
+				:id="`${listId}-${section.id}-group`"
+				class="rows"
+				:aria-labelledby="`${listId}-${section.id}-heading`">
+				<li v-for="item in section.records" :key="item.id">
+					<button
+						type="button"
+						class="text-comparison__change-item"
+						:aria-current="item.id === currentId ? 'true' : undefined"
+						:aria-label="item.accessibleLabel"
+						:data-comparison-select="item.id"
+						:data-operation-symbol="OPS[item.operation][0]"
+						@click="emit('select', item.id)">
+						<span class="text-comparison__change-item-content copy" :class="{ 'copy--label-first': item.textUnchanged }">
+							<span class="preview" dir="auto" aria-hidden="true">
+								<template v-for="(preview, index) in item.previews" :key="preview.id">
+									<span
+										v-if="index > 0"
+										class="separator">;
+									</span>
+									<ins v-if="preview.operation === 'insert'" class="text-comparison__preview-after">{{ preview.after }}</ins>
+									<del v-else-if="preview.operation === 'delete'" class="text-comparison__preview-before">{{ preview.before }}</del>
+									<template v-else-if="preview.textUnchanged">
+										{{ preview.before }}
+									</template>
+									<template v-else>
+										<del class="text-comparison__preview-before">{{
+											preview.before
+										}}</del>
+										<span class="arrow" aria-hidden="true">
+											→
+										</span>
+										<ins class="text-comparison__preview-after">{{
+											preview.after
+										}}</ins>
+									</template>
+								</template>
+							</span>
+							<span class="title">
+								<strong class="label">{{
+									item.label
+								}}</strong>
+								<span class="context">{{
+									item.context
+								}}</span>
+								<span
+									v-if="item.memberCount > 1"
+									class="badge">
+									{{
+										n('text', '%n edit', '%n edits', item.memberCount)
+									}}
+								</span>
+								<span v-if="item.block" class="badge" :aria-label=" t('text', 'Block-level change; fine inline detail is unavailable') ">
+									{{ t('text', 'Block-level') }}
+								</span>
+							</span>
+						</span>
+					</button>
+				</li>
+			</ul>
+		</li>
+	</ol>
+</template>
+
+<script setup lang="ts">
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonDescriptor as Descriptor, ComparisonEdit as Edit } from '../comparison/markdownComparisonTypes.ts'
+
+import { n, t } from '@nextcloud/l10n'
+import { computed, reactive, ref, useId, watch } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import { selectComparisonSignal as selectSignal, comparisonSignalLabel as signalLabel } from '../comparison/comparisonPresentation.ts'
+import { buildComparisonSections as buildSections } from '../comparison/comparisonSections.ts'
+
+const props = defineProps<{
+	edits: readonly Edit[]
+	currentId?: string
+	beforeDocument: Node
+	afterDocument: Node
+}>()
+const emit = defineEmits<{
+	select: [id: string]
+	currentLabel: [label: string]
+}>()
+const PAGE_SIZE = 80
+const PREVIEW_LABELS = {
+	'front-matter': () => t('text', 'Front matter changed'),
+	image: () => t('text', 'Image changed'),
+	mention: () => t('text', 'Mention changed'),
+	mathematics: () => t('text', 'Mathematics changed'),
+	'footnote-reference': () => t('text', 'Footnote changed'),
+	'horizontal-rule': () => t('text', 'Divider changed'),
+	'changed-content': () => t('text', 'Changed content'),
+}
+const CONTEXT = {
+	paragraph: () => t('text', 'Paragraph'),
+	heading: () => t('text', 'Heading'),
+	'list-item': () => t('text', 'List item'),
+	task: () => t('text', 'Task'),
+	table: () => t('text', 'Table'),
+	'table-row': () => t('text', 'Table row'),
+	'table-cell': () => t('text', 'Table cell'),
+	image: () => t('text', 'Image'),
+	'code-block': () => t('text', 'Code block'),
+	quote: () => t('text', 'Quote'),
+	callout: () => t('text', 'Callout'),
+	details: () => t('text', 'Details'),
+	footnote: () => t('text', 'Footnote'),
+	'footnote-reference': () => t('text', 'Footnote reference'),
+	'front-matter': () => t('text', 'Front matter'),
+	mathematics: () => t('text', 'Mathematics'),
+	mention: () => t('text', 'Mention'),
+	preview: () => t('text', 'Link preview'),
+	unknown: () => t('text', 'Changed content'),
+}
+const OPS = {
+	insert: ['+', () => t('text', 'Added')],
+	delete: ['−', () => t('text', 'Removed')],
+	replace: ['↔', () => t('text', 'Changed')],
+	move: ['↳', () => t('text', 'Moved')],
+} as const
+const collapsed = reactive(new Set<string>())
+const listId = useId()
+const pageStart = ref(pageFor(props.currentId))
+const pageEnd = computed(() => Math.min(pageStart.value + PAGE_SIZE, props.edits.length))
+const visibleEdits = computed(() => props.edits.slice(pageStart.value, pageEnd.value))
+const sections = computed(() => buildSections(
+	visibleEdits.value,
+	props.beforeDocument,
+	props.afterDocument,
+).map((section) => ({
+	...section,
+	records: section.edits.map((edit) => record(edit, section.title)),
+})))
+const records = computed(() => sections.value.flatMap(({ records: sectionRecords }) => sectionRecords))
+
+watch(
+	[records, () => props.currentId],
+	() => {
+		const current = records.value.find(({ id }) => id === props.currentId)
+		if (current) {
+			emit('currentLabel', current.label)
+		} else if (
+			!props.currentId
+			|| !props.edits.some(({ id }) => id === props.currentId)
+		) {
+			emit('currentLabel', '')
+		}
+	},
+	{ immediate: true },
+)
+watch([() => props.currentId, () => props.edits], ([id]) => {
+	pageStart.value = pageFor(id)
+	const section = sections.value.find(({ edits }) => edits.some((edit) => edit.id === id))
+	if (section) {
+		collapsed.delete(section.id)
+	}
+})
+
+function pageFor(id?: string) {
+	const index = id ? props.edits.findIndex((edit) => edit.id === id) : -1
+	return index < 0 ? 0 : Math.floor(index / PAGE_SIZE) * PAGE_SIZE
+}
+function movePage(offset: number) {
+	const maximum = Math.max(
+		0,
+		Math.floor((props.edits.length - 1) / PAGE_SIZE) * PAGE_SIZE,
+	)
+	pageStart.value = Math.min(
+		maximum,
+		Math.max(0, pageStart.value + offset * PAGE_SIZE),
+	)
+}
+function toggle(id: string) {
+	if (collapsed.has(id)) {
+		collapsed.delete(id)
+	} else {
+		collapsed.add(id)
+	}
+}
+function record(edit: Edit, sectionTitle: string) {
+	const descriptor = edit.primary
+	const previews = edit.descriptors.map((member) => {
+		let before = previewSide(member.preview.before)
+		let after = previewSide(member.preview.after)
+		const textUnchanged = before === after
+		if (member.operation === 'insert') {
+			after ||= t('text', 'Content added')
+		} else if (member.operation === 'delete') {
+			before ||= t('text', 'Content removed')
+		} else if (textUnchanged) {
+			before = after = before || t('text', 'Content changed')
+		} else {
+			before ||= t('text', 'No content')
+			after ||= t('text', 'No content')
+		}
+		return {
+			id: member.id,
+			operation: member.operation,
+			before,
+			after,
+			textUnchanged,
+			accessible: member.operation === 'insert'
+				? after
+				: member.operation === 'delete'
+					? before
+					: textUnchanged ? before : `${before} → ${after}`,
+		}
+	})
+	const preview = previews.map(({ accessible }) => accessible).join('; ')
+	const context = descriptorContext(descriptor, sectionTitle)
+	const block = edit.descriptors.some(({ detail }) => detail === 'block')
+	const label
+		= edit.kind === 'table-column'
+			? tableColumnLabel(descriptor)
+			: descriptorLabel(descriptor)
+	return {
+		id: edit.id,
+		operation: descriptor.operation,
+		block,
+		label,
+		context,
+		previews,
+		textUnchanged: previews.every(({ textUnchanged }) => textUnchanged),
+		memberCount: edit.descriptors.length,
+		accessibleLabel: [
+			operationLabel(descriptor.operation),
+			label,
+			context,
+			preview,
+			block ? t('text', 'Block-level') : '',
+		]
+			.filter(Boolean)
+			.join('. '),
+	}
+}
+function previewSide(atom: Descriptor['preview']['before']) {
+	if (!atom) {
+		return ''
+	}
+	if (atom.kind === 'text') {
+		return atom.text
+	}
+	return PREVIEW_LABELS[atom.node]()
+}
+function descriptorLabel(descriptor: Descriptor) {
+	if (descriptor.operation === 'move') {
+		return t('text', 'Moved section')
+	}
+	if (descriptor.coarseReason && descriptor.facets.includes('structure')) {
+		return t('text', 'Structure changed')
+	}
+	const signal = selectSignal(descriptor.signals)
+	const label = signal && signalLabel(signal)
+	if (label) {
+		return label
+	}
+	const context = contextType(descriptor)
+	if (descriptor.detail === 'block' && descriptor.operation === 'insert') {
+		return t('text', '{context} added', { context })
+	}
+	if (descriptor.detail === 'block' && descriptor.operation === 'delete') {
+		return t('text', '{context} removed', { context })
+	}
+	return descriptor.facets.includes('structure')
+		? t('text', 'Structure changed')
+		: t('text', '{context} changed', { context })
+}
+function tableColumnLabel(descriptor: Descriptor) {
+	return descriptor.operation === 'insert'
+		? t('text', 'Table column added')
+		: descriptor.operation === 'delete'
+			? t('text', 'Table column removed')
+			: t('text', 'Table column changed')
+}
+function descriptorContext(descriptor: Descriptor, sectionTitle: string) {
+	return sectionTitle
+		? t('text', 'Section: {section}', { section: sectionTitle })
+		: contextType(descriptor)
+}
+function contextType(descriptor: Descriptor) {
+	const code
+		= descriptor.operation === 'delete'
+			? descriptor.context.before?.code
+			: (descriptor.context.after?.code ?? descriptor.context.before?.code)
+	return CONTEXT[code ?? 'unknown']()
+}
+function operationLabel(operation: Descriptor['operation']) {
+	return OPS[operation][1]()
+}
+</script>
+
+<style scoped lang="scss">
+$g: var(--default-grid-baseline);
+$border: var(--color-border);
+$primary: var(--color-primary-element);
+
+.text-comparison {
+	&__change-pages {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: calc(2 * $g);
+		padding-block: calc(2 * $g);
+	}
+	&__change-list,
+	.rows {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+	.section-heading {
+		position: sticky;
+		top: 0;
+		z-index: 1;
+		margin: 0;
+		background: var(--color-main-background);
+	}
+	&__section-toggle,
+	&__change-item {
+		inline-size: 100%;
+		margin: 0 !important;
+		border: 0;
+		border-block-end: 1px solid $border;
+		border-radius: 0;
+		background: transparent;
+		text-align: start;
+	}
+	&__section-toggle {
+		display: flex;
+		align-items: center;
+		gap: calc(2 * $g);
+	}
+	.count {
+		margin-inline-start: auto;
+	}
+	&__change-item {
+		display: grid;
+		grid-template-columns: calc(6 * $g) minmax(0, 1fr) calc(3 * $g);
+		align-items: center;
+		column-gap: calc(2 * $g);
+		padding: calc(2 * $g);
+		&::before {
+			content: attr(data-operation-symbol);
+		}
+		&::after {
+			content: '›';
+		}
+		&[aria-current='true'] {
+			background: var(--color-primary-element-light);
+		}
+	}
+	&__section-toggle:focus-visible,
+	&__change-item:focus-visible {
+		outline: 2px solid $primary !important;
+		outline-offset: -2px;
+	}
+	.copy {
+		display: flex;
+		flex-direction: column;
+		gap: $g;
+		min-inline-size: 0;
+		overflow-wrap: anywhere;
+	}
+	.copy--label-first .preview {
+		order: 2;
+	}
+	.copy--label-first .title {
+		order: 1;
+	}
+	.preview {
+		min-inline-size: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	&__preview-before,
+	&__preview-after {
+		padding-inline: calc(0.5 * $g);
+	}
+	&__preview-before {
+		background: var(--color-error);
+		text-decoration: line-through;
+	}
+	&__preview-after {
+		background: var(--color-success);
+	}
+	.title {
+		display: flex;
+		align-items: center;
+		gap: calc(1.5 * $g);
+		min-inline-size: 0;
+		overflow: hidden;
+		white-space: nowrap;
+	}
+	.label {
+		flex: none;
+	}
+	.context {
+		min-inline-size: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.badge {
+		flex: none;
+	}
+}
+.text-comparison--single .preview {
+	white-space: normal;
+}
+.text-comparison--single .title {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) repeat(2, max-content);
+}
+.text-comparison--single .label {
+	grid-column: 1 / -1;
+}
+</style>

--- a/src/components/ComparisonEditorContent.vue
+++ b/src/components/ComparisonEditorContent.vue
@@ -1,0 +1,32 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<EditorContent
+		class="text-comparison__content"
+		role="document"
+		:editor="editor" />
+</template>
+
+<script setup lang="ts">
+import type { Plugin } from '@tiptap/pm/state'
+import type { Editor } from '@tiptap/vue-3'
+
+import { EditorContent } from '@tiptap/vue-3'
+import { nextTick, onMounted } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+const props = defineProps<{ editor: Editor, plugins: readonly Plugin[] }>()
+const emit = defineEmits<{ ready: [] }>()
+const editor = props.editor
+for (const plugin of props.plugins) {
+	editor.registerPlugin(plugin)
+}
+
+onMounted(async () => {
+	await nextTick()
+	emit('ready')
+})
+</script>

--- a/src/components/MarkdownContentComparison.vue
+++ b/src/components/MarkdownContentComparison.vue
@@ -1,0 +1,769 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<section
+		ref="root"
+		class="text-comparison"
+		:class="`text-comparison--${layoutMode}`"
+		:aria-label="t('text', 'Version comparison')">
+		<p class="text-comparison__sr-only" aria-live="polite" aria-atomic="true">
+			{{ announcement }}
+		</p>
+
+		<MarkdownSourceFallback v-if="failure" :beforeContent="beforeContent" :afterContent="afterContent" />
+		<template v-else>
+			<header class="comparison-header">
+				<div class="toolbar">
+					<div class="view-tabs" role="tablist" :aria-label="t('text', 'Comparison view')">
+						<button
+							v-for="tab in tabs"
+							:key="tab"
+							:ref="(element) => setTabRef(tab, element)"
+							type="button"
+							role="tab"
+							:aria-selected="view === tab"
+							:tabindex="view === tab ? 0 : -1"
+							@click="setView(tab)"
+							@keydown="onViewTabKeydown($event, tab)">
+							{{ tabLabels[tab] }}
+						</button>
+					</div>
+					<div v-if="view === 'documents' && activeIds.length" class="navigation" :aria-label="t('text', 'Change navigation')">
+						<NcButton
+							type="button"
+							variant="tertiary"
+							:aria-label="t('text', 'Previous change')"
+							:disabled="activeIds.length < 2"
+							@click="move(-1)">
+							{{ t('text', 'Previous') }}
+						</NcButton>
+						<span class="status" aria-hidden="true">{{
+							announcement
+						}}</span>
+						<NcButton
+							type="button"
+							variant="tertiary"
+							:aria-label="t('text', 'Next change')"
+							:disabled="activeIds.length < 2"
+							@click="move(1)">
+							{{ t('text', 'Next') }}
+						</NcButton>
+					</div>
+				</div>
+				<div v-if="view === 'changes'" class="changes-controls">
+					<p class="changes-count">
+						{{ n('text', '%n change', '%n changes', activeEdits.length) }}
+					</p>
+					<label v-if="formatCount" class="filter">
+						<input v-model="hideFormatting" type="checkbox">
+						<span>{{ t('text', 'Hide formatting-only changes') }}</span>
+						<small v-if="hideFormatting">{{
+							t('text', '{count} hidden', { count: formatCount })
+						}}</small>
+					</label>
+				</div>
+				<div v-if="view === 'documents' && hideFormatting && formatCount" class="hidden-formatting" role="status">
+					{{
+						n(
+							'text',
+							'%n formatting change hidden',
+							'%n formatting changes hidden',
+							formatCount,
+						)
+					}}
+					<NcButton type="button" variant="tertiary" @click="hideFormatting = false">
+						{{ t('text', 'Show') }}
+					</NcButton>
+				</div>
+			</header>
+
+			<section v-show="view === 'changes'" role="tabpanel" class="text-comparison__changes">
+				<div v-if="activeEdits.length" class="changes-content">
+					<ComparisonChangeList
+						:edits="activeEdits"
+						:currentId="currentId || undefined"
+						:beforeDocument="editors.before!.state.doc"
+						:afterDocument="editors.after!.state.doc"
+						@select="selectEdit"
+						@currentLabel="currentLabel = $event" />
+				</div>
+				<div v-else-if="model.edits.length" class="empty" role="status">
+					{{
+						t(
+							'text',
+							'All rendered changes are formatting-only and hidden by the current filter.',
+						)
+					}}
+				</div>
+				<div v-else-if="rawDifferent" class="empty" role="status">
+					<p>
+						{{
+							t('text', 'No rendered differences — Markdown syntax differs.')
+						}}
+					</p>
+					<NcButton
+						data-comparison-empty-action
+						type="button"
+						variant="tertiary"
+						@click="setView('source')">
+						{{ t('text', 'Open Markdown source') }}
+					</NcButton>
+				</div>
+				<p v-else class="empty" role="status">
+					{{ t('text', 'No differences.') }}
+				</p>
+			</section>
+
+			<section
+				v-if="showDocuments"
+				v-show="view === 'documents'"
+				role="tabpanel"
+				class="text-comparison__documents">
+				<div
+					v-if="layoutMode === 'single'"
+					class="side-tabs"
+					role="tablist"
+					:aria-label="t('text', 'Version to display')">
+					<button
+						v-for="side in sides"
+						:key="side"
+						:ref="(element) => setSideElement(side, 'tab', element)"
+						role="tab"
+						type="button"
+						:aria-selected="activeSide === side"
+						:tabindex="activeSide === side ? 0 : -1"
+						@click="setSide(side)"
+						@keydown="onSideKeydown">
+						{{ sideLabels[side] }}
+					</button>
+				</div>
+				<div class="text-comparison__document-grid">
+					<article
+						v-for="side in sides"
+						v-show="layoutMode === 'paired' || activeSide === side"
+						:key="side"
+						:ref="(element) => setSideElement(side, 'pane', element)"
+						class="text-comparison__document"
+						:class="`text-comparison__document--${side}`"
+						:aria-label="sideLabels[side]">
+						<header>
+							<div class="document-heading">
+								<span aria-hidden="true">{{ side === 'before' ? '−' : '+' }}</span>
+								<h2>{{ sideLabels[side] }}</h2>
+							</div>
+							<span class="document-legend" aria-hidden="true">{{ sideLegends[side] }}</span>
+						</header>
+						<div
+							:ref="(element) => setSideElement(side, 'scroller', element)"
+							class="text-comparison__document-scroller">
+							<ComparisonEditorContent :editor="editors[side]!" :plugins="plugins[side]" @ready="refreshDocuments" />
+						</div>
+					</article>
+				</div>
+			</section>
+
+			<section v-if="view === 'source'" role="tabpanel" class="source">
+				<p class="source-explanation">
+					{{
+						t(
+							'text',
+							'Source compares literal Markdown, so its change groups can differ from rendered changes.',
+						)
+					}}
+				</p>
+				<MarkdownSourceFallback v-if="!SourceView" :beforeContent="beforeContent" :afterContent="afterContent" />
+				<component
+					:is="SourceView"
+					v-else
+					:beforeContent="beforeContent"
+					:afterContent="afterContent"
+					:layoutMode="layoutMode" />
+			</section>
+		</template>
+	</section>
+</template>
+
+<script setup lang="ts">
+import type { Component, ComponentPublicInstance as Public } from 'vue'
+import type { ComparisonEdit as Edit, ComparisonSide as Side } from '../comparison/markdownComparisonTypes.ts'
+
+import { getCurrentUser } from '@nextcloud/auth'
+import { n, t } from '@nextcloud/l10n'
+import { computed, markRaw, nextTick, onBeforeUnmount, onErrorCaptured, onMounted, provide, ref, shallowRef, watch } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import ComparisonChangeList from './ComparisonChangeList.vue'
+import ComparisonEditorContent from './ComparisonEditorContent.vue'
+import MarkdownSourceFallback from './MarkdownSourceFallback.vue'
+import { currentIdAfterFilter, currentOrdinal, isPureFormatting, locateComparisonTarget as locateTarget, moveCurrentId, comparisonScrollBehavior as scrollBehavior, comparisonSideForKey as sideForKey } from '../comparison/comparisonNavigation.ts'
+import { createComparisonEditor as createEditor } from '../comparison/createComparisonEditor.ts'
+import { createComparisonDecorationPlugin as createDecoration, createMarkdownComparisonModel as createModel, exceedsRenderedComparisonLimit as exceedsLimit, ComparisonModelLimitError as ModelLimit, setComparisonDecorationState as setDecorations } from '../comparison/markdownComparison.ts'
+import AttachmentResolver from '../services/AttachmentResolver.js'
+import { ATTACHMENT_RESOLVER, EDITOR_UPLOAD } from './Editor.provider.ts'
+
+const props = defineProps<{
+	beforeContent: string
+	afterContent: string
+	fileId?: number
+	filePath?: string
+	shareToken?: string
+	noLazyImages?: boolean
+	openLinkHandler?: (href: string) => void
+}>()
+const emit = defineEmits<{ ready: [] }>()
+type View = 'changes' | 'documents' | 'source'
+const tabs: readonly View[] = ['changes', 'documents', 'source']
+const sides: readonly Side[] = ['before', 'after']
+const tabLabels = { changes: t('text', 'Changes'), documents: t('text', 'Full documents'), source: t('text', 'Markdown source') }
+const sideLabels = { before: t('text', 'Before'), after: t('text', 'After') }
+const sideLegends = { before: t('text', 'Removed'), after: t('text', 'Added') }
+const root = ref<HTMLElement | null>(null)
+const sideElements: Record<Side, Record<'pane' | 'scroller' | 'tab', HTMLElement | null>> = {
+	before: { pane: null, scroller: null, tab: null },
+	after: { pane: null, scroller: null, tab: null },
+}
+const tabRefs = new Map<View, HTMLButtonElement>()
+const layoutMode = ref<'paired' | 'single'>('paired')
+const activeSide = ref<Side>('before')
+const view = ref<View>('changes')
+const showDocuments = ref(false)
+const hideFormatting = ref(false)
+const currentId = ref<string | null>(null)
+const currentLabel = ref('')
+const failure = ref(false)
+const SourceView = shallowRef<Component | null>(null)
+let observer: ResizeObserver | null = null
+let didReady = false
+let destroyed = false
+
+const resolver = props.fileId
+	? new AttachmentResolver({
+			currentDirectory:
+				props.filePath?.split('/').slice(0, -1).join('/') ?? '/',
+			fileId: props.fileId,
+			session: undefined,
+			shareToken: props.shareToken,
+			user: getCurrentUser(),
+		})
+	: {
+			async resolve(src: string) {
+				return {
+					fullUrl: src,
+					isImage: true,
+					name: src.split('/').pop(),
+					previewUrl: src,
+				}
+			},
+		}
+provide(ATTACHMENT_RESOLVER, shallowRef(resolver))
+provide(EDITOR_UPLOAD, false)
+
+type ComparisonEditor = ReturnType<typeof createEditor>
+type Decoration = ReturnType<typeof createDecoration>
+const editors: Record<Side, ComparisonEditor | null> = { before: null, after: null }
+const plugins: Record<Side, Decoration['plugin'][]> = { before: [], after: [] }
+const pluginKeys: Record<Side, Decoration['key'] | null> = { before: null, after: null }
+let model = { edits: [] as readonly Edit[] }
+
+try {
+	if (exceedsLimit(props.beforeContent, props.afterContent)) {
+		throw new ModelLimit()
+	}
+	editors.before = createEditor(props.beforeContent, {
+		ariaLabel: t('text', 'Before document'),
+		filePath: props.filePath,
+		noLazyImages: props.noLazyImages,
+		openLink: props.openLinkHandler,
+	})
+	editors.after = createEditor(props.afterContent, {
+		ariaLabel: t('text', 'After document'),
+		filePath: props.filePath,
+		noLazyImages: props.noLazyImages,
+		openLink: props.openLinkHandler,
+		schema: editors.before.schema,
+	})
+	model = createModel(
+		editors.before.state.doc,
+		editors.after.state.doc,
+	)
+	currentId.value = model.edits[0]?.id ?? null
+	const descriptors = model.edits.flatMap(({ descriptors }) => descriptors)
+	const initial = decorationSelection(model.edits, currentId.value)
+	for (const side of sides) {
+		const decoration = createDecoration(descriptors, side, t('text', 'Changed content'), initial)
+		plugins[side] = [decoration.plugin]
+		pluginKeys[side] = decoration.key
+	}
+} catch {
+	activateFallback()
+}
+const activeEdits = computed(() => model.edits.filter((edit) => !hideFormatting.value || !isPureFormatting(edit)))
+const activeIds = computed(() => activeEdits.value.map(({ id }) => id))
+const formatCount = computed(() => model.edits.filter(isPureFormatting).length)
+const rawDifferent = computed(() => props.beforeContent !== props.afterContent)
+const announcement = computed(() => failure.value
+	? t('text', 'Detailed rendered comparison unavailable')
+	: activeIds.value.length
+		? t('text', 'Change {current} of {total}: {label}', {
+				current: currentOrdinal(activeIds.value, currentId.value),
+				total: activeIds.value.length,
+				label: currentLabel.value,
+			})
+		: t('text', 'No rendered changes'))
+
+watch(activeIds, (ids) => {
+	currentId.value = currentIdAfterFilter(
+		model.edits,
+		ids,
+		currentId.value,
+	)
+	updateDecorations()
+})
+watch(currentId, refreshDocuments)
+watch(view, (next) => {
+	if (next === 'source' && !SourceView.value) {
+		loadSource()
+	}
+})
+
+onErrorCaptured(() => {
+	activateFallback()
+	nextTick(ready)
+	return false
+})
+onMounted(() => {
+	if (typeof ResizeObserver !== 'undefined') {
+		observer = new ResizeObserver(([entry]) => {
+			const nextLayout
+				= (entry?.contentRect.width ?? root.value?.clientWidth ?? 760) < 760
+					? 'single'
+					: 'paired'
+			if (nextLayout === layoutMode.value) {
+				return
+			}
+			layoutMode.value = nextLayout
+			locateCurrent(true)
+		})
+	}
+	if (root.value) {
+		observer?.observe(root.value)
+	}
+	ready()
+})
+onBeforeUnmount(() => {
+	destroyed = true
+	observer?.disconnect()
+	observer = null
+	destroyEditors()
+})
+
+function decorationSelection(edits: readonly Edit[], current: string | null) {
+	const activeIds = edits.flatMap(({ descriptors }) => descriptors.map(({ id }) => id))
+	const selected = edits.find(({ id }) => id === current)
+	return {
+		activeIds,
+		currentIds: selected?.descriptors.map(({ id }) => id) ?? [],
+	}
+}
+function updateDecorations() {
+	if (
+		sides.some((side) => !editors[side] || !pluginKeys[side] || editors[side]?.isDestroyed)
+	) {
+		return
+	}
+	const selection = decorationSelection(activeEdits.value, currentId.value)
+	for (const side of sides) {
+		setDecorations(editors[side]!, pluginKeys[side]!, selection)
+	}
+}
+function refreshDocuments() {
+	updateDecorations()
+	locateCurrent(true)
+}
+function selectEdit(id: string) {
+	currentId.value = id
+	if (!isPureFormatting(model.edits.find((edit) => edit.id === id)!)) {
+		setView('documents')
+	}
+}
+function move(offset: number) {
+	currentId.value = moveCurrentId(
+		activeIds.value,
+		currentId.value,
+		offset,
+	)
+}
+function locateCurrent(selectVisibleSide = false) {
+	const edit = model.edits.find(({ id }) => id === currentId.value)
+	if (!edit) {
+		return
+	}
+	if (selectVisibleSide
+		&& layoutMode.value === 'single'
+		&& edit.descriptors.every((descriptor) => descriptor[activeSide.value].from === descriptor[activeSide.value].to)) {
+		const other = activeSide.value === 'before' ? 'after' : 'before'
+		if (edit.descriptors.some((descriptor) => descriptor[other].from !== descriptor[other].to)) {
+			activeSide.value = other
+		}
+	}
+	nextTick(() => {
+		for (const side of ['before', 'after'] as const) {
+			const editor = editors[side]
+			const { pane, scroller } = sideElements[side]
+			const range = edit.primary[side]
+			locateTarget(
+				pane,
+				scroller,
+				edit.primary.id,
+				scrollBehavior(),
+				() => {
+					if (!editor || editor.isDestroyed) {
+						return null
+					}
+					const rect = editor.view.coordsAtPos(range.from)
+					return { top: rect.top, height: Math.max(1, rect.bottom - rect.top) }
+				},
+			)
+		}
+	})
+}
+function ready() {
+	if (!didReady && !destroyed) {
+		didReady = true
+		emit('ready')
+	}
+}
+function activateFallback() {
+	failure.value = true
+	destroyEditors()
+}
+function destroyEditors() {
+	for (const side of sides) {
+		editors[side]?.destroy()
+		editors[side] = null
+	}
+}
+async function loadSource() {
+	try {
+		SourceView.value = markRaw((await import('./MarkdownSourceComparison.vue')).default)
+	} catch {
+		SourceView.value = null
+	}
+}
+function setView(next: View) {
+	if (next === 'documents') {
+		showDocuments.value = true
+		locateCurrent(true)
+	}
+	view.value = next
+	nextTick(() => tabRefs.get(next)?.focus())
+}
+function setSide(side: Side) {
+	activeSide.value = side
+	locateCurrent()
+	nextTick(() => sideElements[side].tab?.focus())
+}
+function setSideElement(side: Side, key: 'pane' | 'scroller' | 'tab', element: Element | Public | null) {
+	sideElements[side][key] = element instanceof HTMLElement ? element : null
+}
+function setTabRef(tab: View, element: Element | Public | null) {
+	if (element instanceof HTMLButtonElement) {
+		tabRefs.set(tab, element)
+	}
+}
+function onViewTabKeydown(event: KeyboardEvent, tab: View) {
+	const index = tabs.indexOf(tab)
+	const direction = sideForKey(event.key)
+	if (!direction) {
+		return
+	}
+	event.preventDefault()
+	const next = event.key === 'Home'
+		? 0
+		: event.key === 'End'
+			? tabs.length - 1
+			: (index + (direction === 'before' ? -1 : 1) + tabs.length) % tabs.length
+	setView(tabs[next]!)
+}
+function onSideKeydown(event: KeyboardEvent) {
+	const side = sideForKey(event.key)
+	if (side) {
+		event.preventDefault()
+		setSide(side)
+	}
+}
+</script>
+
+<style lang="scss">
+@use './../css/prosemirror.scss';
+
+$g: var(--default-grid-baseline);
+$border: var(--color-border);
+$primary: var(--color-primary-element);
+
+.text-comparison-root,
+.text-comparison {
+	display: flex;
+	flex: 1;
+	min-inline-size: 0;
+	block-size: 100%;
+	min-block-size: 0;
+	overflow: hidden;
+}
+.text-comparison {
+	flex-direction: column;
+	.view-tabs,
+	.side-tabs {
+		display: flex;
+		gap: calc(2 * $g);
+	}
+	.toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: calc(2 * $g);
+		border-block-end: 1px solid $border;
+	}
+	.navigation {
+		display: grid;
+		align-items: center;
+		grid-template-columns: auto minmax(10rem, 1fr) auto;
+		gap: $g;
+	}
+	.status,
+	.changes-count,
+	.empty p,
+	.source-explanation {
+		margin: 0;
+	}
+	.status {
+		text-align: center;
+	}
+	.view-tabs,
+	.side-tabs {
+		button[role='tab'] {
+			margin: 0 !important;
+			border: 0 !important;
+			border-block-end: 2px solid transparent !important;
+			border-radius: 0 !important;
+			background: transparent !important;
+			&:focus-visible {
+				box-shadow: none !important;
+				outline: 2px solid $primary !important;
+				outline-offset: -2px;
+			}
+			&[aria-selected='true'] {
+				border-block-end-color: $primary !important;
+				font-weight: 700;
+			}
+		}
+	}
+	.changes-controls,
+	.changes-content {
+		box-sizing: border-box;
+		inline-size: min(calc(100% - 16px), 1040px);
+		margin-inline: auto;
+	}
+	.changes-controls {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: calc(2 * $g);
+		flex-wrap: wrap;
+		padding-block: calc(2 * $g);
+	}
+	.changes-count,
+	.filter,
+	.hidden-formatting,
+	.source-explanation {
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+	}
+	.filter,
+	.hidden-formatting {
+		display: flex;
+		align-items: center;
+		gap: calc(1.5 * $g);
+	}
+	.hidden-formatting {
+		justify-content: flex-end;
+		padding: $g calc(3 * $g);
+	}
+	&__changes {
+		flex: 1;
+		min-block-size: 0;
+		overflow: auto;
+	}
+	.changes-content {
+		padding-block-end: calc(8 * $g);
+	}
+	.empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: calc(3 * $g);
+		min-block-size: calc(40 * $g);
+		padding: calc(6 * $g);
+		text-align: center;
+	}
+	&__documents,
+	&__document,
+	.source {
+		display: flex;
+		flex-direction: column;
+		min-block-size: 0;
+		overflow: hidden;
+	}
+	&__documents,
+	.source {
+		flex: 1;
+	}
+	.side-tabs {
+		flex: none;
+		inline-size: fit-content;
+		margin: $g auto;
+	}
+	&__document-grid {
+		display: grid;
+		flex: 1;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		min-block-size: 0;
+		overflow: hidden;
+	}
+	&__document {
+		min-inline-size: 0;
+		> header {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: calc(2 * $g);
+			padding: calc(2 * $g) calc(4 * $g);
+			border-block-end: 1px solid $border;
+			background: var(--color-main-background);
+			flex-wrap: wrap;
+		}
+		.document-heading {
+			display: flex;
+			align-items: center;
+			gap: calc(1.5 * $g);
+			min-inline-size: 0;
+			h2 {
+				margin: 0;
+				font-size: var(--default-font-size);
+				font-weight: var(--font-weight-heading);
+				line-height: var(--default-line-height);
+			}
+			span {
+				inline-size: calc(4 * $g);
+				font-weight: var(--font-weight-heading);
+				line-height: 1;
+				text-align: center;
+			}
+		}
+		.document-legend {
+			margin-inline-start: auto;
+			color: var(--color-text-maxcontrast);
+			font-size: var(--font-size-small);
+			font-weight: var(--font-weight-element);
+			white-space: nowrap;
+		}
+		& + & {
+			border-inline-start: 1px solid $border;
+		}
+	}
+	&__document--before .document-heading > span { color: var(--color-error-text); }
+	&__document--after .document-heading > span { color: var(--color-success-text); }
+	&__document-scroller {
+		flex: 1;
+		min-block-size: 0;
+		padding-inline: calc(4 * $g);
+		overflow: auto;
+	}
+	&__content .ProseMirror {
+		inline-size: auto;
+		min-inline-size: 0;
+		min-block-size: 0;
+		padding: calc(3 * $g) calc(1.5 * $g) calc(9 * $g);
+		border: 0;
+		.text-comparison-change--removed {
+			--comparison-color: var(--color-error);
+			background: var(--color-error-hover);
+			text-decoration: line-through;
+		}
+		.text-comparison-change--added {
+			--comparison-color: var(--color-success);
+			background: var(--color-success-hover);
+			text-decoration: underline;
+		}
+		.text-comparison-change--formatting {
+			--comparison-color: var(--color-primary-element);
+			background: var(--color-primary-element-light);
+		}
+		.text-comparison-change--attribute {
+			box-shadow: inset 0 -2px var(--color-warning);
+		}
+		.text-comparison-change--move {
+			--comparison-color: var(--color-element-info);
+			box-shadow: inset 3px 0 var(--color-element-info);
+		}
+		.text-comparison-change--block {
+			box-shadow: inset 0 0 0 2px var(--color-warning);
+		}
+		.text-comparison-change--current {
+			outline: 2px solid $primary;
+			outline-offset: 2px;
+		}
+		[data-node-view-wrapper].text-comparison-change,
+		tr.text-comparison-change {
+			box-shadow: inset 0 0 0 3px var(--comparison-color, var(--color-warning));
+			&.text-comparison-change--current {
+				box-shadow: inset 0 0 0 4px $primary;
+			}
+		}
+	}
+	&__sr-only {
+		position: absolute;
+		inline-size: 1px;
+		block-size: 1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+	}
+	.source-explanation {
+		padding: calc(2 * $g) calc(3 * $g) 0;
+	}
+	&--single {
+		.toolbar {
+			flex-wrap: wrap;
+		}
+		.view-tabs {
+			flex: 1;
+		}
+		.view-tabs button {
+			flex: 1;
+		}
+		.navigation {
+			flex: 0 0 100%;
+			grid-template-columns: auto minmax(0, 1fr) auto;
+			inline-size: 100%;
+		}
+		.status { min-inline-size: 0; }
+		.text-comparison__document-grid {
+			display: block;
+		}
+		.text-comparison__document {
+			block-size: 100%;
+			border-inline-start: 0;
+		}
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.text-comparison * {
+		scroll-behavior: auto !important;
+		transition: none !important;
+	}
+}
+</style>

--- a/src/components/MarkdownSourceComparison.vue
+++ b/src/components/MarkdownSourceComparison.vue
@@ -1,0 +1,527 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<section ref="root" class="text-source-comparison" :aria-label="t('text', 'Markdown source comparison')">
+		<div v-if="loading" class="text-source-comparison__message" role="status">
+			{{ t('text', 'Loading Markdown source differences…') }}
+		</div>
+		<div v-else-if="error" class="text-source-comparison__message" role="alert">
+			<p>{{ t('text', 'Could not load Markdown source differences.') }}</p>
+			<NcButton type="button" variant="primary" @click="load">
+				{{ t('text', 'Retry') }}
+			</NcButton>
+		</div>
+		<div
+			v-else-if="model?.status === 'limited'"
+			data-source-limited
+			class="text-source-comparison__message"
+			role="status">
+			{{
+				t(
+					'text',
+					'Detailed source differences exceeded the safe processing limit.',
+				)
+			}}
+		</div>
+
+		<MarkdownSourceFallback v-if="model?.status !== 'ready'" :beforeContent="beforeContent" :afterContent="afterContent" />
+
+		<template v-else>
+			<header class="text-source-comparison__toolbar">
+				<p v-if="model.lineEndingChange" data-source-line-ending-change>
+					{{
+						t(
+							'text',
+							'Line endings changed: {before} → {after}',
+							model.lineEndingChange,
+						)
+					}}
+				</p>
+				<div v-if="model.hunks.length" class="text-source-comparison__navigation">
+					<NcButton
+						type="button"
+						variant="tertiary"
+						:disabled="model.hunks.length < 2"
+						@click="move(-1)">
+						{{ t('text', 'Previous') }}
+					</NcButton>
+					<p aria-live="polite" aria-atomic="true">
+						{{
+							t('text', 'Source change {current} of {total}', {
+								current: currentIndex + 1,
+								total: model.hunks.length,
+							})
+						}}
+					</p>
+					<NcButton
+						type="button"
+						variant="tertiary"
+						:disabled="model.hunks.length < 2"
+						@click="move(1)">
+						{{ t('text', 'Next') }}
+					</NcButton>
+				</div>
+				<div
+					v-if="layoutMode === 'single'"
+					class="text-source-comparison__side-tabs"
+					role="tablist"
+					:aria-label="t('text', 'Source version to display')">
+					<button
+						v-for="side in sides"
+						:key="side"
+						:ref="(element) => setTab(side, element)"
+						role="tab"
+						type="button"
+						:aria-selected="activeSide === side"
+						:tabindex="activeSide === side ? 0 : -1"
+						@click="setSide(side)"
+						@keydown="onTabKeydown">
+						{{ sideLabels[side] }}
+					</button>
+				</div>
+			</header>
+			<div class="text-source-comparison__side-headings">
+				<h2
+					v-for="side in sides"
+					:key="side"
+					:data-source-side="side"
+					:hidden="layoutMode === 'single' && activeSide !== side">
+					{{ sideLabels[side] }}
+				</h2>
+			</div>
+
+			<div class="text-source-comparison__hunks">
+				<template v-for="(slot, index) in slots" :key="`slot-${index}`">
+					<div v-if="slot.gap" class="text-source-comparison__gap">
+						<NcButton
+							data-source-gap-toggle
+							type="button"
+							variant="tertiary"
+							:aria-expanded="Boolean(gapRows(slot.gap))"
+							@click="toggleGap(slot.gap)">
+							{{
+								gapRows(slot.gap)
+									? t('text', 'Hide unchanged lines')
+									: t('text', 'Show {count} unchanged lines', {
+										count: slot.gap.count,
+									})
+							}}
+						</NcButton>
+						<div v-if="gapRows(slot.gap)">
+							<SourceRow
+								v-for="(gapRow, rowIndex) in gapRows(slot.gap)"
+								:key="rowIndex"
+								:row="gapRow"
+								:layoutMode="layoutMode"
+								:activeSide="activeSide" />
+						</div>
+						<NcButton
+							v-if="canShowMore(slot.gap)"
+							data-source-gap-more
+							type="button"
+							variant="tertiary"
+							@click="showMoreGap(slot.gap)">
+							{{ t('text', 'Show more unchanged lines') }}
+						</NcButton>
+						<p v-else-if="isGapLimited(slot.gap)" data-source-gap-limited role="status">
+							{{
+								t(
+									'text',
+									'Additional unchanged lines are hidden to keep the comparison responsive.',
+								)
+							}}
+						</p>
+					</div>
+					<section
+						v-if="slot.hunk"
+						class="text-source-comparison__hunk"
+						:data-source-hunk="slot.hunk.id"
+						:class="{ 'text-source-comparison__hunk--current': index === currentIndex }">
+						<h3 class="text-source-comparison__hunk-title">
+							<button type="button" :aria-current="index === currentIndex ? 'true' : undefined" @click="currentId = slot.hunk.id">
+								{{
+									t('text', 'Lines {before} / {after}', {
+										before: slot.hunk.beforeStart,
+										after: slot.hunk.afterStart,
+									})
+								}}
+							</button>
+						</h3>
+						<SourceRow
+							v-for="(hunkRow, rowIndex) in slot.hunk.rows"
+							:key="rowIndex"
+							:row="hunkRow"
+							:layoutMode="layoutMode"
+							:activeSide="activeSide" />
+					</section>
+				</template>
+			</div>
+		</template>
+	</section>
+</template>
+
+<script setup lang="ts">
+import type { ComponentPublicInstance as Public } from 'vue'
+import type { SourceDiffGap as Gap, SourceGapMaterializer as Materializer, SourceDiffModel as Model, SourceDiffRow as Row } from '../comparison/markdownSourceComparison.ts'
+
+import { t } from '@nextcloud/l10n'
+import { computed, defineComponent, h, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import MarkdownSourceFallback from './MarkdownSourceFallback.vue'
+import { comparisonScrollBehavior as scrollBehavior, comparisonSideForKey as sideForKey } from '../comparison/comparisonNavigation.ts'
+import { displayMarkdownSource as display } from '../comparison/markdownSourceDisplay.ts'
+
+const props = defineProps<{
+	beforeContent: string
+	afterContent: string
+	layoutMode: 'paired' | 'single'
+}>()
+type Side = 'before' | 'after'
+const sides: readonly Side[] = ['before', 'after']
+const sideLabels = { before: t('text', 'Before'), after: t('text', 'After') }
+const loading = ref(true)
+const error = ref<unknown>(null)
+const model = ref<Model | null>(null)
+const currentId = ref<string | null>(null)
+const activeSide = ref<Side>('before')
+const rowsByGap = reactive(new Map<string, readonly Row[]>())
+const root = ref<HTMLElement | null>(null)
+const tabs: Record<Side, HTMLButtonElement | null> = { before: null, after: null }
+let controller: AbortController | null = null
+let generation = 0
+let materialize: Materializer | null = null
+let rowLimit = 0
+
+const currentIndex = computed(() => model.value?.status === 'ready'
+	? Math.max(
+			0,
+			model.value.hunks.findIndex(({ id }) => id === currentId.value),
+		)
+	: 0)
+const slots = computed(() => {
+	if (model.value?.status !== 'ready') {
+		return []
+	}
+	const gaps = new Map(model.value.gaps.map((gap) => [gap.slot, gap]))
+	return [...model.value.hunks, null].map((hunk, index) => ({ hunk, gap: gaps.get(index) }))
+})
+const SourceRow = defineComponent({
+	props: {
+		row: { type: Object as () => Row, required: true },
+		layoutMode: { type: String as () => 'paired' | 'single', required: true },
+		activeSide: { type: String as () => Side, required: true },
+	},
+
+	setup(rowProps) {
+		const line = (value: Row[Side], side: Side) => {
+			const operation = value?.changed ? (side === 'before' ? 'removed' : 'added') : undefined
+			const trailing = value?.text.match(/ +$/)?.[0].length ?? 0
+			const showEol = rowProps.row.before && rowProps.row.after
+				&& rowProps.row.before.eol !== rowProps.row.after.eol
+			return h('div', {
+				class: ['text-source-comparison__line', operation && `text-source-comparison__line--${operation}`],
+				hidden: rowProps.layoutMode === 'single' && rowProps.activeSide !== side,
+				'aria-label': operation && t('text', operation === 'removed' ? 'Removed line {line}' : 'Added line {line}', { line: value!.number }),
+				'data-source-operation': operation,
+			}, value
+				? [
+						operation ? h('span', { 'aria-hidden': 'true', 'data-source-cue': '' }, operation === 'removed' ? '−' : '+') : null,
+						h('span', { class: 'text-source-comparison__line-number', 'aria-hidden': 'true' }, String(value.number)),
+						h('code', { dir: 'auto' }, value.segments.map((segment) => h('bdi', {
+							class: segment.changed ? 'text-source-comparison__segment--changed' : undefined,
+						}, display(segment.text)))),
+						showEol && value.eol !== 'none' ? h('span', { class: 'text-source-comparison__annotation', 'data-source-eol': value.eol }, `⟦${value.eol.toUpperCase()}⟧`) : null,
+						trailing ? h('span', { class: 'text-source-comparison__annotation', 'data-source-trailing': trailing }, t('text', '{count} trailing spaces', { count: trailing }).toUpperCase()) : null,
+						value.eol === 'none' ? h('span', { class: 'text-source-comparison__annotation' }, t('text', 'No newline at end of file')) : null,
+					]
+				: [])
+		}
+		return () => h('div', {
+			class: ['text-source-comparison__row', rowProps.layoutMode === 'single' && 'text-source-comparison__row--single'],
+		}, [
+			line(rowProps.row.before, 'before'),
+			line(rowProps.row.after, 'after'),
+		])
+	},
+})
+
+async function load() {
+	const request = ++generation
+	controller?.abort()
+	controller = new AbortController()
+	loading.value = true
+	error.value = null
+	model.value = null
+	rowsByGap.clear()
+	try {
+		const sourceComparison
+			= await import('../comparison/markdownSourceComparison.ts')
+		const { createMarkdownSourceComparison } = sourceComparison
+		const result = await createMarkdownSourceComparison(
+			props.beforeContent,
+			props.afterContent,
+			controller.signal,
+		)
+		if (request !== generation) {
+			return
+		}
+		materialize = sourceComparison.materializeSourceDiffGap
+		rowLimit
+			= sourceComparison.SOURCE_DIFF_LIMITS.maximumDisplayedRows
+		model.value = result
+		currentId.value
+			= result.status === 'ready' ? (result.hunks[0]?.id ?? null) : null
+	} catch (exception) {
+		if (
+			request === generation
+			&& (!(exception instanceof DOMException) || exception.name !== 'AbortError')
+		) {
+			error.value = exception
+		}
+	} finally {
+		if (request === generation) {
+			loading.value = false
+		}
+	}
+}
+function gapRows(gap: Gap) {
+	return rowsByGap.get(gap.id)
+}
+function rowCount() {
+	const hunkRows
+		= model.value?.status === 'ready'
+			? model.value.hunks.reduce((total, hunk) => total + hunk.rows.length, 0)
+			: 0
+	return [...rowsByGap.values()].reduce(
+		(total, rows) => total + rows.length,
+		hunkRows,
+	)
+}
+function availableRows() {
+	return Math.max(0, rowLimit - rowCount())
+}
+function canShowMore(gap: Gap) {
+	const rows = rowsByGap.get(gap.id)
+	return Boolean(rows && rows.length < gap.count && availableRows() > 0)
+}
+function isGapLimited(gap: Gap) {
+	const rows = rowsByGap.get(gap.id)
+	return Boolean(rows && rows.length < gap.count && availableRows() === 0)
+}
+function appendGap(gap: Gap) {
+	if (!materialize) {
+		return
+	}
+	const currentRows = rowsByGap.get(gap.id) ?? []
+	const page = materialize(
+		props.beforeContent,
+		props.afterContent,
+		gap,
+		availableRows(),
+		currentRows.length,
+	)
+	rowsByGap.set(gap.id, [...currentRows, ...page])
+}
+function toggleGap(gap: Gap) {
+	if (rowsByGap.has(gap.id)) {
+		rowsByGap.delete(gap.id)
+	} else if (materialize) {
+		rowsByGap.set(gap.id, [])
+		appendGap(gap)
+	}
+}
+function showMoreGap(gap: Gap) {
+	appendGap(gap)
+}
+function move(offset: number) {
+	if (model.value?.status !== 'ready' || !model.value.hunks.length) {
+		return
+	}
+	const index
+		= (currentIndex.value + offset + model.value.hunks.length)
+			% model.value.hunks.length
+	currentId.value = model.value.hunks[index]!.id
+	nextTick(() => root.value
+		?.querySelector<HTMLElement>(`[data-source-hunk="${currentId.value}"]`)
+		?.scrollIntoView({
+			block: 'center',
+			behavior: scrollBehavior(),
+		}))
+}
+function setSide(side: Side) {
+	activeSide.value = side
+	nextTick(() => tabs[side]?.focus())
+}
+function setTab(side: Side, element: Element | Public | null) {
+	tabs[side] = element instanceof HTMLButtonElement ? element : null
+}
+function onTabKeydown(event: KeyboardEvent) {
+	const side = sideForKey(event.key)
+	if (side) {
+		event.preventDefault()
+		setSide(side)
+	}
+}
+watch(() => [props.beforeContent, props.afterContent], load)
+onMounted(load)
+onBeforeUnmount(() => {
+	generation++
+	controller?.abort()
+})
+</script>
+
+<style lang="scss">
+$g: var(--default-grid-baseline);
+
+.text-source-comparison {
+	container-type: inline-size;
+	min-block-size: 0;
+	overflow: auto;
+
+	&__toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: calc(2 * $g);
+		flex-wrap: wrap;
+		padding: calc(2 * $g) calc(3 * $g);
+	}
+	&__toolbar > p,
+	&__navigation p {
+		margin: 0;
+	}
+	&__navigation {
+		display: grid;
+		align-items: center;
+		grid-template-columns: auto minmax(12rem, 1fr) auto;
+		gap: $g;
+		margin-inline-start: auto;
+	}
+	&__navigation p { text-align: center; }
+	&__side-tabs {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: calc(2 * $g);
+		inline-size: 100%;
+		button[role='tab'] {
+			margin: 0 !important;
+			border: 0 !important;
+			border-block-end: 2px solid transparent !important;
+			border-radius: 0 !important;
+			background: transparent !important;
+			&:focus-visible {
+				box-shadow: none !important;
+				outline: 2px solid var(--color-primary-element) !important;
+				outline-offset: -2px;
+			}
+		}
+	}
+	&__row {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+	&__side-headings {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		border-block: 1px solid var(--color-border);
+		h2 {
+			margin: 0;
+			padding: calc(2 * $g) calc(3 * $g);
+			font-size: var(--default-font-size);
+			font-weight: var(--font-weight-heading);
+			line-height: var(--default-line-height);
+		}
+		h2 + h2 { border-inline-start: 1px solid var(--color-border); }
+	}
+	&__row--single { grid-template-columns: minmax(0, 1fr); }
+	&__line {
+		display: grid;
+		align-items: start;
+		grid-template-columns: 1.5rem 4rem minmax(12rem, 1fr) repeat(2, max-content);
+		min-inline-size: 0;
+		font-family: var(--font-face-monospace);
+		font-size: var(--font-size-small);
+	}
+	&__line[hidden] { display: none; }
+	[data-source-cue] {
+		grid-column: 1;
+		text-align: center;
+	}
+	&__line-number {
+		grid-column: 2;
+		color: var(--color-text-maxcontrast);
+		text-align: end;
+		padding-inline: 8px;
+	}
+	code {
+		grid-column: 3;
+		overflow-x: auto;
+		white-space: pre;
+		user-select: text;
+	}
+	&__annotation {
+		padding-inline: 4px;
+		white-space: nowrap;
+	}
+	&__line--removed { background: var(--color-error-hover); }
+	&__line--added { background: var(--color-success-hover); }
+	&__segment--changed {
+		font-weight: bold;
+		text-decoration: underline;
+	}
+	&__hunk {
+		border-block-end: 1px solid var(--color-border);
+		&--current { box-shadow: inset calc(0.75 * $g) 0 var(--color-primary-element); }
+	}
+	&__hunk-title {
+		margin: 0;
+		background: var(--color-background-dark);
+		color: var(--color-text-maxcontrast);
+		font-size: var(--font-size-small);
+		button {
+			display: block;
+			inline-size: 100%;
+			min-block-size: var(--default-clickable-area);
+			margin: 0 !important;
+			padding: calc(2 * $g) calc(3 * $g);
+			border: 0;
+			border-radius: 0;
+			background: transparent;
+			color: inherit;
+			font: inherit;
+			font-weight: var(--font-weight-heading);
+			text-align: start;
+		}
+	}
+	&__gap {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding: calc(2 * $g);
+		border-block-end: 1px solid var(--color-border);
+		text-align: center;
+		> div { inline-size: 100%; }
+	}
+	&__side-tabs [role='tab'][aria-selected='true'] {
+		border-block-end-color: var(--color-primary-element) !important;
+		font-weight: var(--font-weight-heading);
+	}
+}
+@container (max-width: 560px) {
+	.text-source-comparison__navigation {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		inline-size: 100%;
+		margin-inline-start: 0;
+		button:first-child { grid-column: 1; }
+		button:last-child { grid-column: 2; }
+		p {
+			grid-row: 2;
+			grid-column: 1 / -1;
+		}
+	}
+}
+</style>

--- a/src/components/MarkdownSourceFallback.vue
+++ b/src/components/MarkdownSourceFallback.vue
@@ -1,0 +1,60 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<section class="text-source-fallback" data-comparison-source-fallback :aria-label="t('text', 'Complete Markdown source')">
+		<p>{{ t('text', 'Complete Markdown source is shown because a detailed comparison is unavailable.') }}</p>
+		<p v-if="before.truncated || after.truncated" role="status">
+			{{ t('text', 'Source preview was truncated to the display limit.') }}
+		</p>
+		<div class="text-source-fallback__documents">
+			<article>
+				<h2>{{ t('text', 'Before') }}</h2>
+				<pre tabindex="0"><code>{{ before.text }}</code></pre>
+			</article>
+			<article>
+				<h2>{{ t('text', 'After') }}</h2>
+				<pre tabindex="0"><code>{{ after.text }}</code></pre>
+			</article>
+		</div>
+	</section>
+</template>
+
+<script setup lang="ts">
+import { t } from '@nextcloud/l10n'
+import { computed } from 'vue'
+import { displayBoundedMarkdownSource } from '../comparison/markdownSourceDisplay.ts'
+
+const props = defineProps<{ beforeContent: string, afterContent: string }>()
+const before = computed(() => displayBoundedMarkdownSource(props.beforeContent))
+const after = computed(() => displayBoundedMarkdownSource(props.afterContent))
+</script>
+
+<style lang="scss">
+.text-source-fallback {
+	flex: 1 1 auto;
+	min-block-size: 0;
+	overflow: auto;
+	padding: 16px;
+	container-type: inline-size;
+
+	&__documents {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 16px;
+	}
+
+	pre {
+		min-block-size: 12rem;
+		overflow: auto;
+		white-space: pre;
+		user-select: text;
+	}
+
+	@container (max-width: 759px) {
+		&__documents { grid-template-columns: minmax(0, 1fr); }
+	}
+}
+</style>

--- a/src/composables/useEditorMethods.ts
+++ b/src/composables/useEditorMethods.ts
@@ -12,6 +12,12 @@ import Markdown from '../extensions/Markdown.js'
 import markdownit from '../markdownit/index.js'
 import { isUser } from '../services/SyncService.ts'
 
+export function renderEditorContent(content: string, markdown: boolean) {
+	return markdown
+		? markdownit.render(content) + '<p/>'
+		: `<pre>\n${escapeHtml(content)}</pre>`
+}
+
 /**
  *
  * @param editor to apply methods to
@@ -29,12 +35,9 @@ export function useEditorMethods(editor: Editor) {
 	) => void = (content, { addToHistory = true } = {}) => {
 		const hasMarkdownContent
 			= editor.extensionManager.extensions.includes(Markdown)
-		const html = hasMarkdownContent
-			? markdownit.render(content) + '<p/>'
-			: `<pre>\n${escapeHtml(content)}</pre>`
 		editor
 			.chain()
-			.setContent(html, { emitUpdate: addToHistory })
+			.setContent(renderEditorContent(content, hasMarkdownContent), { emitUpdate: addToHistory })
 			.command(({ tr }) => {
 				tr.setMeta('addToHistory', addToHistory)
 				return true

--- a/src/createMarkdownContentComparison.ts
+++ b/src/createMarkdownContentComparison.ts
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createApp } from 'vue'
+import MarkdownSourceFallback from './components/MarkdownSourceFallback.vue'
+import { OPEN_LINK_HANDLER } from './composables/useOpenLinkHandler.ts'
+import { openLink } from './helpers/links.js'
+
+export interface MarkdownContentComparisonOptions {
+	el: HTMLElement
+	beforeContent: string
+	afterContent: string
+	fileId?: number
+	filePath?: string
+	shareToken?: string
+	noLazyImages?: boolean
+	openLinkHandler?: (href: string) => void
+	onLoaded?: () => void | Promise<void>
+}
+
+export interface MarkdownContentComparisonInstance {
+	destroy: () => void
+}
+
+export async function createMarkdownContentComparison(options: MarkdownContentComparisonOptions): Promise<MarkdownContentComparisonInstance> {
+	if (!(options?.el instanceof HTMLElement)) {
+		throw new TypeError('Comparison el must be an HTMLElement')
+	}
+	if (
+		typeof options.beforeContent !== 'string'
+		|| typeof options.afterContent !== 'string'
+	) {
+		throw new TypeError('beforeContent and afterContent must be strings')
+	}
+
+	const root = document.createElement('div')
+	root.className = 'text-comparison-root'
+	options.el.replaceChildren(root)
+	let app: ReturnType<typeof createApp> | null = null
+	let destroyed = false
+	let fallbackPromise: Promise<void> | null = null
+	let resolveReady!: () => void
+	const ready = new Promise<void>((resolve) => {
+		resolveReady = resolve
+	})
+	const onReady = () => {
+		if (!destroyed) {
+			resolveReady()
+		}
+	}
+	const provide = (nextApp: ReturnType<typeof createApp>) => nextApp.provide(OPEN_LINK_HANDLER, {
+		openLink: options.openLinkHandler ?? openLink,
+	})
+
+	const mountFallback = () => {
+		fallbackPromise ??= (async () => {
+			try {
+				app?.unmount()
+			} catch (error) {
+				void error
+			}
+			root.replaceChildren()
+			if (destroyed) {
+				return
+			}
+			app = provide(createApp(MarkdownSourceFallback, {
+				beforeContent: options.beforeContent,
+				afterContent: options.afterContent,
+			}))
+			app.mount(root)
+			onReady()
+		})()
+		return fallbackPromise
+	}
+
+	try {
+		const { default: MarkdownContentComparison }
+			= await import('./components/MarkdownContentComparison.vue')
+		if (destroyed) {
+			return { destroy() {} }
+		}
+		app = provide(createApp(MarkdownContentComparison, {
+			beforeContent: options.beforeContent,
+			afterContent: options.afterContent,
+			fileId: options.fileId,
+			filePath: options.filePath,
+			shareToken: options.shareToken,
+			noLazyImages: options.noLazyImages ?? false,
+			openLinkHandler: options.openLinkHandler ?? openLink,
+			onReady,
+		}))
+		app.config.errorHandler = () => {
+			void mountFallback()
+		}
+		app.mount(root)
+		await ready
+	} catch {
+		await mountFallback()
+		await ready
+	}
+	try {
+		await options.onLoaded?.()
+	} catch (error) {
+		void error
+	}
+
+	return {
+		destroy() {
+			if (destroyed) {
+				return
+			}
+			destroyed = true
+			try {
+				app?.unmount()
+			} finally {
+				root.remove()
+			}
+			app = null
+		},
+	}
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4,11 +4,12 @@
  */
 
 import { createCollaborativeEditor, createEditor, createMarkdownContentEditor } from './createEditor.ts'
+import { createMarkdownContentComparison } from './createMarkdownContentComparison.ts'
 import { createTable } from './createTable.ts'
 
 import 'vite/modulepreload-polyfill'
 
-const apiVersion = '1.4'
+const apiVersion = '1.5'
 
 window.OCA.Text = {
 	...window.OCA.Text,
@@ -18,4 +19,5 @@ window.OCA.Text.apiVersion = apiVersion
 window.OCA.Text.createEditor = createEditor
 window.OCA.Text.createCollaborativeEditor = createCollaborativeEditor
 window.OCA.Text.createMarkdownContentEditor = createMarkdownContentEditor
+window.OCA.Text.createMarkdownContentComparison = createMarkdownContentComparison
 window.OCA.Text.createTable = createTable

--- a/src/extensions/RichText.ts
+++ b/src/extensions/RichText.ts
@@ -95,7 +95,7 @@ export default Extension.create<RichTextOptions>({
 			Text,
 			Paragraph,
 			HardBreak,
-			Heading,
+			this.options.editing || !this.options.isEmbedded ? Heading : Heading.extend({ addProseMirrorPlugins: () => [] }),
 			Strong,
 			Highlight,
 			Italic,
@@ -123,7 +123,10 @@ export default Extension.create<RichTextOptions>({
 				isEmbedded: this.options.isEmbedded,
 			}),
 			Underline,
-			Image.configure({ noLazyImages: this.options.noLazyImages }),
+			Image.configure({
+				emitAttachmentEvents: this.options.editing,
+				noLazyImages: this.options.noLazyImages,
+			}),
 			ImageInline.configure({ noLazyImages: this.options.noLazyImages }),
 			Dropcursor.configure({
 				color: 'var(--color-primary-element)',
@@ -131,7 +134,7 @@ export default Extension.create<RichTextOptions>({
 			}),
 			Gapcursor,
 			KeepSyntax,
-			Keymap,
+			...(this.options.editing ? [Keymap] : []),
 			FrontMatter,
 			Mention.configure({
 				suggestion: MentionSuggestion({
@@ -141,7 +144,7 @@ export default Extension.create<RichTextOptions>({
 					},
 				}),
 			}),
-			Search,
+			...(this.options.editing ? [Search] : []),
 			Emoji.configure({
 				suggestion: EmojiSuggestion(),
 			}),
@@ -163,6 +166,7 @@ export default Extension.create<RichTextOptions>({
 				notAfter: ['paragraph', 'comments', 'footnotes'],
 			}),
 			TextDirection.configure({
+				inferTextDirectionOnParse: !this.options.editing,
 				types: [
 					'blockquote',
 					'callout',

--- a/src/extensions/TextDirection.ts
+++ b/src/extensions/TextDirection.ts
@@ -119,6 +119,7 @@ declare module '@tiptap/core' {
 export interface TextDirectionOptions {
 	types: string[]
 	defaultDirection: Direction | null
+	inferTextDirectionOnParse: boolean
 }
 
 export const TextDirection = Extension.create<TextDirectionOptions>({
@@ -128,6 +129,7 @@ export const TextDirection = Extension.create<TextDirectionOptions>({
 		return {
 			types: [],
 			defaultDirection: null,
+			inferTextDirectionOnParse: false,
 		}
 	},
 
@@ -138,7 +140,15 @@ export const TextDirection = Extension.create<TextDirectionOptions>({
 				attributes: {
 					dir: {
 						default: null,
-						parseHTML: (element) => element.dir || this.options.defaultDirection,
+						parseHTML: (element) => {
+							if (!this.options.inferTextDirectionOnParse) {
+								return element.dir || this.options.defaultDirection
+							}
+							const explicitDirection = element.dir as Direction
+							return validDirections.includes(explicitDirection)
+								? explicitDirection
+								: getTextDirection(element.textContent ?? '') ?? this.options.defaultDirection
+						},
 						renderHTML: (attributes) => {
 							if (attributes.dir === this.options.defaultDirection) {
 								return {}

--- a/src/markdownit/details.ts
+++ b/src/markdownit/details.ts
@@ -7,9 +7,8 @@ import type MarkdownIt from 'markdown-it'
 import type StateBlock from 'markdown-it/lib/rules_block/state_block.mjs'
 import type Token from 'markdown-it/lib/token.mjs'
 
-const DETAILS_START_REGEX = /^<details>\s*$/
-const DETAILS_AND_SUMMARY_START_REGEX
-	= /(?<=^<details>\s*<summary>).*(?=<\/summary>\s*$)/
+const DETAILS_START_REGEX = /^<details(?<open>\s+open(?:=(?:""|''|open))?)?>\s*$/
+const DETAILS_AND_SUMMARY_START_REGEX = /^<details(?<open>\s+open(?:=(?:""|''|open))?)?>\s*<summary>(?<summary>.*)<\/summary>\s*$/
 const DETAILS_END_REGEX = /^<\/details>\s*$/
 const SUMMARY_REGEX = /(?<=^<summary>).*(?=<\/summary>\s*$)/
 
@@ -32,16 +31,22 @@ function parseDetails(
 
 	let detailsFound = false
 	let detailsSummary = null
+	let openDetails: boolean
 	let startLineCount = 2
 
-	const m = state.src.slice(start, max).match(DETAILS_AND_SUMMARY_START_REGEX)
-	if (m) {
+	const openingLine = state.src.slice(start, max)
+	const combined = openingLine.match(DETAILS_AND_SUMMARY_START_REGEX)
+	if (combined) {
 		// Details block start and summary in same line
-		detailsSummary = m[0].trim()
+		detailsSummary = combined.groups!.summary!.trim()
+		openDetails = Boolean(combined.groups!.open)
 		startLineCount = 1
-	} else if (!state.src.slice(start, max).match(DETAILS_START_REGEX)) {
-		// Details block start in separate line
-		return false
+	} else {
+		const opening = openingLine.match(DETAILS_START_REGEX)
+		if (!opening) {
+			return false
+		}
+		openDetails = Boolean(opening.groups!.open)
 	}
 
 	// Since start is found, we can report success here in validation mode
@@ -105,6 +110,9 @@ function parseDetails(
 	token.block = true
 	token.info = detailsSummary
 	token.map = [startLine, nextLine]
+	if (openDetails) {
+		token.attrSet('open', '')
+	}
 
 	token = state.push('details_summary', 'summary', 1)
 	token.block = false

--- a/src/nodes/Details.js
+++ b/src/nodes/Details.js
@@ -67,6 +67,11 @@ const Details = Node.create({
 			openDetails: {
 				default: false,
 			},
+			open: {
+				default: false,
+				parseHTML: (element) => element.hasAttribute('open'),
+				renderHTML: ({ open }) => open ? { open: '' } : {},
+			},
 		}
 	},
 
@@ -91,7 +96,7 @@ const Details = Node.create({
 	},
 
 	toMarkdown: (state, node) => {
-		state.write('<details>\n')
+		state.write(node.attrs.open ? '<details open>\n' : '<details>\n')
 		state.renderContent(node)
 		state.closeBlock(node)
 		state.ensureNewLine()

--- a/src/nodes/DetailsView.vue
+++ b/src/nodes/DetailsView.vue
@@ -5,13 +5,17 @@
 
 <template>
 	<NodeViewWrapper data-text-el="details" class="details" as="div">
-		<NcButton variant="tertiary" size="small">
+		<NcButton
+			variant="tertiary"
+			size="small"
+			:aria-label="t('text', open ? 'Collapse details' : 'Expand details')"
+			:aria-expanded="open"
+			@click="toggleOpen">
 			<template #icon>
 				<TriangleSmallDownIcon
 					:size="20"
 					class="button-open"
-					:class="{ open: open }"
-					@click="toggleOpen" />
+					:class="{ open: open }" />
 			</template>
 		</NcButton>
 		<NodeViewContent class="details-container" :class="{ 'is-hidden': !open }" />
@@ -19,6 +23,7 @@
 </template>
 
 <script>
+import { t } from '@nextcloud/l10n'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/vue-3'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import TriangleSmallDownIcon from 'vue-material-design-icons/TriangleSmallDown.vue'
@@ -52,25 +57,30 @@ export default {
 	},
 
 	watch: {
-		'node.attrs.openDetails': function() {
-			this.openByAttr()
+		'node.attrs.openDetails': function(open) {
+			if (open) {
+				this.open = true
+				this.updateAttributes({ openDetails: false })
+			}
+		},
+
+		'node.attrs.open': function(open) {
+			this.open = open
 		},
 	},
 
 	beforeMount() {
-		this.openByAttr()
+		this.open = this.node.attrs.open || this.node.attrs.openDetails
+		if (this.node.attrs.openDetails) {
+			this.updateAttributes({ openDetails: false })
+		}
 	},
 
 	methods: {
+		t,
+
 		toggleOpen() {
 			this.open = !this.open
-		},
-
-		openByAttr() {
-			if (this.node.attrs.openDetails) {
-				this.open = true
-				this.updateAttributes({ openDetails: false })
-			}
 		},
 	},
 }

--- a/src/nodes/Image.ts
+++ b/src/nodes/Image.ts
@@ -17,6 +17,7 @@ const imageFileDropPluginKey = new PluginKey('imageFileDrop')
 const imageExtractAttachmentsKey = new PluginKey('imageExtractAttachments')
 
 interface ImageOptions extends TiptapImageOptions {
+	emitAttachmentEvents: boolean
 	noLazyImages: boolean
 }
 
@@ -53,6 +54,7 @@ const Image = TiptapImage.extend<ImageOptions>({
 	addOptions() {
 		return {
 			...this.parent?.() as ImageOptions,
+			emitAttachmentEvents: true,
 			noLazyImages: false,
 		}
 	},
@@ -120,31 +122,33 @@ const Image = TiptapImage.extend<ImageOptions>({
 					},
 				},
 			}),
-			new Plugin({
-				key: imageExtractAttachmentsKey,
-				state: {
-					init(_, { doc }) {
-						const attachmentSrcs = extractAttachmentSrcs(doc)
-						emit('text:editor:attachments:updated', { attachmentSrcs })
-						return { attachmentSrcs }
-					},
-					apply(tr, value, _oldState, newState) {
-						if (!tr.docChanged) {
-							return value
-						}
-						const attachmentSrcs = extractAttachmentSrcs(newState.doc)
-						if (
-							JSON.stringify(attachmentSrcs)
-							=== JSON.stringify(value?.attachmentSrcs)
-						) {
-							return value
-						}
+			...(this.options.emitAttachmentEvents
+				? [new Plugin({
+						key: imageExtractAttachmentsKey,
+						state: {
+							init(_, { doc }) {
+								const attachmentSrcs = extractAttachmentSrcs(doc)
+								emit('text:editor:attachments:updated', { attachmentSrcs })
+								return { attachmentSrcs }
+							},
+							apply(tr, value, _oldState, newState) {
+								if (!tr.docChanged) {
+									return value
+								}
+								const attachmentSrcs = extractAttachmentSrcs(newState.doc)
+								if (
+									JSON.stringify(attachmentSrcs)
+									=== JSON.stringify(value?.attachmentSrcs)
+								) {
+									return value
+								}
 
-						emit('text:editor:attachments:updated', { attachmentSrcs })
-						return { attachmentSrcs }
-					},
-				},
-			}),
+								emit('text:editor:attachments:updated', { attachmentSrcs })
+								return { attachmentSrcs }
+							},
+						},
+					})]
+				: []),
 		]
 	},
 

--- a/src/nodes/ImageView.vue
+++ b/src/nodes/ImageView.vue
@@ -24,8 +24,10 @@
 							v-if="isMediaAttachment"
 							contenteditable="false"
 							class="media">
-							<a
+							<button
+								type="button"
 								class="media-wrapper media-wrapper__attachment"
+								:aria-label="t('text', 'Open attachment {name}', { name: alt || attachment?.name || src })"
 								@click="handleAttachmentClick">
 								<img
 									v-show="loaded"
@@ -37,7 +39,7 @@
 									<span class="name">{{ alt }}</span>
 									<span class="size">{{ attachmentSize }}</span>
 								</div>
-							</a>
+							</button>
 							<div v-if="showDeleteIcon" class="buttons">
 								<NcButton
 									:aria-label="t('text', 'Delete this attachment')"
@@ -50,14 +52,18 @@
 							</div>
 						</div>
 						<div v-else contenteditable="false" class="media media__image">
-							<a class="media-wrapper" @click="handleImageClick">
+							<button
+								type="button"
+								class="media-wrapper"
+								:aria-label="t('text', 'Open image {name}', { name: alt || attachment?.name || src })"
+								@click="handleImageClick">
 								<img
 									v-show="loaded"
 									:src="imageUrl"
 									:alt="alt"
 									class="image__main"
 									@load="onLoaded">
-							</a>
+							</button>
 						</div>
 					</template>
 					<template v-else>
@@ -593,7 +599,11 @@ export default {
 
 	.media-wrapper {
 		display: flex;
-		// Overwrite some global rules for a elments
+		padding: 0;
+		border: 0;
+		background: transparent;
+		font: inherit;
+		cursor: pointer;
 		text-decoration: none;
 		color: var(--color-main-text);
 

--- a/src/services/AttachmentResolver.js
+++ b/src/services/AttachmentResolver.js
@@ -22,7 +22,6 @@ export default class AttachmentResolver {
 		this.#shareToken = shareToken
 		this.#currentDirectory = currentDirectory
 		this.#documentId = fileId ?? session.documentId
-		this.#initAttachmentListPromise = this.#updateAttachmentList()
 	}
 
 	async #updateAttachmentList() {
@@ -52,7 +51,7 @@ export default class AttachmentResolver {
 		if (src.match(directoryRegexp)) {
 			const imageFileName = decodeURIComponent(src.replace(directoryRegexp, '').split('?')[0])
 
-			// Wait until attachment list got fetched (initialized by constructor)
+			this.#initAttachmentListPromise ??= this.#updateAttachmentList()
 			await this.#initAttachmentListPromise
 			attachment = this.#findAttachment(imageFileName)
 

--- a/src/tests/comparison/ComparisonChangeList.spec.ts
+++ b/src/tests/comparison/ComparisonChangeList.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonDescriptor, ComparisonEdit } from '../../comparison/markdownComparisonTypes.ts'
+
+import * as l10n from '@nextcloud/l10n'
+import { mount } from '@vue/test-utils'
+import { schema } from 'prosemirror-schema-basic'
+import { describe, expect, it, vi } from 'vitest'
+import ComparisonChangeList from '../../components/ComparisonChangeList.vue'
+
+function descriptor(id: string, text: string, facets: ComparisonDescriptor['facets'] = ['text']): ComparisonDescriptor {
+	return {
+		id,
+		operation: 'replace',
+		detail: 'inline',
+		facets,
+		before: { from: 0, to: 1 },
+		after: { from: 0, to: 1 },
+		context: { before: null, after: null },
+		preview: { before: { kind: 'text', text }, after: { kind: 'text', text } },
+		signals: [],
+	}
+}
+
+const document = schema.node('doc', null, [schema.node('paragraph', null, schema.text('Body'))])
+
+describe('ComparisonChangeList', () => {
+	it('AUD-14 renders only the bounded page containing a high-cardinality current edit', () => {
+		const edits = Array.from({ length: 10_000 }, (_value, index): ComparisonEdit => {
+			const primary = descriptor(`member-${index}`, `preview-${index}`)
+			return { id: `edit-${index}`, kind: 'content', primary, descriptors: [primary] }
+		})
+		const wrapper = mount(ComparisonChangeList, {
+			props: { edits, currentId: 'edit-9999', beforeDocument: document, afterDocument: document },
+		})
+		const rows = wrapper.findAll('[data-comparison-select]')
+
+		expect(rows).toHaveLength(80)
+		expect(rows[0]!.attributes('data-comparison-select')).toBe('edit-9920')
+		expect(rows.at(-1)!.attributes('data-comparison-select')).toBe('edit-9999')
+		expect(wrapper.find('[data-comparison-select="edit-9999"]').attributes('aria-current')).toBe('true')
+	})
+
+	it('preserves the current change label when paging away from its row', async () => {
+		const edits = Array.from({ length: 160 }, (_value, index): ComparisonEdit => {
+			const primary = descriptor(`member-${index}`, `preview-${index}`)
+			return { id: `edit-${index}`, kind: 'content', primary, descriptors: [primary] }
+		})
+		const wrapper = mount(ComparisonChangeList, {
+			props: { edits, currentId: 'edit-159', beforeDocument: document, afterDocument: document },
+		})
+		const initialLabel = wrapper.emitted('currentLabel')!.at(-1)![0]
+
+		await wrapper.findAll('.text-comparison__change-pages button')[0]!.trigger('click')
+
+		expect(wrapper.findAll('[data-comparison-select]')[0]!.attributes('data-comparison-select')).toBe('edit-0')
+		expect(wrapper.find('[aria-current="true"]').exists()).toBe(false)
+		expect(wrapper.emitted('currentLabel')!.at(-1)![0]).toBe(initialLabel)
+		expect(initialLabel).not.toBe('')
+	})
+
+	it('AUD-14 unmounts records in collapsed sections', async () => {
+		const primary = descriptor('member', 'preview')
+		const edit: ComparisonEdit = { id: 'edit', kind: 'content', primary, descriptors: [primary] }
+		const wrapper = mount(ComparisonChangeList, {
+			props: { edits: [edit], beforeDocument: document, afterDocument: document },
+		})
+
+		await wrapper.get('.text-comparison__section-toggle').trigger('click')
+
+		expect(wrapper.findAll('[data-comparison-select]')).toHaveLength(0)
+	})
+
+	it('translates only the selected lookup entry for each record', () => {
+		const translate = vi.spyOn(l10n, 't')
+		const primary: ComparisonDescriptor = {
+			...descriptor('member', 'preview', ['attribute']),
+			signals: [{ type: 'attribute', attribute: 'link', change: 'changed' }],
+		}
+		const edit: ComparisonEdit = { id: 'edit', kind: 'content', primary, descriptors: [primary] }
+
+		mount(ComparisonChangeList, {
+			props: { edits: [edit], beforeDocument: document, afterDocument: document },
+		})
+
+		const messages = translate.mock.calls.map(([, message]) => message)
+		expect(messages).toContain('Link changed')
+		expect(messages).not.toContain('Heading level changed')
+		translate.mockRestore()
+	})
+
+	it('V01 renders one row per first-class edit using explicit primary and all member descriptors', async () => {
+		const first = descriptor('member-first', 'wrong', ['formatting'])
+		const primary = descriptor('member-primary', 'primary')
+		const edit: ComparisonEdit = { id: 'edit-row', kind: 'content', primary, descriptors: [first, primary] }
+		const wrapper = mount(ComparisonChangeList, {
+			props: { edits: [edit], currentId: 'edit-row', beforeDocument: document, afterDocument: document },
+		})
+		const rows = wrapper.findAll('[data-comparison-select]')
+		expect(rows).toHaveLength(1)
+		expect(rows[0]!.attributes('data-comparison-select')).toBe('edit-row')
+		expect(rows[0]!.find('.text-comparison__change-item-content').exists()).toBe(true)
+		expect(rows[0]!.text()).toContain('primary')
+		expect(rows[0]!.text()).toContain('2 edits')
+		await rows[0]!.trigger('click')
+		expect(wrapper.emitted('select')).toEqual([['edit-row']])
+	})
+
+	it('renders explicit before and after previews for a replacement', () => {
+		const primary: ComparisonDescriptor = {
+			...descriptor('member', 'unused'),
+			preview: {
+				before: { kind: 'text', text: 'before text' },
+				after: { kind: 'text', text: 'after text' },
+			},
+		}
+		const edit: ComparisonEdit = { id: 'edit', kind: 'content', primary, descriptors: [primary] }
+		const wrapper = mount(ComparisonChangeList, {
+			props: { edits: [edit], beforeDocument: document, afterDocument: document },
+		})
+
+		expect(wrapper.get('del.text-comparison__preview-before').text()).toBe('before text')
+		expect(wrapper.get('ins.text-comparison__preview-after').text()).toBe('after text')
+	})
+
+	it('labels a coarse composite change by its structural scope instead of an incidental task attribute', () => {
+		const primary: ComparisonDescriptor = {
+			...descriptor('member', 'nested content', ['text', 'attribute', 'structure']),
+			coarseReason: 'ambiguous-attribution',
+			signals: [
+				{ type: 'attribute', attribute: 'task-state', change: 'changed' },
+				{ type: 'node' },
+			],
+		}
+		const edit: ComparisonEdit = { id: 'edit', kind: 'content', primary, descriptors: [primary] }
+		const wrapper = mount(ComparisonChangeList, {
+			props: { edits: [edit], beforeDocument: document, afterDocument: document },
+		})
+
+		expect(wrapper.get('[data-comparison-select]').text()).toContain('Structure changed')
+		expect(wrapper.get('[data-comparison-select]').text()).not.toContain('Task state changed')
+	})
+
+	it.each([
+		['insert', 'inline', 'Paragraph changed', 'Paragraph added'],
+		['delete', 'inline', 'Paragraph changed', 'Paragraph removed'],
+		['insert', 'block', 'Paragraph added', 'Paragraph changed'],
+		['delete', 'block', 'Paragraph removed', 'Paragraph changed'],
+	] as const)('labels a %s %s operation at the correct altitude', (operation, detail, expected, rejected) => {
+		const primary: ComparisonDescriptor = {
+			...descriptor('member', 's'),
+			operation,
+			detail,
+			context: {
+				before: { code: 'paragraph', path: [], from: 0, to: 1 },
+				after: { code: 'paragraph', path: [], from: 0, to: 1 },
+			},
+			preview: operation === 'insert'
+				? { before: null, after: { kind: 'text', text: 's' } }
+				: { before: { kind: 'text', text: 's' }, after: null },
+		}
+		const edit: ComparisonEdit = { id: 'edit', kind: 'content', primary, descriptors: [primary] }
+		const wrapper = mount(ComparisonChangeList, {
+			props: { edits: [edit], beforeDocument: document, afterDocument: document },
+		})
+
+		expect(wrapper.get('[data-comparison-select]').text()).toContain(expected)
+		expect(wrapper.get('[data-comparison-select]').text()).not.toContain(rejected)
+	})
+})

--- a/src/tests/comparison/MarkdownSourceComponent.spec.ts
+++ b/src/tests/comparison/MarkdownSourceComponent.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import MarkdownSourceComparison from '../../components/MarkdownSourceComparison.vue'
+import { SOURCE_DIFF_LIMITS } from '../../comparison/markdownSourceComparison.ts'
+import {
+	COMPLETE_SOURCE_DISPLAY_LIMITS,
+	displayBoundedMarkdownSource,
+	displayMarkdownSource,
+} from '../../comparison/markdownSourceDisplay.ts'
+
+describe('Markdown source component', () => {
+	const multilineSource = (length: number) => {
+		const line = `${'x'.repeat(COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerLine - 1)}\n`
+		return line.repeat(Math.floor(length / line.length)) + 'x'.repeat(length % line.length)
+	}
+
+	it.each([
+		COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerSide - 1,
+		COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerSide,
+	])('AUD-08 preserves complete source at the %i-character display boundary', (length) => {
+		const source = multilineSource(length)
+		expect(displayBoundedMarkdownSource(source)).toEqual({ text: source, truncated: false })
+	})
+
+	it('keeps supplementary characters well formed at the input boundary', () => {
+		const limit = COMPLETE_SOURCE_DISPLAY_LIMITS.maximumInputCharactersPerSide
+		const exact = `${multilineSource(limit - 2)}😀`
+		const crossingPrefix = multilineSource(limit - 1)
+		const crossing = `${crossingPrefix}😀`
+
+		expect(displayBoundedMarkdownSource(exact)).toEqual({ text: exact, truncated: false })
+		const result = displayBoundedMarkdownSource(crossing)
+		expect(result.text).toBe(crossingPrefix)
+		expect(result.text.length).toBeLessThanOrEqual(COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerSide)
+		expect(result.text.isWellFormed()).toBe(true)
+		expect(result.truncated).toBe(true)
+	})
+
+	it('keeps supplementary characters and visible controls intact at the output boundary', () => {
+		expect(displayMarkdownSource('abc😀', 5)).toBe('abc😀')
+		expect(displayMarkdownSource('abc😀', 4)).toBe('abc')
+		expect(displayMarkdownSource('\tremaining', 5)).toBe('⟦TAB⟧')
+	})
+
+	it.each([
+		['high', '\uD83D', '⟦U+D83D⟧'],
+		['low', '\uDE00', '⟦U+DE00⟧'],
+	])('renders a lone %s surrogate as an exact reversible token', (_name, source, expected) => {
+		const result = displayBoundedMarkdownSource(source)
+
+		expect(result).toEqual({ text: expected, truncated: false })
+		expect(result.text).not.toContain('\uFFFD')
+		expect(result.text.isWellFormed()).toBe(true)
+	})
+
+	it('reports expansion truncation instead of silently omitting a supplementary character', () => {
+		const result = displayBoundedMarkdownSource(`${'\t'.repeat(200_000)}😀`)
+
+		expect(result.truncated).toBe(true)
+		expect(result.text).toHaveLength(COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerLine)
+		expect(result.text).not.toContain('\uFFFD')
+		expect(result.text.isWellFormed()).toBe(true)
+		expect(result.text.length).toBeLessThanOrEqual(COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerLine)
+	})
+
+	it('shows complete fallback immediately, then enhanced literal hunks', async () => {
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: 'old\t \n', afterContent: 'new\u200B\n', layoutMode: 'paired' },
+		})
+		expect(wrapper.find('[data-comparison-source-fallback]').exists()).toBe(true)
+		await vi.waitFor(() => expect(wrapper.find('[data-source-hunk]').exists()).toBe(true))
+		expect(wrapper.text()).toContain('old')
+		expect(wrapper.text()).toContain('new⟦ZWSP⟧')
+	})
+
+	it('AUD-05 exposes side, operation, whitespace, EOL, and missing-newline semantics', async () => {
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: {
+				beforeContent: `old${String.fromCharCode(9)}\r\ntrail  `,
+				afterContent: 'new\ntrail\n',
+				layoutMode: 'paired',
+			},
+		})
+		await vi.waitFor(() => expect(wrapper.find('[data-source-hunk]').exists()).toBe(true))
+
+		expect(wrapper.find('[data-source-side="before"]').text()).toBe('Before')
+		expect(wrapper.find('[data-source-side="after"]').text()).toBe('After')
+		expect(wrapper.find('[data-source-operation="removed"]').attributes('aria-label')).toContain('Removed line')
+		expect(wrapper.find('[data-source-operation="added"]').attributes('aria-label')).toContain('Added line')
+		expect(wrapper.find('[data-source-operation="removed"] [data-source-cue]').text()).toBe('−')
+		expect(wrapper.find('[data-source-operation="added"] [data-source-cue]').text()).toBe('+')
+		for (const token of ['TAB', 'CRLF', 'LF', '2 TRAILING SPACES', 'No newline at end of file']) {
+			expect(wrapper.text()).toContain(token)
+		}
+	})
+
+	it('omits per-line badges when paired line endings match', async () => {
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: {
+				beforeContent: 'old\nunchanged\n',
+				afterContent: 'new\nunchanged\n',
+				layoutMode: 'paired',
+			},
+		})
+		await vi.waitFor(() => expect(wrapper.find('[data-source-hunk]').exists()).toBe(true))
+
+		expect(wrapper.findAll('[data-source-eol]')).toHaveLength(0)
+	})
+
+	it('AUD-13 renders the audited bidi and control set as visible inert source tokens', async () => {
+		const controls = '\u061C\u00AD\u200E\u200F\u0085\u2028\u2029'
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent: controls, afterContent: '', layoutMode: 'paired' },
+		})
+		await vi.waitFor(() => expect(wrapper.find('[data-source-hunk]').exists()).toBe(true))
+
+		for (const token of ['ALM', 'SHY', 'LRM', 'RLM', 'NEL', 'LS', 'PS']) {
+			expect(wrapper.text()).toContain(token)
+		}
+		for (const control of controls) {
+			expect(wrapper.text()).not.toContain(control)
+		}
+	})
+
+	it('AUD-08 expands a large unchanged gap incrementally with observable source ranges', async () => {
+		const prefix = Array.from({ length: 3_000 }, (_value, index) => `prefix-${index}`)
+		const suffix = Array.from({ length: 3_000 }, (_value, index) => `suffix-${index}`)
+		const beforeContent = [...prefix, 'old literal', ...suffix].join('\n')
+		const afterContent = [...prefix, 'new literal', ...suffix].join('\n')
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent, afterContent, layoutMode: 'paired' },
+		})
+		await vi.waitFor(() => expect(wrapper.findAll('.text-source-comparison__gap button')).toHaveLength(2))
+
+		await wrapper.findAll('[data-source-gap-toggle]')[0]!.trigger('click')
+
+		expect(wrapper.findAll('.text-source-comparison__row')).toHaveLength(SOURCE_DIFF_LIMITS.maximumGapPageRows + 7)
+		expect(wrapper.text()).toContain('prefix-0')
+		expect(wrapper.text()).toContain(`prefix-${SOURCE_DIFF_LIMITS.maximumGapPageRows - 1}`)
+		expect(wrapper.text()).not.toContain(`prefix-${SOURCE_DIFF_LIMITS.maximumGapPageRows}`)
+
+		await wrapper.find('[data-source-gap-more]').trigger('click')
+
+		expect(wrapper.findAll('.text-source-comparison__row')).toHaveLength(SOURCE_DIFF_LIMITS.maximumGapPageRows * 2 + 7)
+		expect(wrapper.text()).toContain(`prefix-${SOURCE_DIFF_LIMITS.maximumGapPageRows}`)
+	})
+
+	it('AUD-08 never expands gaps beyond the shared displayed-row ceiling', async () => {
+		const prefix = Array.from({ length: 3_000 }, (_value, index) => `prefix-${index}`)
+		const suffix = Array.from({ length: 3_000 }, (_value, index) => `suffix-${index}`)
+		const beforeContent = [...prefix, 'old literal', ...suffix].join('\n')
+		const afterContent = [...prefix, 'new literal', ...suffix].join('\n')
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent, afterContent, layoutMode: 'paired' },
+		})
+		await vi.waitFor(() => expect(wrapper.findAll('[data-source-gap-toggle]')).toHaveLength(2))
+
+		for (const toggle of wrapper.findAll('[data-source-gap-toggle]')) {
+			await toggle.trigger('click')
+			while (wrapper.find('[data-source-gap-more]').exists()) {
+				await wrapper.find('[data-source-gap-more]').trigger('click')
+			}
+		}
+
+		expect(wrapper.findAll('.text-source-comparison__row')).toHaveLength(SOURCE_DIFF_LIMITS.maximumDisplayedRows)
+		expect(wrapper.text()).toContain('prefix-0')
+		expect(wrapper.text()).toContain('suffix-3')
+		expect(wrapper.text()).not.toContain('suffix-2999')
+		expect(wrapper.find('[data-source-gap-limited]').exists()).toBe(true)
+	}, 15_000)
+
+	it('V11 preserves bounded complete fallback when source enhancement is limited', async () => {
+		const beforeContent = 'x'.repeat(SOURCE_DIFF_LIMITS.maximumCharacters + 1)
+		const wrapper = mount(MarkdownSourceComparison, {
+			props: { beforeContent, afterContent: 'after', layoutMode: 'single' },
+		})
+		await vi.waitFor(() => expect(wrapper.find('[data-source-limited]').exists()).toBe(true))
+		expect(wrapper.find('[data-comparison-source-fallback]').exists()).toBe(true)
+		expect(wrapper.find('pre code').text()).toHaveLength(COMPLETE_SOURCE_DISPLAY_LIMITS.maximumVisibleCharactersPerLine)
+		expect(wrapper.findAll('[role="status"]').map((status) => status.text()).join(' ')).toContain('truncated')
+	})
+})

--- a/src/tests/comparison/MarkdownSourceFallback.spec.ts
+++ b/src/tests/comparison/MarkdownSourceFallback.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import MarkdownSourceFallback from '../../components/MarkdownSourceFallback.vue'
+
+vi.mock('../../comparison/markdownSourceComparison.ts', () => {
+	throw new Error('enhanced Source is unavailable')
+})
+
+describe('complete Markdown source fallback', () => {
+	it('always renders both complete snapshots as inert literal text with visible controls', () => {
+		const wrapper = mount(MarkdownSourceFallback, {
+			props: {
+				beforeContent: '<script>globalThis.pwned = true</script>\nzero\u200Bwidth',
+				afterContent: '<img src=x onerror=alert(1)>\nlast',
+			},
+		})
+		const sources = wrapper.findAll('pre code')
+		expect(sources).toHaveLength(2)
+		expect(sources[0]!.text()).toContain('<script>globalThis.pwned = true</script>')
+		expect(sources[0]!.text()).toContain('⟦ZWSP⟧')
+		expect(sources[1]!.text()).toContain('<img src=x onerror=alert(1)>')
+		expect(wrapper.find('script').exists()).toBe(false)
+		expect(wrapper.find('img').exists()).toBe(false)
+	})
+})

--- a/src/tests/comparison/a15HistoryDifferential.spec.ts
+++ b/src/tests/comparison/a15HistoryDifferential.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+
+import { describe, expect, it } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import { createHierarchicalMarkdownComparisonModel } from '../../comparison/hierarchicalMarkdownComparisonModel.ts'
+
+interface EditorLike {
+	state: { doc: ProseMirrorNode }
+	destroy: () => void
+}
+
+interface ExpectedReplacement {
+	operation: string
+	detail: string
+	before: string
+	after: string
+}
+
+interface RegressionCase {
+	name: string
+	before: string
+	after: string
+	expected: readonly ExpectedReplacement[]
+}
+
+const regressionCorpus: readonly RegressionCase[] = [
+	{
+		name: 'keeps an exact trailing block outside earlier replacements',
+		before: `# Wiki App
+
+Old build instructions.
+
+Shared footer.
+`,
+		after: `# Collective Wiki
+
+New installation instructions.
+
+Shared footer.
+`,
+		expected: [
+			{ operation: 'insert', detail: 'inline', before: '', after: 'Collective ' },
+			{ operation: 'delete', detail: 'inline', before: ' App', after: '' },
+			{ operation: 'replace', detail: 'inline', before: 'Old build', after: 'New installation' },
+		],
+	},
+	{
+		name: 'keeps a weighted multi-block gap precise',
+		before: `## Development Background: Ownership
+
+Individual users own files. Collective pages should be owned by the collective.
+
+## Stable anchor
+
+This block is unchanged.
+`,
+		after: `## Development background: Ownership
+
+Collective data is owned by the collective instead.
+
+## Stable anchor
+
+This block is unchanged.
+`,
+		expected: [
+			{ operation: 'replace', detail: 'inline', before: 'B', after: 'b' },
+			{ operation: 'delete', detail: 'inline', before: 'Individual users own files. ', after: '' },
+			{ operation: 'replace', detail: 'inline', before: 'pages should be ', after: 'data is ' },
+			{ operation: 'insert', detail: 'inline', before: '', after: ' instead' },
+		],
+	},
+	{
+		name: 'reports code text and language replacements directly',
+		before: `\`\`\`
+const value = 1
+\`\`\`
+`,
+		after: `\`\`\`js
+const value = 1 // comment
+\`\`\`
+`,
+		expected: [
+			{ operation: 'replace', detail: 'block', before: 'const value = 1', after: 'const value = 1 // comment' },
+			{ operation: 'insert', detail: 'inline', before: '', after: ' // comment' },
+		],
+	},
+	{
+		name: 'reports a removed list item as a node deletion',
+		before: `- Remove me
+- Keep me
+`,
+		after: `- Keep me
+`,
+		expected: [
+			{ operation: 'delete', detail: 'block', before: 'Remove me', after: '' },
+		],
+	},
+	{
+		name: 'does not expose parser-only Markdown syntax as a change signal',
+		before: `GNU AGPL v3 or later
+`,
+		after: `Files: *
+Copyright: Azul <azul@example.com>
+License: AGPL v3 or later
+`,
+		expected: [
+			{
+				operation: 'replace',
+				detail: 'inline',
+				before: 'GNU',
+				after: 'Files: *\nCopyright: Azul azul@example.com\nLicense:',
+			},
+		],
+	},
+]
+
+function replacementOutput(beforeContent: string, afterContent: string) {
+	const beforeEditor = createComparisonEditor(beforeContent) as EditorLike
+	const afterEditor = createComparisonEditor(afterContent) as EditorLike
+	try {
+		const before = beforeEditor.state.doc
+		const after = afterEditor.state.doc
+		return createHierarchicalMarkdownComparisonModel(before, after).edits
+			.flatMap(({ descriptors }) => descriptors)
+			.map((descriptor) => ({
+				operation: descriptor.operation,
+				detail: descriptor.detail,
+				facets: descriptor.facets,
+				before: before.textBetween(descriptor.before.from, descriptor.before.to, '\n', '\ufffc'),
+				after: after.textBetween(descriptor.after.from, descriptor.after.to, '\n', '\ufffc'),
+				context: descriptor.context,
+				signals: descriptor.signals,
+				coarseReason: descriptor.coarseReason ?? null,
+			}))
+	} finally {
+		beforeEditor.destroy()
+		afterEditor.destroy()
+	}
+}
+
+function replacementProjection(replacements: ReturnType<typeof replacementOutput>): ExpectedReplacement[] {
+	return replacements.map(({ operation, detail, before, after }) => ({ operation, detail, before, after }))
+}
+
+function corpusCase(name: string) {
+	return regressionCorpus.find((candidate) => candidate.name === name)!
+}
+
+describe('A15 repository-history regression corpus', () => {
+	it.each(regressionCorpus)('$name', ({ before, after, expected }) => {
+		const replacements = replacementOutput(before, after)
+
+		expect(replacementProjection(replacements)).toEqual(expected)
+		expect(replacements.every(({ coarseReason }) => coarseReason === null)).toBe(true)
+	})
+
+	it('keeps replacement descriptor signals observable', () => {
+		const code = corpusCase('reports code text and language replacements directly')
+		const codeReplacements = replacementOutput(code.before, code.after)
+		expect(codeReplacements[0]).toMatchObject({
+			facets: ['attribute'],
+			signals: [{ type: 'attribute', attribute: 'code-language', change: 'changed' }],
+		})
+
+		const deletion = corpusCase('reports a removed list item as a node deletion')
+		expect(replacementOutput(deletion.before, deletion.after)[0]).toMatchObject({
+			facets: ['text', 'structure'],
+			context: { before: { code: 'list-item' }, after: null },
+			signals: [{ type: 'node' }],
+		})
+
+		const syntax = corpusCase('does not expose parser-only Markdown syntax as a change signal')
+		expect(replacementOutput(syntax.before, syntax.after)[0]).toMatchObject({
+			facets: ['text', 'attribute', 'unknown'],
+			signals: [{ type: 'attribute', attribute: 'link', change: 'added' }],
+		})
+	})
+})

--- a/src/tests/comparison/comparisonAlignment.spec.ts
+++ b/src/tests/comparison/comparisonAlignment.spec.ts
@@ -1,0 +1,343 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+	alignComparisonAxis,
+	createComparisonWorkLedger,
+	DEFAULT_COMPARISON_CELL_LEDGER,
+	DEFAULT_COMPARISON_TOKEN_LEDGER,
+	forcedIncreasingPairs,
+} from '../../comparison/comparisonAlignment.ts'
+
+function options(work = createComparisonWorkLedger()) {
+	return {
+		work,
+		fingerprint: (value: string) => value,
+		profile: (value: string) => [...value],
+		compatible: () => true,
+	}
+}
+
+interface EvidencedItem {
+	id: number
+	side: 'before' | 'after'
+}
+
+function evidencedOptions(work = createComparisonWorkLedger()) {
+	return {
+		work,
+		fingerprint: ({ id, side }: EvidencedItem) => `${side}:${id}`,
+		profile: ({ id, side }: EvidencedItem) => [`item:${id}`, side],
+		compatible: () => true,
+	}
+}
+
+function evidencedAxis(size: number, side: EvidencedItem['side']): EvidencedItem[] {
+	return Array.from({ length: size }, (_value, id) => ({ id, side }))
+}
+
+const FINAL_CELL_LEDGER = DEFAULT_COMPARISON_CELL_LEDGER
+const FINAL_TOKEN_LEDGER = DEFAULT_COMPARISON_TOKEN_LEDGER
+const FINAL_SQUARE_SIZE = Math.floor(Math.sqrt(FINAL_CELL_LEDGER))
+
+function permutations(values: readonly number[]): number[][] {
+	if (values.length < 2) {
+		return [Array.from(values)]
+	}
+	return values.flatMap((value, index) => permutations(values.toSpliced(index, 1))
+		.map((suffix) => [value, ...suffix]))
+}
+
+function exhaustiveForcedPairs(values: readonly number[]) {
+	let maximum = 0
+	const optimal: number[][] = []
+	for (let mask = 0; mask < 2 ** values.length; mask++) {
+		const indices = values.flatMap((_value, index) => mask & (1 << index) ? [index] : [])
+		if (!indices.every((index, offset) => offset === 0 || values[indices[offset - 1]!]! < values[index]!)) {
+			continue
+		}
+		if (indices.length > maximum) {
+			maximum = indices.length
+			optimal.length = 0
+		}
+		if (indices.length === maximum) {
+			optimal.push(indices)
+		}
+	}
+	return optimal[0]!.filter((index) => optimal.every((candidate) => candidate.includes(index)))
+		.map((before) => ({ before, after: values[before]! }))
+}
+
+describe('comparison alignment', () => {
+	it('uses the authoritative comparison-wide shipping ledgers', () => {
+		expect(createComparisonWorkLedger()).toEqual({
+			remainingCells: 40_000,
+			remainingTokenComparisons: 84_000_000,
+		})
+	})
+
+	it('pairs a whole equal axis without weighted work', () => {
+		const work = createComparisonWorkLedger()
+
+		expect(alignComparisonAxis(['alpha', 'beta'], ['alpha', 'beta'], options(work))).toEqual([
+			{ before: 0, after: 0 },
+			{ before: 1, after: 1 },
+		])
+		expect(work).toEqual({
+			remainingCells: DEFAULT_COMPARISON_CELL_LEDGER,
+			remainingTokenComparisons: DEFAULT_COMPARISON_TOKEN_LEDGER,
+		})
+	})
+
+	it('A03 uses ordered unique fingerprints as exact anchors', () => {
+		const work = createComparisonWorkLedger()
+
+		expect(alignComparisonAxis(['alpha', 'omega'], ['new', 'alpha', 'omega'], options(work))).toEqual([
+			{ before: null, after: 0 },
+			{ before: 0, after: 1 },
+			{ before: 1, after: 2 },
+		])
+		expect(work.remainingCells).toBe(40_000)
+	})
+
+	it('matches exhaustive forced-LIS anchors for crossing candidates', () => {
+		for (let size = 1; size <= 6; size++) {
+			for (const values of permutations(Array.from({ length: size }, (_value, index) => index))) {
+				const pairs = values.map((after, before) => ({ before, after }))
+				expect(forcedIncreasingPairs(pairs), values.join(','))
+					.toEqual(exhaustiveForcedPairs(values))
+			}
+		}
+	})
+
+	it('aligns around the forced subset of crossing exact candidates', () => {
+		expect(alignComparisonAxis(['alpha', 'beta', 'gamma'], ['beta', 'gamma', 'alpha'], options())).toEqual([
+			{ before: 0, after: null },
+			{ before: 1, after: 0 },
+			{ before: 2, after: 1 },
+			{ before: null, after: 2 },
+		])
+	})
+
+	it('retains the first exact duplicate when one is inserted', () => {
+		expect(alignComparisonAxis(['same'], ['same', 'same'], options())).toEqual([
+			{ before: 0, after: 0 },
+			{ before: null, after: 1 },
+		])
+	})
+
+	it('retains the first exact duplicate when one is deleted', () => {
+		expect(alignComparisonAxis(['same', 'same'], ['same'], options())).toEqual([
+			{ before: 0, after: 0 },
+			{ before: 1, after: null },
+		])
+	})
+
+	it('A09 pairs one compatible changed item without weighted work', () => {
+		const work = createComparisonWorkLedger()
+
+		expect(alignComparisonAxis(['before'], ['after'], options(work))).toEqual([
+			{ before: 0, after: 0 },
+		])
+		expect(work.remainingCells).toBe(DEFAULT_COMPARISON_CELL_LEDGER)
+		expect(work.remainingTokenComparisons).toBe(DEFAULT_COMPARISON_TOKEN_LEDGER)
+	})
+
+	it('leaves one incompatible changed item unmatched', () => {
+		const incompatible = {
+			...options(),
+			compatible: () => false,
+		}
+
+		expect(alignComparisonAxis(['list'], ['quote'], incompatible)).toEqual([
+			{ before: 0, after: null },
+			{ before: null, after: 0 },
+		])
+	})
+
+	it('A10 coarsens a multi-item rewrite with ambiguous exact attribution', () => {
+		expect(alignComparisonAxis(['aa', 'bb', 'cc'], ['xx', 'yy'], options())).toEqual([{
+			before: { from: 0, to: 3 },
+			after: { from: 0, to: 2 },
+			coarseReason: 'ambiguous-attribution',
+		}])
+	})
+
+	it.each([
+		Math.floor(FINAL_SQUARE_SIZE / 2),
+		FINAL_SQUARE_SIZE - 1,
+	])('A11 keeps a final-ledger-derived unique-evidence %i square gap precise', (size) => {
+		const result = alignComparisonAxis(
+			evidencedAxis(size, 'before'),
+			evidencedAxis(size, 'after'),
+			evidencedOptions(),
+		)
+
+		expect(result).toHaveLength(size)
+		expect(result.every((step, index) => step.before === index && step.after === index)).toBe(true)
+	})
+
+	it('A12 keeps the largest default-ledger square gap precise', () => {
+		const work = createComparisonWorkLedger()
+		const size = FINAL_SQUARE_SIZE
+		const result = alignComparisonAxis(
+			evidencedAxis(size, 'before'),
+			evidencedAxis(size, 'after'),
+			evidencedOptions(work),
+		)
+
+		expect(result).toHaveLength(size)
+		expect(work.remainingCells).toBe(0)
+		expect(work.remainingTokenComparisons).toBe(FINAL_TOKEN_LEDGER - 4 * size ** 2)
+	})
+
+	it('A13 refuses the first generated cell and token overflows atomically', () => {
+		const cellWork = createComparisonWorkLedger()
+		const size = FINAL_SQUARE_SIZE
+		expect(alignComparisonAxis(
+			evidencedAxis(size + 1, 'before'),
+			evidencedAxis(size, 'after'),
+			evidencedOptions(cellWork),
+		)).toEqual([{
+			before: { from: 0, to: size + 1 },
+			after: { from: 0, to: size },
+			coarseReason: 'comparison-limit',
+		}])
+		expect(cellWork).toEqual(createComparisonWorkLedger())
+
+		const tokenWork = createComparisonWorkLedger()
+		const longProfile = Array.from({ length: Math.floor(FINAL_TOKEN_LEDGER / (2 * size * size)) + 1 }, () => 'x')
+		expect(alignComparisonAxis(
+			evidencedAxis(size, 'before'),
+			evidencedAxis(size, 'after'),
+			{
+				...evidencedOptions(tokenWork),
+				profile: () => longProfile,
+			},
+		)).toEqual([{
+			before: { from: 0, to: size },
+			after: { from: 0, to: size },
+			coarseReason: 'comparison-limit',
+		}])
+		expect(tokenWork).toEqual(createComparisonWorkLedger())
+	})
+
+	it('A14 allocates final-ledger cell work by axis order without debiting a refused gap', () => {
+		interface Item {
+			fingerprint: string
+			profile: readonly string[]
+		}
+		const gap = (size: number, name: string, side: 'before' | 'after'): Item[] => (
+			Array.from({ length: size }, (_value, id) => ({
+				fingerprint: `${name}:${side}:${id}`,
+				profile: [`${name}:${id}`, side],
+			}))
+		)
+		const anchor = (name: string): Item => ({ fingerprint: name, profile: [name] })
+		const firstSize = Math.floor(FINAL_SQUARE_SIZE / 2)
+		const refusedSize = FINAL_SQUARE_SIZE
+		const lastSize = Math.max(2, Math.floor(firstSize / 10))
+		const before = [
+			...gap(firstSize, 'first', 'before'),
+			anchor('anchor-1'),
+			...gap(refusedSize, 'refused', 'before'),
+			anchor('anchor-2'),
+			...gap(lastSize, 'last', 'before'),
+		]
+		const after = [
+			...gap(firstSize, 'first', 'after'),
+			anchor('anchor-1'),
+			...gap(refusedSize, 'refused', 'after'),
+			anchor('anchor-2'),
+			...gap(lastSize, 'last', 'after'),
+		]
+		const work = createComparisonWorkLedger()
+		const result = alignComparisonAxis(before, after, {
+			work,
+			fingerprint: (item) => item.fingerprint,
+			profile: (item) => item.profile,
+			compatible: () => true,
+		})
+		const refusedStart = firstSize + 1
+
+		expect(result).toContainEqual({
+			before: { from: refusedStart, to: refusedStart + refusedSize },
+			after: { from: refusedStart, to: refusedStart + refusedSize },
+			coarseReason: 'comparison-limit',
+		})
+		expect(result.at(-1)).toEqual({ before: before.length - 1, after: after.length - 1 })
+		expect(work.remainingCells).toBe(FINAL_CELL_LEDGER - firstSize ** 2 - lastSize ** 2)
+	})
+
+	it('A14 retains token and tie debits while preserving work after a refused token gap', () => {
+		interface Item {
+			fingerprint: string
+			profile: readonly string[]
+		}
+		const gapSize = Math.floor(FINAL_SQUARE_SIZE / 2)
+		const firstAfterSize = gapSize - 1
+		const lastSize = Math.max(2, Math.floor(gapSize / 10))
+		const firstProduct = gapSize * firstAfterSize
+		const firstProfileLength = Math.floor(FINAL_TOKEN_LEDGER / (4 * firstProduct))
+		const firstProfile = Array.from({ length: firstProfileLength }, () => 'same')
+		const tieCharge = 2 * firstProduct * firstProfileLength
+		const refusedProfileLength = Math.floor((FINAL_TOKEN_LEDGER - tieCharge) / (2 * gapSize ** 2)) + 1
+		const refusedProfile = Array.from({ length: refusedProfileLength }, () => 'refused')
+		const gap = (size: number, name: string, side: 'before' | 'after', profile?: readonly string[]): Item[] => (
+			Array.from({ length: size }, (_value, id) => ({
+				fingerprint: `${name}:${side}:${id}`,
+				profile: profile ?? [`${name}:${id}`, side],
+			}))
+		)
+		const anchor = (name: string): Item => ({ fingerprint: name, profile: [name] })
+		const before = [
+			...gap(gapSize, 'tie', 'before', firstProfile),
+			anchor('anchor-1'),
+			...gap(gapSize, 'refused', 'before', refusedProfile),
+			anchor('anchor-2'),
+			...gap(lastSize, 'last', 'before'),
+		]
+		const after = [
+			...gap(firstAfterSize, 'tie', 'after', firstProfile),
+			anchor('anchor-1'),
+			...gap(gapSize, 'refused', 'after', refusedProfile),
+			anchor('anchor-2'),
+			...gap(lastSize, 'last', 'after'),
+		]
+		const work = createComparisonWorkLedger()
+		const result = alignComparisonAxis(before, after, {
+			work,
+			fingerprint: (item) => item.fingerprint,
+			profile: (item) => item.profile,
+			compatible: () => true,
+		})
+		const lastCharge = 4 * lastSize ** 2
+
+		expect(result[0]).toMatchObject({ coarseReason: 'ambiguous-attribution' })
+		expect(result).toContainEqual({
+			before: { from: gapSize + 1, to: 2 * gapSize + 1 },
+			after: { from: firstAfterSize + 1, to: firstAfterSize + gapSize + 1 },
+			coarseReason: 'comparison-limit',
+		})
+		expect(result.at(-1)).toEqual({ before: before.length - 1, after: after.length - 1 })
+		expect(work).toEqual({
+			remainingCells: FINAL_CELL_LEDGER - firstProduct - lastSize ** 2,
+			remainingTokenComparisons: FINAL_TOKEN_LEDGER - tieCharge - lastCharge,
+		})
+	})
+
+	it('P05 admits a skewed one-by-many gap by its exact cell charge', () => {
+		const work = createComparisonWorkLedger()
+		const result = alignComparisonAxis(
+			evidencedAxis(1, 'before'),
+			evidencedAxis(20_000, 'after'),
+			evidencedOptions(work),
+		)
+
+		expect(result).not.toContainEqual(expect.objectContaining({ coarseReason: 'comparison-limit' }))
+		expect(work.remainingCells).toBe(20_000)
+	})
+})

--- a/src/tests/comparison/comparisonAlignmentOracle.spec.ts
+++ b/src/tests/comparison/comparisonAlignmentOracle.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonAlignmentStep, ComparisonWorkLedger } from '../../comparison/comparisonAlignment.ts'
+
+import { describe, expect, it } from 'vitest'
+import {
+	DEFAULT_COMPARISON_CELL_LEDGER,
+	DEFAULT_COMPARISON_TOKEN_LEDGER,
+	solveWeightedGap,
+} from '../../comparison/comparisonAlignment.ts'
+
+interface OracleItem {
+	fingerprint: string
+	profile: readonly string[]
+}
+
+interface Rational {
+	numerator: bigint
+	denominator: bigint
+}
+
+interface OracleMatch {
+	before: number
+	after: number
+}
+
+function compareRational(a: Rational, b: Rational) {
+	const difference = a.numerator * b.denominator - b.numerator * a.denominator
+	return difference < 0n ? -1 : difference > 0n ? 1 : 0
+}
+
+function addRational(a: Rational, b: Rational): Rational {
+	return {
+		numerator: a.numerator * b.denominator + b.numerator * a.denominator,
+		denominator: a.denominator * b.denominator,
+	}
+}
+
+function oraclePairScore(before: OracleItem, after: OracleItem): Rational {
+	if (before.fingerprint === after.fingerprint) {
+		return { numerator: 3n, denominator: 1n }
+	}
+	let prefix = 0
+	while (prefix < before.profile.length
+		&& prefix < after.profile.length
+		&& before.profile[prefix] === after.profile[prefix]) {
+		prefix++
+	}
+	let suffix = 0
+	const maximumSuffix = Math.min(before.profile.length, after.profile.length) - prefix
+	while (suffix < maximumSuffix
+		&& before.profile[before.profile.length - suffix - 1] === after.profile[after.profile.length - suffix - 1]) {
+		suffix++
+	}
+	const denominator = BigInt(Math.max(before.profile.length, after.profile.length, 1))
+	return { numerator: denominator + BigInt(prefix + suffix), denominator }
+}
+
+function enumerateMatchings(
+	beforeCount: number,
+	afterCount: number,
+	beforeStart = 0,
+	afterStart = 0,
+): OracleMatch[][] {
+	const matchings: OracleMatch[][] = [[]]
+	for (let before = beforeStart; before < beforeCount; before++) {
+		for (let after = afterStart; after < afterCount; after++) {
+			for (const suffix of enumerateMatchings(beforeCount, afterCount, before + 1, after + 1)) {
+				matchings.push([{ before, after }, ...suffix])
+			}
+		}
+	}
+	return matchings
+}
+
+function oracleAlignment(before: readonly OracleItem[], after: readonly OracleItem[]) {
+	let bestScore: Rational = { numerator: -1n, denominator: 1n }
+	let best: OracleMatch[][] = []
+	for (const matching of enumerateMatchings(before.length, after.length)) {
+		const score = matching.reduce(
+			(total, pair) => addRational(total, oraclePairScore(before[pair.before]!, after[pair.after]!)),
+			{ numerator: 0n, denominator: 1n },
+		)
+		const order = compareRational(score, bestScore)
+		if (order > 0) {
+			bestScore = score
+			best = [matching]
+		} else if (order === 0) {
+			best.push(matching)
+		}
+	}
+	const signatures = new Map(best.map((matching) => [
+		matching.map(({ before: a, after: b }) => `${a}:${b}`).join(','),
+		matching,
+	]))
+	if (signatures.size > 1) {
+		return { coarseReason: 'ambiguous-attribution' as const }
+	}
+	return { steps: alignmentSteps(before.length, after.length, [...signatures.values()][0]!) }
+}
+
+function alignmentSteps(beforeCount: number, afterCount: number, matches: readonly OracleMatch[]) {
+	const steps: ComparisonAlignmentStep[] = []
+	let before = 0
+	let after = 0
+	for (const match of matches) {
+		while (before < match.before) {
+			steps.push({ before: before++, after: null })
+		}
+		while (after < match.after) {
+			steps.push({ before: null, after: after++ })
+		}
+		steps.push({ before: before++, after: after++ })
+	}
+	while (before < beforeCount) {
+		steps.push({ before: before++, after: null })
+	}
+	while (after < afterCount) {
+		steps.push({ before: null, after: after++ })
+	}
+	return steps
+}
+
+function axes(items: readonly OracleItem[], maximumLength: number): OracleItem[][] {
+	const result: OracleItem[][] = [[]]
+	for (let length = 1; length <= maximumLength; length++) {
+		for (const prefix of result.filter((axis) => axis.length === length - 1)) {
+			for (const item of items) {
+				result.push([...prefix, item])
+			}
+		}
+	}
+	return result
+}
+
+function freshWork(): ComparisonWorkLedger {
+	return {
+		remainingCells: DEFAULT_COMPARISON_CELL_LEDGER,
+		remainingTokenComparisons: DEFAULT_COMPARISON_TOKEN_LEDGER,
+	}
+}
+
+describe('comparison alignment exact oracles', () => {
+	it('matches an independent exact-rational and signature oracle exhaustively', () => {
+		const items: OracleItem[] = [
+			{ fingerprint: 'a', profile: ['shared', 'a'] },
+			{ fingerprint: 'b', profile: ['shared', 'b'] },
+			{ fingerprint: 'c', profile: ['c'] },
+		]
+		const candidates = axes(items, 3)
+		for (const before of candidates) {
+			for (const after of candidates) {
+				const actual = solveWeightedGap(before, after, {
+					work: freshWork(),
+					fingerprint: (item) => item.fingerprint,
+					profile: (item) => item.profile,
+					compatible: () => true,
+				})
+				expect(actual, `${before.map(({ fingerprint }) => fingerprint)} -> ${after.map(({ fingerprint }) => fingerprint)}`)
+					.toEqual(oracleAlignment(before, after))
+			}
+		}
+	})
+})

--- a/src/tests/comparison/comparisonDecorations.spec.ts
+++ b/src/tests/comparison/comparisonDecorations.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonDescriptor } from '../../comparison/markdownComparisonTypes.ts'
+
+import { EditorState } from '@tiptap/pm/state'
+import { schema } from 'prosemirror-schema-basic'
+import { describe, expect, it } from 'vitest'
+import { createComparisonDocumentIndex } from '../../comparison/comparisonDocumentIndex.ts'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+import {
+	ComparisonProjectionError,
+	createComparisonDecorationPlugin,
+	prepareComparisonDecorations,
+} from '../../comparison/markdownComparison.ts'
+
+function descriptor(id: string, before: { from: number, to: number }, after = before): ComparisonDescriptor {
+	return {
+		id,
+		operation: 'replace',
+		detail: 'inline',
+		facets: ['text'],
+		before,
+		after,
+		context: { before: null, after: null },
+		preview: { before: null, after: null },
+		signals: [],
+	}
+}
+
+const doc = schema.node('doc', null, [schema.node('paragraph', null, schema.text('hello'))])
+
+describe('comparison decorations', () => {
+	it('does not infer a current descriptor without edit-owned selection', () => {
+		const change = descriptor('text', { from: 1, to: 4 })
+		const { key, plugin } = createComparisonDecorationPlugin([change], 'before', 'Changed')
+		const state = EditorState.create({ doc, plugins: [plugin] })
+		expect(key.getState(state)).toMatchObject({ activeIds: ['text'], currentIds: [] })
+	})
+
+	it('V04 projects non-empty ranges without creating any marker for a zero-length side', () => {
+		expect(prepareComparisonDecorations(doc, [descriptor('empty', { from: 2, to: 2 })], 'before')).toEqual([])
+		const projected = prepareComparisonDecorations(doc, [descriptor('text', { from: 1, to: 4 })], 'before')
+		expect(projected).toEqual([expect.objectContaining({ from: 1, to: 4, type: 'inline' })])
+	})
+
+	it('fails the complete projection when a non-empty range cannot be represented', () => {
+		const invalid = descriptor('invalid', { from: 99, to: 100 })
+		expect(() => prepareComparisonDecorations(doc, [invalid], 'before')).toThrow(ComparisonProjectionError)
+	})
+
+	it('AUD-04 decorates the enclosing list for a coarse nested-list range', () => {
+		const editor = createComparisonEditor('- outer\n  - first\n  - second')
+		try {
+			const index = createComparisonDocumentIndex(editor.state.doc)
+			const outerList = index.children[0]!
+			const nestedList = outerList.children[0]!.children[1]!
+			const firstItem = nestedList.children[0]!
+			const lastItem = nestedList.children.at(-1)!
+			const change = descriptor('nested-list', { from: firstItem.from, to: lastItem.to })
+			change.detail = 'block'
+			change.context.before = {
+				code: 'list-item',
+				path: firstItem.path,
+				from: firstItem.from,
+				to: firstItem.to,
+			}
+
+			expect(prepareComparisonDecorations(editor.state.doc, [change], 'before')).toEqual([
+				expect.objectContaining({ from: nestedList.from, to: nestedList.to, type: 'node' }),
+			])
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('invalidates prepared immutable decorations after a document transaction', () => {
+		const change = descriptor('text', { from: 1, to: 4 })
+		const { key, plugin } = createComparisonDecorationPlugin([change], 'before', 'Changed', {
+			activeIds: ['text'],
+			currentIds: ['text'],
+		})
+		const state = EditorState.create({ doc, plugins: [plugin] })
+		expect(key.getState(state)?.prepared).toHaveLength(1)
+		const changed = state.apply(state.tr.insertText('!', 1))
+		expect(key.getState(changed)).toMatchObject({ activeIds: [], currentIds: [], prepared: [] })
+	})
+})

--- a/src/tests/comparison/comparisonDocumentLocation.spec.ts
+++ b/src/tests/comparison/comparisonDocumentLocation.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { locateComparisonTarget } from '../../comparison/comparisonNavigation.ts'
+
+function scrollerIn(pane: HTMLElement) {
+	const scroller = document.createElement('div')
+	pane.append(scroller)
+	Object.defineProperties(scroller, {
+		clientHeight: { value: 300 },
+		scrollHeight: { value: 1200 },
+		scrollLeft: { value: 20 },
+		scrollTop: { value: 50 },
+	})
+	vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue({ height: 300, top: 100 } as DOMRect)
+	Object.defineProperty(scroller, 'scrollTo', { value: vi.fn() })
+	return scroller
+}
+
+describe('comparison document location', () => {
+	it('prefers the decorated DOM target', () => {
+		const pane = document.createElement('article')
+		const scroller = scrollerIn(pane)
+		const target = document.createElement('span')
+		target.dataset.comparisonChange = 'descriptor-1'
+		scroller.append(target)
+		vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({ height: 20, top: 700 } as DOMRect)
+		const fallback = vi.fn(() => ({ top: 900, height: 1 }))
+		expect(locateComparisonTarget(pane, scroller, 'descriptor-1', 'smooth', fallback)).toBe(true)
+		expect(fallback).not.toHaveBeenCalled()
+	})
+
+	it('V04 centers a supplied position rectangle for a marker-free zero-length side', () => {
+		const pane = document.createElement('article')
+		const scroller = scrollerIn(pane)
+		const fallback = vi.fn(() => ({ top: 700, height: 1 }))
+		expect(locateComparisonTarget(pane, scroller, 'missing', 'auto', fallback)).toBe(true)
+		expect(scroller.scrollTo).toHaveBeenCalledWith({ behavior: 'auto', left: 20, top: 500.5 })
+		expect(pane.querySelector('[data-comparison-change="missing"]')).toBeNull()
+	})
+
+	it('fails closed for invalid or hidden panes', () => {
+		const pane = document.createElement('article')
+		const scroller = scrollerIn(pane)
+		pane.hidden = true
+		expect(locateComparisonTarget(pane, scroller, 'missing', 'auto', () => ({ top: 1, height: 1 }))).toBe(false)
+		expect(locateComparisonTarget(null, scroller, 'missing', 'auto')).toBe(false)
+	})
+})

--- a/src/tests/comparison/comparisonEditorLifecycle.spec.ts
+++ b/src/tests/comparison/comparisonEditorLifecycle.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { PluginKey, Plugin as ProseMirrorPlugin } from '@tiptap/pm/state'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import ComparisonEditorContent from '../../components/ComparisonEditorContent.vue'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+
+describe('comparison editor lifecycle boundary', () => {
+	it('mounts the detached editor with its comparison plugin and node views', async () => {
+		const editor = createComparisonEditor('::: info\nBefore\n:::')
+		const plugin = new ProseMirrorPlugin({ key: new PluginKey('comparison') })
+		const wrapper = mount(ComparisonEditorContent, { props: { editor, plugins: [plugin] } })
+		try {
+			await vi.waitFor(() => expect(wrapper.emitted('ready')).toHaveLength(1))
+			const content = wrapper.get('.text-comparison__content')
+			expect(editor.view.dom.parentElement).toBe(content.element)
+			expect(content.find('[data-node-view-wrapper][data-text-el="callout"]').exists()).toBe(true)
+			expect(plugin.spec.key?.get(editor.state)).toBeDefined()
+		} finally {
+			wrapper.unmount()
+			editor.destroy()
+		}
+	})
+})

--- a/src/tests/comparison/comparisonNavigation.spec.ts
+++ b/src/tests/comparison/comparisonNavigation.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonDescriptor, ComparisonEdit } from '../../comparison/markdownComparisonTypes.ts'
+
+import { describe, expect, it } from 'vitest'
+import {
+	currentIdAfterFilter,
+	currentOrdinal,
+	isPureFormatting,
+	moveCurrentId,
+} from '../../comparison/comparisonNavigation.ts'
+
+function descriptor(id: string, facets: ComparisonDescriptor['facets'], operation: ComparisonDescriptor['operation'] = 'replace'): ComparisonDescriptor {
+	return {
+		id,
+		operation,
+		detail: 'inline',
+		facets,
+		before: { from: 0, to: 1 },
+		after: { from: 0, to: 1 },
+		context: { before: null, after: null },
+		preview: { before: null, after: null },
+		signals: [],
+	}
+}
+
+function edit(id: string, descriptors: ComparisonDescriptor[]): ComparisonEdit {
+	return { id, kind: 'content', primary: descriptors.at(-1)!, descriptors }
+}
+
+describe('edit-first comparison navigation', () => {
+	const edits = [
+		edit('e0', [descriptor('d0', ['text'])]),
+		edit('e1', [descriptor('d1', ['formatting'])]),
+		edit('e2', [descriptor('d2a', ['formatting']), descriptor('d2b', ['text', 'formatting'])]),
+		edit('e3', [descriptor('d3', ['attribute'])]),
+	]
+
+	it('requires every member to be formatting-only', () => {
+		expect(isPureFormatting(edits[1]!)).toBe(true)
+		expect(isPureFormatting(edits[2]!)).toBe(false)
+	})
+
+	it('V02 preserves the current edit or moves next then previous after filtering', () => {
+		expect(currentIdAfterFilter(edits, ['e0', 'e2', 'e3'], 'e2')).toBe('e2')
+		expect(currentIdAfterFilter(edits, ['e0', 'e2', 'e3'], 'e1')).toBe('e2')
+		expect(currentIdAfterFilter(edits, ['e0'], 'e1')).toBe('e0')
+		expect(currentIdAfterFilter(edits, [], 'e1')).toBeNull()
+	})
+
+	it('V01 wraps navigation and reports one ordinal per first-class edit', () => {
+		const active = ['e0', 'e2', 'e3']
+		expect(moveCurrentId(active, 'e0', -1)).toBe('e3')
+		expect(moveCurrentId(active, 'e3', 1)).toBe('e0')
+		expect(currentOrdinal(active, 'e2')).toBe(2)
+		expect(currentOrdinal([], null)).toBe(0)
+	})
+})

--- a/src/tests/comparison/comparisonPerformance.spec.ts
+++ b/src/tests/comparison/comparisonPerformance.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+
+import { describe, expect, it } from 'vitest'
+import {
+	alignComparisonAxis,
+	createComparisonWorkLedger,
+	DEFAULT_COMPARISON_TOKEN_LEDGER,
+} from '../../comparison/comparisonAlignment.ts'
+import { createHierarchicalMarkdownComparisonModel } from '../../comparison/hierarchicalMarkdownComparisonModel.ts'
+import { prepareComparisonDecorations } from '../../comparison/markdownComparison.ts'
+import { createComparisonTestEditor } from './comparisonTestEditor.ts'
+
+interface Item {
+	key: string
+	profile: readonly string[]
+}
+
+function items(count: number, side: string): Item[] {
+	return Array.from({ length: count }, (_value, index) => ({
+		key: `${side}:${index}`,
+		profile: [`item:${index}`, side],
+	}))
+}
+
+function options(work = createComparisonWorkLedger()) {
+	return {
+		work,
+		fingerprint: ({ key }: Item) => key,
+		profile: ({ profile }: Item) => profile,
+		compatible: () => true,
+	}
+}
+
+describe('bounded comparison performance fixtures', () => {
+	it('AUD-14 projects near-limit one-sided descriptors within a bounded candidate budget', () => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const headings = Array.from({ length: 6490 }, (_value, index) => (
+				editor.schema.nodes.heading!.create({ level: 1 }, editor.schema.text(`Section ${index}`))
+			))
+			const populated = editor.schema.nodes.doc!.create(null, headings)
+			const empty = editor.schema.nodes.doc!.create()
+			const model = createHierarchicalMarkdownComparisonModel(populated, empty)
+			const descriptors = model.edits.flatMap(({ descriptors: members }) => members)
+
+			const prepared = prepareComparisonDecorations(populated, descriptors, 'before')
+
+			expect(prepared).toHaveLength(headings.length)
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('P01 compares a near-6500-line exact-anchor document with negligible weighted work', () => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const headings = Array.from({ length: 6490 }, (_value, index) => (
+				editor.schema.nodes.heading!.create({ level: 1 }, editor.schema.text(`Section ${index}`))
+			))
+			const before = editor.schema.nodes.doc!.create(null, headings)
+			const changedHeading = editor.schema.nodes.heading!.create(
+				{ level: 1 },
+				editor.schema.text('Section 3245 edited'),
+			)
+			const after = editor.schema.nodes.doc!.create(null, headings.with(3245, changedHeading))
+
+			const model = createHierarchicalMarkdownComparisonModel(before, after)
+
+			expect(model.edits).toHaveLength(1)
+
+			const work = createComparisonWorkLedger()
+			const axis = Array.from({ length: 6490 }, (_value, index) => ({
+				key: `anchor:${index}`,
+				profile: [`anchor:${index}`],
+			}))
+			const changed = axis.with(3245, { key: 'changed:3245', profile: ['changed:3245'] })
+			alignComparisonAxis(axis, changed, options(work))
+			expect(work).toEqual(createComparisonWorkLedger())
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it.each(['insert', 'delete'] as const)('places a near-6500-line one-sided %s axis in linear time', (operation) => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const headings = Array.from({ length: 6490 }, (_value, index) => (
+				editor.schema.nodes.heading!.create({ level: 1 }, editor.schema.text(`Section ${index}`))
+			))
+			const empty = editor.schema.nodes.doc!.create()
+			const populated = editor.schema.nodes.doc!.create(null, headings)
+			const model = operation === 'insert'
+				? createHierarchicalMarkdownComparisonModel(empty, populated)
+				: createHierarchicalMarkdownComparisonModel(populated, empty)
+
+			expect(model.edits).toHaveLength(headings.length)
+			expect(model.edits.every(({ primary }) => primary.operation === operation)).toBe(true)
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('P04 shares the final token ledger across nested production nodes', () => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const firstBeforeCount = 100
+			const firstAfterCount = firstBeforeCount - 1
+			const firstProduct = firstBeforeCount * firstAfterCount
+			const firstLength = Math.floor(DEFAULT_COMPARISON_TOKEN_LEDGER / (4 * firstProduct))
+			const firstCharge = 2 * firstProduct * firstLength
+			const secondCount = 100
+			const secondLength = Math.floor((DEFAULT_COMPARISON_TOKEN_LEDGER - firstCharge) / (2 * secondCount ** 2)) + 1
+			const paragraphs = (count: number, character: string, length: number) => Array.from(
+				{ length: count },
+				() => editor.schema.nodes.paragraph!.create(null, editor.schema.text(character.repeat(length))),
+			)
+			const quote = (children: readonly Node[]) => (
+				editor.schema.nodes.blockquote!.create(null, children)
+			)
+			const anchor = editor.schema.nodes.paragraph!.create(null, editor.schema.text('exact nested boundary anchor'))
+			const before = editor.schema.nodes.doc!.create(null, [
+				quote(paragraphs(firstBeforeCount, 'a', firstLength)),
+				anchor,
+				quote(paragraphs(secondCount, 'c', secondLength)),
+			])
+			const after = editor.schema.nodes.doc!.create(null, [
+				quote(paragraphs(firstAfterCount, 'b', firstLength)),
+				anchor,
+				quote(paragraphs(secondCount, 'd', secondLength)),
+			])
+			const model = createHierarchicalMarkdownComparisonModel(before, after)
+
+			expect(2 * secondCount ** 2 * (secondLength - 1)).toBeLessThanOrEqual(DEFAULT_COMPARISON_TOKEN_LEDGER - firstCharge)
+			expect(2 * secondCount ** 2 * secondLength).toBeGreaterThan(DEFAULT_COMPARISON_TOKEN_LEDGER - firstCharge)
+			expect(model.edits.map(({ primary }) => primary.coarseReason)).toEqual([
+				'ambiguous-attribution',
+				'comparison-limit',
+			])
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('P03 bounds many aggregate maximal gaps with one comparison-wide ledger', () => {
+		const gapCount = 5
+		const gapSize = 200
+		const before: Item[] = []
+		const after: Item[] = []
+		for (let gap = 0; gap < gapCount; gap++) {
+			before.push(...items(gapSize, `before-${gap}`))
+			after.push(...items(gapSize, `after-${gap}`))
+			if (gap < gapCount - 1) {
+				const anchor = { key: `anchor-${gap}`, profile: [`anchor-${gap}`] }
+				before.push(anchor)
+				after.push(anchor)
+			}
+		}
+		const work = createComparisonWorkLedger()
+
+		const result = alignComparisonAxis(before, after, options(work))
+		const limited = result.filter((region) => 'coarseReason' in region && region.coarseReason === 'comparison-limit')
+
+		expect(work.remainingCells).toBe(0)
+		expect(limited).toHaveLength(gapCount - 1)
+	})
+})

--- a/src/tests/comparison/comparisonPresentation.spec.ts
+++ b/src/tests/comparison/comparisonPresentation.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComparisonAttributeCode, ComparisonSignal } from '../../comparison/markdownComparisonTypes.ts'
+
+import { describe, expect, it } from 'vitest'
+import { selectComparisonSignal } from '../../comparison/comparisonPresentation.ts'
+
+const bold: ComparisonSignal = { type: 'mark', mark: 'bold', change: 'added' }
+const attribute = (code: ComparisonAttributeCode): ComparisonSignal => ({ type: 'attribute', attribute: code, change: 'changed' })
+
+describe('AUD-10 comparison presentation', () => {
+	it('selects the same strongest attribute regardless of descriptor storage order', () => {
+		const signals = [bold, attribute('image-alt'), attribute('image-target')]
+		expect(selectComparisonSignal(signals)).toEqual(attribute('image-target'))
+		expect(selectComparisonSignal([...signals].reverse())).toEqual(attribute('image-target'))
+	})
+
+	it('prioritizes every specific attribute and node structure over generic formatting', () => {
+		for (const code of ['link', 'task-state', 'heading-level', 'table-span', 'unknown-attribute'] as const) {
+			expect(selectComparisonSignal([bold, attribute(code)])).toEqual(attribute(code))
+		}
+		const node: ComparisonSignal = { type: 'node' }
+		expect(selectComparisonSignal([bold, node])).toEqual(node)
+	})
+})

--- a/src/tests/comparison/comparisonSections.spec.ts
+++ b/src/tests/comparison/comparisonSections.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonDescriptor, ComparisonEdit } from '../../comparison/markdownComparisonTypes.ts'
+
+import { schema } from 'prosemirror-schema-basic'
+import { describe, expect, it } from 'vitest'
+import { buildComparisonSections, headingLocations, nearestHeading } from '../../comparison/comparisonSections.ts'
+
+function doc(...blocks: Array<[type: 'heading' | 'paragraph', text: string]>): Node {
+	return schema.node('doc', null, blocks.map(([type, text]) => schema.node(type, type === 'heading' ? { level: 1 } : null, text ? schema.text(text) : undefined)))
+}
+
+function descriptor(id: string, operation: ComparisonDescriptor['operation'], before: number, after: number): ComparisonDescriptor {
+	return {
+		id,
+		operation,
+		detail: 'inline',
+		facets: ['text'],
+		before: { from: before, to: before + 1 },
+		after: { from: after, to: after + 1 },
+		context: {
+			before: { code: 'paragraph', path: [1], from: before, to: before + 1 },
+			after: { code: 'paragraph', path: [1], from: after, to: after + 1 },
+		},
+		preview: { before: null, after: null },
+		signals: [],
+	}
+}
+
+function edit(id: string, primary: ComparisonDescriptor, members: ComparisonDescriptor[] = [primary]): ComparisonEdit {
+	return { id, kind: 'content', primary, descriptors: members }
+}
+
+describe('edit-first comparison sections', () => {
+	it('finds ordered headings and resolves the nearest preceding heading', () => {
+		const document = doc(['paragraph', 'Intro'], ['heading', 'One'], ['paragraph', 'Body'], ['heading', 'Two'])
+		const headings = headingLocations(document)
+		expect(headings.map(({ text }) => text)).toEqual(['One', 'Two'])
+		expect(nearestHeading(headings, 0)).toBe('')
+		expect(nearestHeading(headings, headings[1]!.from)).toBe('Two')
+	})
+
+	it('builds one row source per edit', () => {
+		const before = doc(['heading', 'Alpha'], ['paragraph', 'Before'])
+		const after = doc(['heading', 'Alpha'], ['paragraph', 'After'])
+		const headingEnd = after.child(0).nodeSize
+		const primary = descriptor('d-primary', 'replace', headingEnd, headingEnd)
+		const formatting = { ...descriptor('d-format', 'replace', headingEnd, headingEnd), facets: ['formatting'] as const }
+		const sections = buildComparisonSections([edit('edit-1', primary, [formatting, primary])], before, after)
+
+		expect(sections).toEqual([expect.objectContaining({
+			id: 'edit-1',
+			title: 'Alpha',
+			edits: [expect.objectContaining({ id: 'edit-1', primary })],
+		})])
+	})
+
+	it('uses Before context for deletions and the After title for a correlated rename', () => {
+		const before = doc(['heading', 'Old'], ['paragraph', 'Before'])
+		const after = doc(['heading', 'New'], ['paragraph', 'After'])
+		const beforeBody = before.child(0).nodeSize
+		const afterBody = after.child(0).nodeSize
+		const rename = descriptor('rename', 'replace', 0, 0)
+		rename.context.before = { code: 'heading', path: [0], from: 0, to: beforeBody }
+		rename.context.after = { code: 'heading', path: [0], from: 0, to: afterBody }
+		const deletion = descriptor('delete', 'delete', beforeBody, afterBody)
+		const sections = buildComparisonSections([edit('rename-edit', rename), edit('delete-edit', deletion)], before, after)
+
+		expect(sections.map(({ title }) => title)).toEqual(['New'])
+		expect(sections[0]!.edits.map(({ id }) => id)).toEqual(['rename-edit', 'delete-edit'])
+	})
+})

--- a/src/tests/comparison/comparisonTestEditor.ts
+++ b/src/tests/comparison/comparisonTestEditor.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+
+export function createComparisonTestEditor(content: string) {
+	return createComparisonEditor(content, { noLazyImages: true })
+}
+
+export function comparisonTestDocument(content: string) {
+	const editor = createComparisonEditor(content, { noLazyImages: true })
+	try {
+		return editor.state.doc
+	} finally {
+		editor.destroy()
+	}
+}

--- a/src/tests/comparison/createComparisonEditor.spec.ts
+++ b/src/tests/comparison/createComparisonEditor.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createComparisonEditor } from '../../comparison/createComparisonEditor.ts'
+
+describe('comparison editor', () => {
+	it('creates a complete immutable detached Text editor with directional paragraphs', () => {
+		const editor = createComparisonEditor('English\n\nالعربية')
+		try {
+			expect(editor.options.element).toBeInstanceOf(HTMLElement)
+			expect((editor.options.element as HTMLElement).isConnected).toBe(false)
+			expect(editor.isEditable).toBe(false)
+			expect(editor.state.doc.textContent).toBe('Englishالعربية')
+			const directions: Array<string | null> = []
+			editor.state.doc.descendants((node) => {
+				if (node.type.name === 'paragraph') {
+					directions.push(node.attrs.dir as string | null)
+				}
+			})
+			expect(directions.slice(0, 2)).toEqual(['ltr', 'rtl'])
+		} finally {
+			editor.destroy()
+		}
+	})
+})

--- a/src/tests/comparison/createMarkdownContentComparison.spec.ts
+++ b/src/tests/comparison/createMarkdownContentComparison.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Editor } from '@tiptap/vue-3'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import * as markdownComparison from '../../comparison/markdownComparison.ts'
+import { createMarkdownContentComparison } from '../../createMarkdownContentComparison.ts'
+
+const originalScrollTo = HTMLElement.prototype.scrollTo
+
+beforeAll(async () => {
+	HTMLElement.prototype.scrollTo = vi.fn()
+	await Promise.all([
+		import('../../components/MarkdownContentComparison.vue'),
+		import('../../components/MarkdownSourceFallback.vue'),
+	])
+})
+
+afterAll(() => {
+	if (originalScrollTo) {
+		HTMLElement.prototype.scrollTo = originalScrollTo
+	} else {
+		delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo
+	}
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('Markdown comparison factory fallback and lifecycle', () => {
+	it('V09 reports syntax-only Markdown as no semantic edit and opens Source', async () => {
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({
+			beforeContent: '*same rendered text*',
+			afterContent: '_same rendered text_',
+			el,
+		})
+
+		expect(el.querySelectorAll('[data-comparison-change]')).toHaveLength(0)
+		expect(el.querySelector('[role="status"]')?.textContent).toContain('No rendered differences')
+		const openSource = el.querySelector<HTMLButtonElement>('[data-comparison-empty-action]')
+		expect(openSource).not.toBeNull()
+		openSource!.click()
+		await nextTick()
+		expect([...el.querySelectorAll<HTMLElement>('[role="tab"]')]
+			.find(({ textContent }) => textContent?.trim() === 'Markdown source')
+			?.getAttribute('aria-selected')).toBe('true')
+		instance.destroy()
+	})
+
+	it('F05 remounts complete Source when rendered editor initialization fails', async () => {
+		vi.spyOn(Editor.prototype, 'mount').mockImplementation(() => {
+			throw new Error('forced mount failure')
+		})
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({ beforeContent: '<b>before</b>', afterContent: '<i>after</i>', el })
+		expect(el.querySelector('[data-comparison-source-fallback]')).not.toBeNull()
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(0)
+		expect(el.textContent).toContain('<b>before</b>')
+		expect(el.textContent).toContain('<i>after</i>')
+		instance.destroy()
+		instance.destroy()
+		expect(el.childElementCount).toBe(0)
+	})
+
+	it('F06 remounts complete Source without partial Documents when projection fails', async () => {
+		const originalSetAttribute = Element.prototype.setAttribute
+		vi.spyOn(Element.prototype, 'setAttribute').mockImplementation(function(this: Element, name, value) {
+			if (name === 'data-comparison-change') {
+				throw new Error('forced projection failure')
+			}
+			return originalSetAttribute.call(this, name, value)
+		})
+		const beforeContent = 'Complete projection before'
+		const afterContent = 'Complete projection after'
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({ beforeContent, afterContent, el })
+		const fullDocuments = [...el.querySelectorAll<HTMLButtonElement>('[role="tab"]')]
+			.find(({ textContent }) => textContent?.trim() === 'Full documents')
+
+		fullDocuments!.click()
+		await vi.waitFor(() => {
+			expect(el.querySelector('[data-comparison-source-fallback]')).not.toBeNull()
+		})
+		expect(el.querySelectorAll('.text-comparison__documents .ProseMirror')).toHaveLength(0)
+		expect(el.textContent).toContain(beforeContent)
+		expect(el.textContent).toContain(afterContent)
+		instance.destroy()
+	})
+
+	it('V12 can reopen the same pair after idempotent destroy without leaking root DOM', async () => {
+		const el = document.createElement('div')
+		for (let index = 0; index < 2; index++) {
+			const instance = await createMarkdownContentComparison({ beforeContent: 'Before', afterContent: 'After', el })
+			expect(el.querySelectorAll('.text-comparison-root')).toHaveLength(1)
+			instance.destroy()
+			instance.destroy()
+			expect(el.childElementCount).toBe(0)
+		}
+	})
+
+	it('keeps both document editors alive while switching views', async () => {
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({ beforeContent: 'Before', afterContent: 'After', el })
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(0)
+		expect(el.querySelectorAll('[data-comparison-source-fallback]')).toHaveLength(0)
+		const selectTab = async (label: string) => {
+			const tab = [...el.querySelectorAll<HTMLButtonElement>('[role="tab"]')]
+				.find(({ textContent }) => textContent?.trim() === label)
+			expect(tab).toBeDefined()
+			tab!.click()
+			await nextTick()
+		}
+
+		await selectTab('Full documents')
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(2)
+		await selectTab('Changes')
+		await selectTab('Full documents')
+
+		expect(el.querySelector('.text-comparison > [data-comparison-source-fallback]')).toBeNull()
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(2)
+		instance.destroy()
+	})
+
+	it('omits duplicate heading anchors from the two comparison documents', async () => {
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({
+			beforeContent: '# Shared heading\n\nBefore',
+			afterContent: '# Shared heading\n\nAfter',
+			el,
+		})
+		const documents = [...el.querySelectorAll<HTMLButtonElement>('[role="tab"]')]
+			.find(({ textContent }) => textContent?.trim() === 'Full documents')
+
+		documents!.click()
+		await nextTick()
+
+		await vi.waitFor(() => expect(el.querySelectorAll('.ProseMirror')).toHaveLength(2))
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		expect(el.querySelectorAll('.text-comparison__documents .heading-anchor[id]')).toHaveLength(0)
+		instance.destroy()
+	})
+
+	it('AUD-02 publishes the current selection when Documents mounts lazily', async () => {
+		const originalScrollTo = HTMLElement.prototype.scrollTo
+		const scrollTo = vi.fn()
+		HTMLElement.prototype.scrollTo = scrollTo
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({
+			beforeContent: 'Old first.\n\nOld second.',
+			afterContent: 'New first.\n\nNew second.',
+			el,
+		})
+		const secondEdit = el.querySelectorAll<HTMLButtonElement>('[data-comparison-select]')[1]
+
+		secondEdit!.click()
+		await vi.waitFor(() => {
+			expect(el.querySelectorAll('[data-comparison-change="change-1"][aria-current="true"]')).toHaveLength(2)
+		})
+		await vi.waitFor(() => expect(scrollTo).toHaveBeenCalled())
+		instance.destroy()
+		if (originalScrollTo) {
+			HTMLElement.prototype.scrollTo = originalScrollTo
+		} else {
+			delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo
+		}
+	})
+
+	it('AUD-11 locates the current edit on the newly visible side after a single-to-paired resize', async () => {
+		const originalResizeObserver = globalThis.ResizeObserver
+		const originalScrollTo = HTMLElement.prototype.scrollTo
+		const scrollTo = vi.fn()
+		let resizeTo!: (width: number) => void
+		HTMLElement.prototype.scrollTo = scrollTo
+		globalThis.ResizeObserver = class {
+			constructor(private readonly callback: ResizeObserverCallback) {}
+
+			observe(target: Element) {
+				resizeTo = (width) => this.callback([{ target, contentRect: { width } } as ResizeObserverEntry], this)
+				resizeTo(600)
+			}
+
+			disconnect() {}
+
+			unobserve() {}
+		} as typeof ResizeObserver
+		const el = document.createElement('div')
+		const instance = await createMarkdownContentComparison({
+			beforeContent: 'Old first.\n\nOld second.',
+			afterContent: 'New first.\n\nNew second.',
+			el,
+		})
+		try {
+			el.querySelectorAll<HTMLButtonElement>('[data-comparison-select]')[1]!.click()
+			await vi.waitFor(() => expect(el.querySelector('.text-comparison--single')).not.toBeNull())
+			const afterScroller = el.querySelector<HTMLElement>('.text-comparison__document--after .text-comparison__document-scroller')!
+			await vi.waitFor(() => expect(scrollTo).toHaveBeenCalled())
+			expect(scrollTo.mock.contexts).not.toContain(afterScroller)
+
+			resizeTo(900)
+			await vi.waitFor(() => expect(el.querySelector('.text-comparison--paired')).not.toBeNull())
+
+			expect(scrollTo.mock.contexts).toContain(afterScroller)
+		} finally {
+			instance.destroy()
+			globalThis.ResizeObserver = originalResizeObserver
+			if (originalScrollTo) {
+				HTMLElement.prototype.scrollTo = originalScrollTo
+			} else {
+				delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo
+			}
+		}
+	})
+
+	it('keeps the working comparison when the loaded callback throws', async () => {
+		const el = document.createElement('div')
+		const creation = createMarkdownContentComparison({
+			beforeContent: 'Before',
+			afterContent: 'After',
+			el,
+			onLoaded: () => { throw new Error('callback failure') },
+		})
+		const instance = await Promise.race([
+			creation,
+			new Promise<null>((resolve) => setTimeout(() => resolve(null), 1000)),
+		])
+		expect(instance).not.toBeNull()
+		expect(el.querySelector('.text-comparison')).not.toBeNull()
+		expect(el.querySelector('[data-comparison-source-fallback]')).toBeNull()
+		instance?.destroy()
+	})
+
+	it('AUD-21 awaits a rejected loaded callback and keeps the working comparison', async () => {
+		const el = document.createElement('div')
+		let rejectLoaded!: (error: Error) => void
+		const onLoaded = vi.fn(() => new Promise<void>((_resolve, reject) => {
+			rejectLoaded = reject
+		}))
+		const creation = createMarkdownContentComparison({
+			beforeContent: 'Before',
+			afterContent: 'After',
+			el,
+			onLoaded,
+		})
+		let creationSettled = false
+		void creation.then(() => {
+			creationSettled = true
+		})
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(onLoaded).toHaveBeenCalledOnce()
+		expect(creationSettled).toBe(false)
+		rejectLoaded(new Error('async callback failure'))
+		const instance = await creation
+
+		expect(el.querySelector('.text-comparison')).not.toBeNull()
+		expect(el.querySelector('[data-comparison-source-fallback]')).toBeNull()
+		instance.destroy()
+	})
+
+	it('F07 routes a descriptor model limit to complete Source', async () => {
+		vi.spyOn(markdownComparison, 'createMarkdownComparisonModel').mockImplementation(() => {
+			throw new markdownComparison.ComparisonModelLimitError()
+		})
+		const beforeContent = '# Complete before snapshot\n\nBefore body\n'
+		const afterContent = '# Complete after snapshot\n\nAfter body\n'
+		const el = document.createElement('div')
+
+		const instance = await createMarkdownContentComparison({ beforeContent, afterContent, el })
+
+		expect(el.querySelector('[data-comparison-source-fallback]')).not.toBeNull()
+		expect(el.querySelectorAll('.ProseMirror')).toHaveLength(0)
+		expect(el.textContent).toContain('Detailed rendered comparison unavailable')
+		expect(el.textContent).not.toContain('No rendered changes')
+		expect(el.textContent).toContain(beforeContent)
+		expect(el.textContent).toContain(afterContent)
+		instance.destroy()
+	})
+})

--- a/src/tests/comparison/hierarchicalMarkdownComparison.spec.ts
+++ b/src/tests/comparison/hierarchicalMarkdownComparison.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@tiptap/pm/model'
+import type { ComparisonEdit, ComparisonSide } from '../../comparison/markdownComparisonTypes.ts'
+
+import { Schema } from '@tiptap/pm/model'
+import { schema as basicSchema } from 'prosemirror-schema-basic'
+import { describe, expect, it } from 'vitest'
+import {
+	ComparisonModelLimitError,
+	createHierarchicalMarkdownComparisonModel,
+	MAX_INLINE_ENVELOPE_SIZE,
+	MAX_RENDERED_COMPARISON_DESCRIPTORS,
+} from '../../comparison/hierarchicalMarkdownComparisonModel.ts'
+import { comparisonTestDocument, createComparisonTestEditor } from './comparisonTestEditor.ts'
+
+function compare(beforeContent: string, afterContent: string) {
+	const before = comparisonTestDocument(beforeContent)
+	const after = comparisonTestDocument(afterContent)
+	return {
+		before,
+		after,
+		model: createHierarchicalMarkdownComparisonModel(before, after),
+	}
+}
+
+function meaningfulSize(doc: Node) {
+	return doc.content.size - (doc.lastChild?.content.size === 0 ? doc.lastChild.nodeSize : 0)
+}
+
+function editText(doc: { textBetween: (from: number, to: number, separator: string) => string }) {
+	return (edit: ComparisonEdit, side: ComparisonSide) => (
+		doc.textBetween(edit.primary[side].from, edit.primary[side].to, '\n')
+	)
+}
+
+describe('hierarchical markdown comparison', () => {
+	it('A01 emits no edit for two equal documents', () => {
+		const { model } = compare('# Title\n\nBody text.\n', '# Title\n\nBody text.\n')
+
+		expect(model.edits).toEqual([])
+	})
+
+	it('A02 normalizes separate schema instances without position or content drift', () => {
+		const beforeEditor = createComparisonTestEditor('# Title\n\nOriginal body.\n')
+		const afterEditor = createComparisonTestEditor('# Title\n\nUpdated body.\n')
+		try {
+			const before = beforeEditor.state.doc
+			const after = afterEditor.state.doc
+			expect(before.type.schema).not.toBe(after.type.schema)
+
+			const model = createHierarchicalMarkdownComparisonModel(before, after)
+
+			expect(model.edits).toHaveLength(1)
+			const [edit] = model.edits
+			expect(before.textBetween(edit!.primary.before.from, edit!.primary.before.to)).toBe('Original')
+			expect(after.textBetween(edit!.primary.after.from, edit!.primary.after.to)).toBe('Updated')
+		} finally {
+			beforeEditor.destroy()
+			afterEditor.destroy()
+		}
+	})
+
+	it('AUD-19 rejects cross-schema normalization that drops node attributes', () => {
+		const paragraph = basicSchema.spec.nodes.get('paragraph')!
+		const beforeSchema = new Schema({
+			nodes: basicSchema.spec.nodes.update('paragraph', { ...paragraph, attrs: { audit: { default: null } } }),
+			marks: basicSchema.spec.marks,
+		})
+		const afterSchema = new Schema({ nodes: basicSchema.spec.nodes, marks: basicSchema.spec.marks })
+		const before = beforeSchema.node('doc', null, [beforeSchema.node('paragraph', { audit: 'must-survive' }, beforeSchema.text('same'))])
+		const after = afterSchema.node('doc', null, [afterSchema.node('paragraph', null, afterSchema.text('same'))])
+
+		expect(() => createHierarchicalMarkdownComparisonModel(before, after)).toThrow(/schema normalization lost semantics/)
+	})
+
+	it('A05 retains the first repeated paragraph and inserts the second copy', () => {
+		const { after, model } = compare('Anchor\n\nSame\n', 'Anchor\n\nSame\n\nSame\n')
+		const text = editText(after)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]!.primary.operation).toBe('insert')
+		expect(text(model.edits[0]!, 'after')).toBe('Same')
+		expect(model.edits[0]!.primary.after).toEqual({
+			from: after.child(0).nodeSize + after.child(1).nodeSize,
+			to: meaningfulSize(after),
+		})
+	})
+
+	it('A06 retains the first repeated paragraph and deletes the second copy', () => {
+		const { before, model } = compare('Anchor\n\nSame\n\nSame\n', 'Anchor\n\nSame\n')
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]!.primary.operation).toBe('delete')
+		expect(model.edits[0]!.primary.before).toEqual({
+			from: before.child(0).nodeSize + before.child(1).nodeSize,
+			to: meaningfulSize(before),
+		})
+	})
+
+	it.each([
+		['insertion', '# Existing\n', '## Added\n\n# Existing\n', 'insert'],
+		['deletion', '## Removed\n\n# Existing\n', '# Existing\n', 'delete'],
+	] as const)('AUD-12 reports a heading %s as added or removed without adjacent heading attributes', (_name, beforeContent, afterContent, operation) => {
+		const { model } = compare(beforeContent, afterContent)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]!.primary.operation).toBe(operation)
+		expect(model.edits[0]!.primary.signals).not.toContainEqual(expect.objectContaining({
+			type: 'attribute',
+			attribute: 'heading-level',
+		}))
+	})
+
+	it('A07 reports a paragraph turning into a heading as one semantic replacement', () => {
+		const { model } = compare('Shared title\n', '# Shared title\n')
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]).toMatchObject({
+			kind: 'content',
+			primary: {
+				detail: 'block',
+				operation: 'replace',
+				context: { before: { code: 'paragraph' }, after: { code: 'heading' } },
+			},
+		})
+		expect(model.edits[0]!.primary.facets).toContain('structure')
+		expect(model.edits[0]!.primary.signals).toContainEqual({
+			type: 'attribute',
+			attribute: 'heading-level',
+			change: 'added',
+		})
+	})
+
+	it('A08 does not pair incompatible non-text containers', () => {
+		const { model } = compare('- Shared item\n', '> Shared item\n')
+
+		expect(model.edits).toHaveLength(2)
+		expect(model.edits.map(({ primary }) => primary.operation).toSorted()).toEqual(['delete', 'insert'])
+	})
+
+	it.each([
+		['section headings', '# Setup\n\n# Usage\n\n# Notes\n', '# Install\n\n# Config\n'],
+		['shopping items', 'Buy milk\n\nBuy eggs\n\nBuy rice\n', 'Get bread\n\nGet jam\n'],
+	])('A10 coarsens a no-affix %s rewrite', (_name, beforeContent, afterContent) => {
+		const { before, after, model } = compare(beforeContent, afterContent)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]!.primary).toMatchObject({
+			coarseReason: 'ambiguous-attribution',
+			detail: 'block',
+			operation: 'replace',
+			before: { from: 0, to: meaningfulSize(before) },
+			after: { from: 0, to: meaningfulSize(after) },
+		})
+	})
+
+	it('reports one reordered block as one move edit', () => {
+		const { model } = compare(
+			'Unique alpha\n\nUnique beta\n\nUnique gamma\n',
+			'Unique beta\n\nUnique gamma\n\nUnique alpha\n',
+		)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]!.primary).toMatchObject({
+			operation: 'move',
+			detail: 'block',
+			facets: ['structure'],
+		})
+	})
+
+	it('pairs uniquely compatible changed containers instead of coarsening their shared gap', () => {
+		const before = [
+			'# Operational notes',
+			'',
+			'> Draft maintenance window starts at 20:00.',
+			'',
+			'::: info',
+			'The canary is limited to one region.',
+			':::',
+			'',
+			'<details open>',
+			'<summary>Draft runbook</summary>',
+			'',
+			'Rollback after two failed health checks.',
+			'',
+			'</details>',
+			'',
+		].join('\n')
+		const after = [
+			'# Operational notes',
+			'',
+			'> Approved maintenance window starts at 21:00.',
+			'',
+			'::: warn',
+			'The canary is limited to two regions.',
+			':::',
+			'',
+			'<details>',
+			'<summary>Approved runbook</summary>',
+			'',
+			'Rollback after one failed health check.',
+			'',
+			'</details>',
+			'',
+		].join('\n')
+		const { model } = compare(before, after)
+		const attributes = model.edits.flatMap(({ descriptors }) => descriptors)
+			.flatMap(({ signals }) => signals)
+			.filter((signal) => signal.type === 'attribute')
+			.map(({ attribute }) => attribute)
+		const primaryAttributes = model.edits
+			.flatMap(({ primary }) => primary.signals)
+			.filter((signal) => signal.type === 'attribute')
+			.map(({ attribute }) => attribute)
+
+		expect(model.edits.length).toBeGreaterThan(3)
+		expect(model.edits.every(({ primary }) => primary.coarseReason === undefined)).toBe(true)
+		expect(attributes).toContain('callout-type')
+		expect(attributes).toContain('details-state')
+		expect(primaryAttributes.filter((attribute) => attribute === 'callout-type')).toHaveLength(1)
+		expect(primaryAttributes.filter((attribute) => attribute === 'details-state')).toHaveLength(1)
+	})
+
+	it('does not label code content edits as language changes', () => {
+		const { model } = compare(
+			'```javascript\nconst stage = "draft"\n```\n',
+			'```typescript\nconst stage = "ready"\n```\n',
+		)
+		const languageEdits = model.edits.filter(({ primary }) => primary.signals.some((signal) => (
+			signal.type === 'attribute' && signal.attribute === 'code-language'
+		)))
+
+		expect(languageEdits).toHaveLength(1)
+		expect(model.edits.some(({ primary }) => (
+			primary.preview.before?.kind === 'text'
+			&& primary.preview.before.text === 'draft'
+			&& primary.signals.every((signal) => signal.type !== 'attribute' || signal.attribute !== 'code-language')
+		))).toBe(true)
+	})
+
+	it('expands front-matter previews to complete changed lines', () => {
+		const { model } = compare([
+			'---',
+			'release: atlas-2.4',
+			'status: draft',
+			'owner: Maya Chen',
+			'tags: [payments, canary]',
+			'legacy: true',
+			'---',
+			'',
+			'# Release record',
+		].join('\n'), [
+			'---',
+			'release: atlas-2.4.1',
+			'status: approved',
+			'owner: Noor Rahman',
+			'tags: [payments, canary, customer-visible]',
+			'approved-at: 2026-08-30T21:00:00+07:00',
+			'---',
+			'',
+			'# Release record',
+		].join('\n'))
+		const previews = model.edits
+			.filter(({ primary }) => primary.context.before?.code === 'front-matter')
+			.map(({ primary }) => [primary.preview.before, primary.preview.after])
+			.flat()
+			.map((preview) => preview?.kind === 'text' ? preview.text : '')
+
+		expect(previews).toHaveLength(4)
+		expect(previews[0]).toMatch(/^release: atlas-2\.4\b/)
+		expect(previews[1]).toMatch(/^release: atlas-2\.4\.1\b/)
+		expect(previews[2]).toMatch(/^tags: \[payments, canary\]/)
+		expect(previews[3]).toMatch(/^tags: \[payments, canary, customer-visible\]/)
+	})
+
+	it('moves exact repeated section content with its unique heading anchor', () => {
+		const repeated = 'Health check passed.\n\nDeploy the stable build.'
+		const before = [
+			'# Repeated deployment notes',
+			`## Region A\n\n${repeated}`,
+			`## Region B\n\n${repeated}`,
+			`## Retired region\n\n${repeated}`,
+			`## Region C\n\n${repeated}`,
+		].join('\n\n')
+		const after = [
+			'# Repeated deployment notes',
+			`## Region C\n\n${repeated}`,
+			`## Region A\n\n${repeated}`,
+			'## New region\n\nHealth check passed.\n\nDeploy the canary build.',
+			`## Region B\n\n${repeated}`,
+		].join('\n\n')
+		const { before: beforeDoc, after: afterDoc, model } = compare(before, after)
+		const moved = model.edits.find(({ primary }) => primary.operation === 'move')!
+		const repeatedCopies = model.edits.filter(({ primary }) => primary.operation !== 'move')
+			.map((edit) => ({
+				operation: edit.primary.operation,
+				before: beforeDoc.textBetween(edit.primary.before.from, edit.primary.before.to, '\n'),
+				after: afterDoc.textBetween(edit.primary.after.from, edit.primary.after.to, '\n'),
+			}))
+
+		expect(model.edits).toHaveLength(7)
+		expect(beforeDoc.textBetween(moved.primary.before.from, moved.primary.before.to, '\n'))
+			.toBe('Region C\nHealth check passed.\nDeploy the stable build.')
+		expect(afterDoc.textBetween(moved.primary.after.from, moved.primary.after.to, '\n'))
+			.toBe('Region C\nHealth check passed.\nDeploy the stable build.')
+		expect(repeatedCopies.filter(({ before }) => before === 'Health check passed.')).toHaveLength(1)
+		expect(repeatedCopies.filter(({ after }) => after === 'Health check passed.')).toHaveLength(1)
+	})
+
+	it('F08 keeps a large inline envelope as one rendered block change', () => {
+		const shared = 'z'.repeat(MAX_INLINE_ENVELOPE_SIZE)
+		const { before, after, model } = compare(`start ${shared}\n`, `${shared} finish\n`)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]!.primary).toMatchObject({
+			detail: 'block',
+			before: { from: 0, to: meaningfulSize(before) },
+			after: { from: 0, to: meaningfulSize(after) },
+		})
+	})
+
+	it('accepts 10000 descriptors and rejects 10001 at the production default', () => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const document = (count: number, side: 'before' | 'after') => {
+				const nodes = Array.from({ length: count }, (_value, index) => [
+					editor.schema.nodes.paragraph!.create(null, editor.schema.text(`${side} ${index}`)),
+					editor.schema.nodes.heading!.create({ level: 2 }, editor.schema.text(`Exact anchor ${index}`)),
+				]).flat()
+				return editor.schema.nodes.doc!.create(null, nodes)
+			}
+			const before = document(MAX_RENDERED_COMPARISON_DESCRIPTORS + 1, 'before')
+			const atLimit = createHierarchicalMarkdownComparisonModel(
+				editor.schema.nodes.doc!.create(null, before.content.content.slice(0, -2)),
+				document(MAX_RENDERED_COMPARISON_DESCRIPTORS, 'after'),
+			)
+
+			expect(MAX_RENDERED_COMPARISON_DESCRIPTORS).toBe(10_000)
+			expect(atLimit.edits).toHaveLength(MAX_RENDERED_COMPARISON_DESCRIPTORS)
+			expect(() => createHierarchicalMarkdownComparisonModel(
+				before,
+				document(MAX_RENDERED_COMPARISON_DESCRIPTORS + 1, 'after'),
+			)).toThrow(ComparisonModelLimitError)
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('freezes the model and keeps the primary inside its own descriptors', () => {
+		const { model } = compare('one\n\ntwo\n', 'one edited\n\ntwo edited\n')
+
+		expect(Object.isFrozen(model)).toBe(true)
+		expect(Object.isFrozen(model.edits)).toBe(true)
+		expect(model.edits.every((edit) => edit.descriptors.includes(edit.primary))).toBe(true)
+		expect(new Set(model.edits.map(({ id }) => id))).toHaveLength(model.edits.length)
+		expect(new Set(model.edits.flatMap(({ descriptors }) => descriptors.map(({ id }) => id))))
+			.toHaveLength(model.edits.flatMap(({ descriptors }) => descriptors).length)
+	})
+})

--- a/src/tests/comparison/markdownSourceComparison.spec.ts
+++ b/src/tests/comparison/markdownSourceComparison.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { SourceDiffHunk, SourceDiffLine } from '../../comparison/markdownSourceComparison.ts'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createMarkdownSourceComparison, materializeSourceDiffGap, SOURCE_DIFF_LIMITS } from '../../comparison/markdownSourceComparison.ts'
+import { compareMarkdownSourceLines } from '../../comparison/markdownSourceComparisonProtocol.ts'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('literal Markdown source comparison', () => {
+	const lines = (hunks: readonly SourceDiffHunk[], side: 'before' | 'after') => hunks
+		.flatMap(({ rows }) => rows.flatMap((row) => row[side] ? [row[side]] : []))
+
+	it('V10 normalizes EOL only for matching while retaining literal line facts', async () => {
+		const model = await createMarkdownSourceComparison('tab\tvalue  \r\nzero\u200Bwidth\nlast', 'tab value \nzero width\nlast\n')
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		const before = lines(model.hunks, 'before')
+		const after = lines(model.hunks, 'after')
+		expect(before[0]).toMatchObject({ text: 'tab\tvalue  ', eol: 'crlf' })
+		expect(before.some(({ text }) => text.includes('\u200b'))).toBe(true)
+		expect(before.at(-1)?.eol).toBe('none')
+		expect(after.at(-1)?.eol).toBe('lf')
+	})
+
+	it('AUD-14 materializes stable paired row records with the source model', async () => {
+		const model = await createMarkdownSourceComparison('old\nsame\n', 'new\nsame\n')
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		const hunk = model.hunks[0]!
+
+		expect(hunk.rows.map(({ before, after }) => [before?.text, after?.text])).toEqual([['old', 'new'], ['same', 'same']])
+		expect(hunk.rows).toBe(hunk.rows)
+	})
+
+	it('AUD-08 represents large collapsed gaps without retained line clones', async () => {
+		const source = Array.from({ length: 10_000 }, (_value, index) => `line ${index}`).join('\n')
+		const model = await createMarkdownSourceComparison(source, source)
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+
+		expect(model.gaps).toEqual([{
+			id: 'source-gap-0',
+			slot: 0,
+			beforeFrom: 0,
+			beforeTo: 10_000,
+			afterFrom: 0,
+			afterTo: 10_000,
+			count: 10_000,
+		}])
+	})
+
+	it('AUD-08 materializes large gaps in bounded observable pages', async () => {
+		const source = Array.from({ length: 10_000 }, (_value, index) => `line ${index}`).join('\n')
+		const model = await createMarkdownSourceComparison(source, source)
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		const gap = model.gaps[0]!
+
+		const firstPage = materializeSourceDiffGap(source, source, gap, Number.POSITIVE_INFINITY)
+		const secondPage = materializeSourceDiffGap(source, source, gap, SOURCE_DIFF_LIMITS.maximumGapPageRows, SOURCE_DIFF_LIMITS.maximumGapPageRows)
+
+		expect(firstPage).toHaveLength(SOURCE_DIFF_LIMITS.maximumGapPageRows)
+		expect(firstPage[0]?.before).toMatchObject({ number: 1, text: 'line 0' })
+		expect(firstPage.at(-1)?.after).toMatchObject({ number: SOURCE_DIFF_LIMITS.maximumGapPageRows, text: `line ${SOURCE_DIFF_LIMITS.maximumGapPageRows - 1}` })
+		expect(secondPage).toHaveLength(SOURCE_DIFF_LIMITS.maximumGapPageRows)
+		expect(secondPage[0]?.before).toMatchObject({ number: SOURCE_DIFF_LIMITS.maximumGapPageRows + 1, text: `line ${SOURCE_DIFF_LIMITS.maximumGapPageRows}` })
+		expect(secondPage.at(-1)?.after).toMatchObject({ number: SOURCE_DIFF_LIMITS.maximumGapPageRows * 2, text: `line ${SOURCE_DIFF_LIMITS.maximumGapPageRows * 2 - 1}` })
+	})
+
+	it('falls back when visible controls exceed the source display limit', async () => {
+		const source = `${'\t'.repeat(200_000)}😀`
+
+		await expect(createMarkdownSourceComparison(source, source)).resolves.toEqual({
+			status: 'limited',
+			reason: 'size',
+		})
+	})
+
+	it('retains complete literal lines when only line endings differ', async () => {
+		const beforeSource = 'same\r\nbytes\r\n'
+		const afterSource = 'same\nbytes\n'
+		const model = await createMarkdownSourceComparison(beforeSource, afterSource)
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		expect(model.hunks).toEqual([])
+		expect(model.gaps).toHaveLength(1)
+		const rows = materializeSourceDiffGap(beforeSource, afterSource, model.gaps[0]!)
+		expect(rows.map(({ before }: { before?: SourceDiffLine }) => ({ text: before?.text, eol: before?.eol }))).toEqual([
+			{ text: 'same', eol: 'crlf' },
+			{ text: 'bytes', eol: 'crlf' },
+		])
+		expect(rows.map(({ after }: { after?: SourceDiffLine }) => ({ text: after?.text, eol: after?.eol }))).toEqual([
+			{ text: 'same', eol: 'lf' },
+			{ text: 'bytes', eol: 'lf' },
+		])
+	})
+
+	it('keeps syntax-only and HTML-like changes as literal text', async () => {
+		const model = await createMarkdownSourceComparison('# Heading\n<script>x</script>', '# Heading #\n<img onerror=x>')
+		expect(model.status).toBe('ready')
+		if (model.status !== 'ready') {
+			return
+		}
+		expect(lines(model.hunks, 'before').map(({ text }) => text)).toContain('<script>x</script>')
+		expect(lines(model.hunks, 'after').map(({ text }) => text)).toContain('<img onerror=x>')
+	})
+
+	it('reports limits and aborts without losing the caller fallback contract', async () => {
+		await expect(createMarkdownSourceComparison('x'.repeat(SOURCE_DIFF_LIMITS.maximumCharacters + 1), ''))
+			.resolves.toEqual({ status: 'limited', reason: 'size' })
+		const controller = new AbortController()
+		controller.abort()
+		await expect(createMarkdownSourceComparison('before', 'after', controller.signal)).rejects.toMatchObject({ name: 'AbortError' })
+	})
+
+	it('V11 terminates an in-flight worker when the caller aborts', async () => {
+		const terminate = vi.fn()
+		vi.stubGlobal('Worker', class {
+			addEventListener() {}
+			removeEventListener() {}
+			postMessage() {}
+			terminate() { terminate() }
+		})
+		const controller = new AbortController()
+		const comparison = createMarkdownSourceComparison('before', 'after', controller.signal)
+		controller.abort()
+		await expect(comparison).rejects.toMatchObject({ name: 'AbortError' })
+		expect(terminate).toHaveBeenCalledOnce()
+	})
+
+	it('terminates the worker when posting the comparison request throws', async () => {
+		const failure = new Error('post failure')
+		const terminate = vi.fn()
+		vi.stubGlobal('Worker', class {
+			addEventListener() {}
+			removeEventListener() {}
+			postMessage() {
+				throw failure
+			}
+
+			terminate() { terminate() }
+		})
+
+		await expect(createMarkdownSourceComparison('before', 'after')).rejects.toBe(failure)
+		expect(terminate).toHaveBeenCalledOnce()
+	})
+
+	it('rejects message decoding errors once and ignores a late success', async () => {
+		const workers: Array<{ onmessage?: EventListener, onmessageerror?: EventListener }> = []
+		const terminate = vi.fn()
+		vi.stubGlobal('Worker', class {
+			onmessage?: EventListener
+			onmessageerror?: EventListener
+			constructor() {
+				workers.push(this)
+			}
+
+			postMessage() {}
+
+			terminate() { terminate() }
+		})
+		const comparison = createMarkdownSourceComparison('before', 'after')
+
+		expect(workers[0]!.onmessageerror).toBeTypeOf('function')
+		workers[0]!.onmessageerror!(new MessageEvent('messageerror'))
+		workers[0]!.onmessage!(new MessageEvent('message', { data: { status: 'ready', changes: [] } }))
+
+		await expect(comparison).rejects.toThrow('Source comparison worker failed')
+		expect(terminate).toHaveBeenCalledOnce()
+	})
+
+	it('rejects malformed worker responses after cleanup', async () => {
+		const workers: Array<{ onmessage?: EventListener }> = []
+		const terminate = vi.fn()
+		vi.stubGlobal('Worker', class {
+			onmessage?: EventListener
+			constructor() {
+				workers.push(this)
+			}
+
+			postMessage() {}
+
+			terminate() { terminate() }
+		})
+		const comparison = createMarkdownSourceComparison('before', 'after')
+
+		workers[0]!.onmessage!(new MessageEvent('message', { data: null }))
+
+		await expect(comparison).rejects.toThrow('Source comparison worker failed')
+		expect(terminate).toHaveBeenCalledOnce()
+	})
+
+	it('uses the same bounded line protocol for main-thread and worker paths', () => {
+		expect(compareMarkdownSourceLines({ before: 'old\n', after: 'new\n', maximumEditLength: 10, timeoutMilliseconds: 1000 }))
+			.toMatchObject({ status: 'ready' })
+		expect(compareMarkdownSourceLines({ before: 'old\n', after: 'new\n', maximumEditLength: 0, timeoutMilliseconds: 1000 }))
+			.toEqual({ status: 'limited' })
+	})
+})

--- a/src/tests/comparison/markdownSourceComparisonWorker.spec.ts
+++ b/src/tests/comparison/markdownSourceComparisonWorker.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { SourceComparisonWorkerRequest } from '../../comparison/markdownSourceComparisonProtocol.ts'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+	vi.resetModules()
+	vi.unstubAllGlobals()
+})
+
+describe('Markdown source comparison worker', () => {
+	it('delegates ready and limited messages to the shared protocol', async () => {
+		let listener: ((event: MessageEvent<SourceComparisonWorkerRequest>) => void) | undefined
+		const postMessage = vi.fn()
+		vi.stubGlobal('addEventListener', vi.fn((_type, callback) => {
+			listener = callback
+		}))
+		vi.stubGlobal('postMessage', postMessage)
+		await import('../../comparison/markdownSourceComparison.worker.ts')
+		expect(listener).toBeTypeOf('function')
+		listener?.(new MessageEvent('message', { data: { before: 'old\n', after: 'new\n', maximumEditLength: 10, timeoutMilliseconds: 1000 } }))
+		expect(postMessage).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'ready' }))
+		listener?.(new MessageEvent('message', { data: { before: 'old\n', after: 'new\n', maximumEditLength: 0, timeoutMilliseconds: 1000 } }))
+		expect(postMessage).toHaveBeenLastCalledWith({ status: 'limited' })
+	})
+})

--- a/src/tests/comparison/renderedComparisonLimit.spec.ts
+++ b/src/tests/comparison/renderedComparisonLimit.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import { exceedsRenderedComparisonLimit, RENDERED_COMPARISON_LIMITS } from '../../comparison/markdownComparison.ts'
+
+describe('rendered comparison preflight', () => {
+	it('accepts each exact geometry ceiling and rejects the first excess', () => {
+		const chars = RENDERED_COMPARISON_LIMITS.maximumCharactersPerSnapshot
+		const lineChars = RENDERED_COMPARISON_LIMITS.maximumCharactersPerLine
+		const line = `${'a'.repeat(lineChars - 1)}\n`
+		const source = (length: number) => line.repeat(Math.floor(length / line.length)) + 'a'.repeat(length % line.length)
+		expect(exceedsRenderedComparisonLimit(source(chars), 'after')).toBe(false)
+		expect(exceedsRenderedComparisonLimit(source(chars + 1), 'after')).toBe(true)
+		expect(exceedsRenderedComparisonLimit('a'.repeat(lineChars), 'after')).toBe(false)
+		expect(exceedsRenderedComparisonLimit('a'.repeat(lineChars + 1), 'after')).toBe(true)
+		const lines = RENDERED_COMPARISON_LIMITS.maximumLinesPerSnapshot
+		expect(exceedsRenderedComparisonLimit('x\n'.repeat(lines - 1), 'after')).toBe(false)
+		expect(exceedsRenderedComparisonLimit('x\r'.repeat(lines), 'after')).toBe(true)
+	})
+})

--- a/src/tests/comparison/tableGridComparison.spec.ts
+++ b/src/tests/comparison/tableGridComparison.spec.ts
@@ -1,0 +1,655 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Schema } from '@tiptap/pm/model'
+import type { ComparisonEdit, ComparisonSide } from '../../comparison/markdownComparisonTypes.ts'
+
+import { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { describe, expect, it, vi } from 'vitest'
+import {
+	alignComparisonColumns,
+	DEFAULT_COMPARISON_TOKEN_LEDGER,
+} from '../../comparison/comparisonAlignment.ts'
+import { createHierarchicalMarkdownComparisonModel } from '../../comparison/hierarchicalMarkdownComparisonModel.ts'
+import { comparisonTestDocument, createComparisonTestEditor } from './comparisonTestEditor.ts'
+
+function markdownTable(header: readonly string[], rows: readonly (readonly string[])[]) {
+	return [
+		`| ${header.join(' | ')} |`,
+		`|${header.map(() => '---').join('|')}|`,
+		...rows.map((row) => `| ${row.join(' | ')} |`),
+	].join('\n')
+}
+
+function compare(before: string, after: string) {
+	return createHierarchicalMarkdownComparisonModel(
+		comparisonTestDocument(before),
+		comparisonTestDocument(after),
+	)
+}
+
+interface TableSpec {
+	header: readonly { text: string, colspan?: number, rowspan?: number }[]
+	rows: readonly (readonly { text: string, colspan?: number, rowspan?: number }[])[]
+}
+
+function tableNode(schema: Schema, spec: TableSpec) {
+	const text = (value: string) => value ? schema.text(value) : undefined
+	const cell = (name: 'tableHeader' | 'tableCell', value: TableSpec['header'][number]) => schema.nodes[name]!.create(
+		{ colspan: value.colspan ?? 1, rowspan: value.rowspan ?? 1 },
+		name === 'tableHeader' ? text(value.text) : schema.nodes.paragraph!.create(null, text(value.text)),
+	)
+	const header = schema.nodes.tableHeadRow!.create(null, spec.header.map((value) => cell('tableHeader', value)))
+	const rows = spec.rows.map((row) => schema.nodes.tableRow!.create(null, row.map((value) => cell('tableCell', value))))
+	return schema.nodes.table!.create(null, [header, ...rows])
+}
+
+function tableDocument(schema: Schema, spec: TableSpec) {
+	return schema.nodes.doc!.create(null, tableNode(schema, spec))
+}
+
+function compareTableSpecs(before: TableSpec, after: TableSpec) {
+	const editor = createComparisonTestEditor('placeholder')
+	try {
+		return createHierarchicalMarkdownComparisonModel(
+			tableDocument(editor.schema, before),
+			tableDocument(editor.schema, after),
+		)
+	} finally {
+		editor.destroy()
+	}
+}
+
+function malformedTableDocument(
+	schema: Schema,
+	children: readonly ('caption' | 'header' | 'body' | 'header-with-body-cell' | 'body-with-header-cell')[],
+) {
+	const text = (value: string) => schema.text(value)
+	const headerCell = () => schema.nodes.tableHeader!.create(null, text('header'))
+	const bodyCell = () => schema.nodes.tableCell!.create(null, schema.nodes.paragraph!.create(null, text('body')))
+	const nodes = children.map((kind) => {
+		if (kind === 'caption') {
+			return schema.nodes.tableCaption!.create(null, text('caption'))
+		}
+		if (kind === 'header') {
+			return schema.nodes.tableHeadRow!.create(null, headerCell())
+		}
+		if (kind === 'body') {
+			return schema.nodes.tableRow!.create(null, bodyCell())
+		}
+		if (kind === 'header-with-body-cell') {
+			return schema.nodes.tableHeadRow!.create(null, bodyCell())
+		}
+		return schema.nodes.tableRow!.create(null, headerCell())
+	})
+	return schema.nodes.doc!.create(null, schema.nodes.table!.create(null, nodes))
+}
+
+function expectColumnEdit(
+	edit: ComparisonEdit,
+	operation: 'delete' | 'insert',
+	column: number,
+	rows: number,
+) {
+	const side: ComparisonSide = operation === 'delete' ? 'before' : 'after'
+	expect(edit.kind).toBe('table-column')
+	expect(edit.primary.operation).toBe(operation)
+	expect(edit.descriptors).toHaveLength(rows)
+	expect(edit.descriptors.every((descriptor) => descriptor.operation === operation)).toBe(true)
+	expect(edit.descriptors.map((descriptor) => descriptor.context[side]?.path.at(-1)))
+		.toEqual(Array.from({ length: rows }, () => column))
+	expect(edit.descriptors).toContain(edit.primary)
+}
+
+describe('sparse table comparison', () => {
+	it('AUD-14 does not materialize table profiles before matrix budget admission', () => {
+		const editor = createComparisonTestEditor('placeholder')
+		const columns = 201
+		const before = tableDocument(editor.schema, {
+			header: Array.from({ length: columns }, (_value, index) => ({ text: `before-${index}` })),
+			rows: [],
+		})
+		const after = tableDocument(editor.schema, {
+			header: Array.from({ length: columns }, (_value, index) => ({ text: `after-${index}` })),
+			rows: [],
+		})
+		const textContent = vi.spyOn(ProseMirrorNode.prototype, 'textContent', 'get')
+		try {
+			const model = createHierarchicalMarkdownComparisonModel(before, after)
+
+			expect(model.edits[0]!.primary.coarseReason).toBe('comparison-limit')
+			const tableCellReads = textContent.mock.contexts.filter((node) => (
+				(node as ProseMirrorNode).type.name === 'tableHeader'
+			)).length
+			expect(tableCellReads).toBeLessThanOrEqual(columns * 2 * 5)
+		} finally {
+			textContent.mockRestore()
+			editor.destroy()
+		}
+	})
+
+	it.each([
+		['first', 0],
+		['middle', 1],
+		['last', 2],
+	] as const)('T01 attributes the %s duplicate-body column deletion', (_name, column) => {
+		const widerHeader = ['A', 'B', 'C']
+		const narrowerHeader = widerHeader.filter((_value, index) => index !== column)
+		const wider = markdownTable(widerHeader, Array.from({ length: 2 }, () => ['x', 'x', 'x']))
+		const narrower = markdownTable(narrowerHeader, Array.from({ length: 2 }, () => ['x', 'x']))
+
+		const deletion = compare(wider, narrower)
+		expect(deletion.edits).toHaveLength(1)
+		expectColumnEdit(deletion.edits[0]!, 'delete', column, 3)
+	})
+
+	it.each([
+		['first', 0],
+		['middle', 1],
+		['last', 2],
+	] as const)('T02 attributes the %s duplicate-body column insertion', (_name, column) => {
+		const widerHeader = ['A', 'B', 'C']
+		const narrowerHeader = widerHeader.filter((_value, index) => index !== column)
+		const wider = markdownTable(widerHeader, Array.from({ length: 2 }, () => ['x', 'x', 'x']))
+		const narrower = markdownTable(narrowerHeader, Array.from({ length: 2 }, () => ['x', 'x']))
+
+		const insertion = compare(narrower, wider)
+		expect(insertion.edits).toHaveLength(1)
+		expectColumnEdit(insertion.edits[0]!, 'insert', column, 3)
+	})
+
+	it('T03 distinguishes duplicate headers with an exact body row', () => {
+		const model = compare(
+			markdownTable(['X', 'X', 'X'], [['a', 'b', 'c'], ['x', 'x', 'x']]),
+			markdownTable(['X', 'X'], [['a', 'b'], ['x', 'x']]),
+		)
+
+		expect(model.edits).toHaveLength(1)
+		expectColumnEdit(model.edits[0]!, 'delete', 2, 3)
+	})
+
+	it('T04 pairs equal duplicate-vector multiplicity by rank beside a unique deletion', () => {
+		const model = compare(
+			markdownTable(['A', 'X', 'X', 'C'], [['x', 'x', 'x', 'x']]),
+			markdownTable(['A', 'X', 'X'], [['x', 'x', 'x']]),
+		)
+
+		expect(model.edits).toHaveLength(1)
+		expectColumnEdit(model.edits[0]!, 'delete', 3, 2)
+	})
+
+	it('T05 keeps unequal identical-column multiplicity coarse', () => {
+		const model = compare(
+			markdownTable(['X', 'X', 'X'], [['', '', ''], ['x', 'x', 'x']]),
+			markdownTable(['X', 'X'], [['', ''], ['x', 'x']]),
+		)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]).toMatchObject({
+			kind: 'content',
+			primary: {
+				operation: 'replace',
+				coarseReason: 'ambiguous-attribution',
+				context: { before: { code: 'table' }, after: { code: 'table' } },
+			},
+		})
+	})
+
+	it('T06 keeps a crossing exact column reorder coarse', () => {
+		const model = compare(
+			markdownTable(['A', 'B', 'C'], [['a', 'b', 'c']]),
+			markdownTable(['C', 'B', 'A'], [['c', 'b', 'a']]),
+		)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]).toMatchObject({
+			kind: 'content',
+			primary: {
+				operation: 'replace',
+				coarseReason: 'table-evidence-conflict',
+				context: { before: { code: 'table' }, after: { code: 'table' } },
+			},
+		})
+	})
+
+	it('T07 keeps one edited retained column precise at cell altitude', () => {
+		const model = compare(
+			markdownTable(['A', 'B', 'C'], [['1', '2', '3']]),
+			markdownTable(['A', 'X', 'C'], [['1', 'changed', '3']]),
+		)
+		const descriptors = model.edits.flatMap(({ descriptors }) => descriptors)
+
+		expect(model.edits).toHaveLength(2)
+		expect(model.edits.every(({ kind }) => kind === 'content')).toBe(true)
+		expect(descriptors).toHaveLength(2)
+		expect(descriptors.map(({ context }) => context.before?.path)).toEqual([
+			[0, 0, 1],
+			[0, 1, 1],
+		])
+		expect(descriptors.map(({ before, after }) => ({ before, after }))).toEqual([
+			{ before: { from: 6, to: 7 }, after: { from: 6, to: 7 } },
+			{ before: { from: 20, to: 21 }, after: { from: 20, to: 27 } },
+		])
+		expect(descriptors.every(({ context }) => (
+			context.before?.code === 'table-cell' && context.after?.code === 'table-cell'
+		))).toBe(true)
+	})
+
+	it('T08 keeps two adjacent edited columns precise when the optimum is unique', () => {
+		const model = compare(
+			markdownTable(['A', 'B old', 'C old', 'D'], [['1', 'before b', 'before c', '4']]),
+			markdownTable(['A', 'B new', 'C new', 'D'], [['1', 'after b', 'after c', '4']]),
+		)
+		const descriptors = model.edits.flatMap(({ descriptors }) => descriptors)
+
+		expect(descriptors).toHaveLength(4)
+		expect(model.edits.every(({ kind }) => kind === 'content')).toBe(true)
+		expect(descriptors.every(({ coarseReason }) => coarseReason === undefined)).toBe(true)
+		expect(descriptors.every(({ context }) => (
+			context.before?.code === 'table-cell' && context.after?.code === 'table-cell'
+		))).toBe(true)
+	})
+
+	it('groups one column alignment change across its physical cells without duplicating content edits', () => {
+		const model = compare([
+			'# Evidence matrix',
+			'',
+			'| Signal | Evidence | State |',
+			'| :--- | :---: | ---: |',
+			'| API \\| worker | **Draft** [runbook](https://example.org/draft) | 10% |',
+			'| Screenshot | ![Audit thumbnail](demo-assets/table-thumbnail.jpg) | Pending |',
+		].join('\n'), [
+			'# Evidence matrix',
+			'',
+			'| Signal | Evidence | State |',
+			'| ---: | :--- | :---: |',
+			'| API \\| worker | **Approved** [runbook](https://example.org/approved) | 25% |',
+			'| Screenshot | ![Approved audit thumbnail](demo-assets/table-thumbnail.jpg) | Complete |',
+		].join('\n'))
+		const alignmentEdits = model.edits.filter(({ primary }) => primary.signals.some((signal) => (
+			signal.type === 'attribute' && signal.attribute === 'table-alignment'
+		)))
+		expect(model.edits).toHaveLength(7)
+		expect(alignmentEdits).toHaveLength(3)
+		expect(alignmentEdits.map(({ descriptors }) => descriptors.length)).toEqual([3, 3, 3])
+		expect(alignmentEdits.every(({ descriptors }) => descriptors.every(({ signals }) => signals.some((signal) => (
+			signal.type === 'attribute' && signal.attribute === 'table-alignment'
+		))))).toBe(true)
+	})
+
+	it('T09 combines an edited retained column with one adjacent column deletion', () => {
+		const model = compare(
+			markdownTable(['A', 'B old', 'C'], [['1', 'before', '3']]),
+			markdownTable(['A', 'B new'], [['1', 'after']]),
+		)
+		const columnEdits = model.edits.filter(({ kind }) => kind === 'table-column')
+		const cellEdits = model.edits.filter(({ kind }) => kind === 'content')
+
+		expect(columnEdits).toHaveLength(1)
+		expectColumnEdit(columnEdits[0]!, 'delete', 2, 2)
+		expect(cellEdits).toHaveLength(2)
+		expect(cellEdits.flatMap(({ descriptors }) => descriptors).every(({ context }) => (
+			context.before?.code === 'table-cell' && context.after?.code === 'table-cell'
+		))).toBe(true)
+	})
+
+	it('T10 keeps a row insertion at row altitude beside a column deletion', () => {
+		const model = compare(
+			markdownTable(['A', 'B', 'C'], [['one', 'x', 'x'], ['two', 'x', 'x']]),
+			markdownTable(['A', 'B'], [['one', 'x'], ['inserted row', 'unique'], ['two', 'x']]),
+		)
+		const columnEdits = model.edits.filter(({ kind }) => kind === 'table-column')
+		const rowInsertions = model.edits.filter(({ primary }) => (
+			primary.operation === 'insert' && primary.context.after?.code === 'table-row'
+		))
+
+		expect(columnEdits).toHaveLength(1)
+		expectColumnEdit(columnEdits[0]!, 'delete', 2, 3)
+		expect(rowInsertions).toHaveLength(1)
+	})
+
+	it('T10 keeps a row deletion at row altitude beside a column insertion', () => {
+		const model = compare(
+			markdownTable(['A', 'B'], [['one', 'x'], ['deleted row', 'unique'], ['two', 'x']]),
+			markdownTable(['A', 'B', 'C'], [['one', 'x', 'x'], ['two', 'x', 'x']]),
+		)
+		const columnEdits = model.edits.filter(({ kind }) => kind === 'table-column')
+		const rowDeletions = model.edits.filter(({ primary }) => (
+			primary.operation === 'delete' && primary.context.before?.code === 'table-row'
+		))
+
+		expect(columnEdits).toHaveLength(1)
+		expectColumnEdit(columnEdits[0]!, 'insert', 2, 3)
+		expect(rowDeletions).toHaveLength(1)
+	})
+
+	it('T11 keeps a ragged typo precise at physical-cell altitude', () => {
+		const model = compare(
+			markdownTable(['A', 'B', 'C'], [['one', 'before']]),
+			markdownTable(['A', 'B', 'C'], [['one', 'after']]),
+		)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]).toMatchObject({
+			kind: 'content',
+			primary: {
+				operation: 'replace',
+				context: { before: { code: 'table-cell' }, after: { code: 'table-cell' } },
+			},
+		})
+	})
+
+	it.each([
+		['fills', 'insert', ['one'], ['one', 'two']],
+		['removes', 'delete', ['one', 'two'], ['one']],
+	] as const)('T12 %s a ragged absent-present slot as one local cell change', (_name, operation, beforeRow, afterRow) => {
+		const model = compare(
+			markdownTable(['A', 'B'], [beforeRow]),
+			markdownTable(['A', 'B'], [afterRow]),
+		)
+		const side: ComparisonSide = operation === 'delete' ? 'before' : 'after'
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]).toMatchObject({ kind: 'content', primary: { operation } })
+		expect(model.edits[0]!.primary.context[side]?.code).toBe('table-cell')
+	})
+
+	it('T13 groups only present physical cells from a deleted ragged column', () => {
+		const wider = markdownTable(['A', 'B', 'C'], [
+			['x', 'x'],
+			['x', 'x', 'distinct C'],
+		])
+		const narrower = markdownTable(['A', 'B'], [
+			['x', 'x'],
+			['x', 'x'],
+		])
+		const model = compare(wider, narrower)
+
+		expect(model.edits).toHaveLength(1)
+		expectColumnEdit(model.edits[0]!, 'delete', 2, 2)
+	})
+
+	it.each(['deletion', 'insertion'] as const)('T14 fails a ragged middle identity conflict transactionally on %s', (direction) => {
+		const wider = markdownTable(['A', 'B', 'C'], [
+			['x', 'x', 'x'],
+			['x', 'x'],
+		])
+		const narrower = markdownTable(['A', 'C'], [
+			['x', 'x'],
+			['x'],
+		])
+		const model = direction === 'deletion'
+			? compare(wider, narrower)
+			: compare(narrower, wider)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]).toMatchObject({
+			kind: 'content',
+			primary: {
+				operation: 'replace',
+				coarseReason: 'table-evidence-conflict',
+				context: { before: { code: 'table' }, after: { code: 'table' } },
+			},
+		})
+		expect(model.edits[0]!.descriptors).toHaveLength(1)
+	})
+
+	it.each(['deletion', 'insertion'] as const)('AUD-01 fails closed when a ragged width change creates cross-row exact identity on %s', (direction) => {
+		for (const width of [2, 3, 4]) {
+			const wider = markdownTable(
+				Array.from({ length: width + 1 }, () => 'N'),
+				[
+					Array.from({ length: width }, () => 'x'),
+					Array.from({ length: width + 1 }, () => 'x'),
+				],
+			)
+			const narrower = markdownTable(
+				Array.from({ length: width }, () => 'N'),
+				[
+					Array.from({ length: width - 1 }, () => 'x'),
+					Array.from({ length: width }, () => 'x'),
+				],
+			)
+			const model = direction === 'deletion'
+				? compare(wider, narrower)
+				: compare(narrower, wider)
+			const rowOperations = model.edits.filter(({ primary }) => (
+				primary.context.before?.code === 'table-row' || primary.context.after?.code === 'table-row'
+			))
+
+			expect(rowOperations).toHaveLength(0)
+			expect(model.edits).toHaveLength(1)
+			expect(model.edits[0]).toMatchObject({
+				kind: 'content',
+				primary: {
+					operation: 'replace',
+					coarseReason: 'table-evidence-conflict',
+					context: { before: { code: 'table' }, after: { code: 'table' } },
+				},
+			})
+			expect(model.edits[0]!.descriptors).toHaveLength(1)
+		}
+	})
+
+	it.each(['deletion', 'insertion'] as const)('AUD-01 reconciles the complete row basis when row count and width change on %s', (direction) => {
+		const wider = markdownTable(['N', 'N', 'N'], [
+			['x', 'x'],
+			['x', 'x', 'x'],
+		])
+		const narrower = markdownTable(['N', 'N'], [
+			['inserted', 'unique'],
+			['x'],
+			['x', 'x'],
+		])
+		const model = direction === 'deletion'
+			? compare(wider, narrower)
+			: compare(narrower, wider)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]).toMatchObject({
+			kind: 'content',
+			primary: {
+				operation: 'replace',
+				coarseReason: 'table-evidence-conflict',
+				context: { before: { code: 'table' }, after: { code: 'table' } },
+			},
+		})
+		expect(model.edits[0]!.descriptors).toHaveLength(1)
+	})
+
+	it.each(['deletion', 'insertion'] as const)('AUD-01 keeps a genuine ragged row replacement beside a column %s', (direction) => {
+		const wider = markdownTable(['A', 'B', 'C'], [
+			['retained', 'x'],
+			['deleted', 'y', 'z'],
+		])
+		const narrower = markdownTable(['A', 'B'], [
+			['inserted', 'q'],
+			['retained', 'x'],
+		])
+		const model = direction === 'deletion'
+			? compare(wider, narrower)
+			: compare(narrower, wider)
+		const columnEdits = model.edits.filter(({ kind }) => kind === 'table-column')
+		const rowOperations = model.edits.filter(({ primary }) => (
+			primary.context.before?.code === 'table-row' || primary.context.after?.code === 'table-row'
+		))
+
+		expect(columnEdits).toHaveLength(1)
+		expectColumnEdit(columnEdits[0]!, direction === 'deletion' ? 'delete' : 'insert', 2, 1)
+		expect(rowOperations.map(({ primary }) => primary.operation).toSorted()).toEqual(['delete', 'insert'])
+		expect(model.edits.every(({ primary }) => primary.coarseReason === undefined)).toBe(true)
+	})
+
+	it.each([
+		['deletes', 'delete', 3, 2],
+		['inserts', 'insert', 3, 4],
+	] as const)('T15 %s the outer repeated row after retaining the first exact copies', (_name, operation, beforeCount, afterCount) => {
+		const rows = (count: number) => Array.from({ length: count }, () => ['Same', 'x'])
+		const model = compare(
+			markdownTable(['H1', 'H2'], rows(beforeCount)),
+			markdownTable(['H1', 'H2'], rows(afterCount)),
+		)
+		const side: ComparisonSide = operation === 'delete' ? 'before' : 'after'
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]).toMatchObject({ kind: 'content', primary: { operation } })
+		expect(model.edits[0]!.primary.context[side]?.code).toBe('table-row')
+		expect(model.edits[0]!.primary.context[side]?.path.at(-1)).toBe(operation === 'delete' ? 3 : 4)
+	})
+
+	it.each([
+		['span', { header: [{ text: 'changed', colspan: 2 }], rows: [] }],
+		['row span', { header: [{ text: 'changed', rowspan: 2 }], rows: [[{ text: 'body' }]] }],
+		['malformed empty row', { header: [{ text: 'changed' }], rows: [[]] }],
+		['more than 512 rows', {
+			header: [{ text: 'changed' }],
+			rows: Array.from({ length: 512 }, (_value, index) => [{ text: `row ${index}` }]),
+		}],
+		['more than 10000 physical cells', {
+			header: Array.from({ length: 100 }, (_value, index) => ({ text: index === 0 ? 'changed' : `head ${index}` })),
+			rows: Array.from({ length: 100 }, (_value, row) => (
+				Array.from({ length: 100 }, (_cell, column) => ({ text: `cell ${row}:${column}` }))
+			)),
+		}],
+	] as const)('T16 emits one unsupported-table edit for %s geometry', (_name, invalid) => {
+		const valid = { header: [{ text: 'valid' }], rows: [] }
+		const model = compareTableSpecs(valid, invalid)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]).toMatchObject({
+			kind: 'content',
+			primary: {
+				operation: 'replace',
+				coarseReason: 'unsupported-table',
+				context: { before: { code: 'table' }, after: { code: 'table' } },
+			},
+		})
+		expect(model.edits[0]!.descriptors).toHaveLength(1)
+	})
+
+	it.each([
+		['a missing header', ['body']],
+		['duplicate headers', ['header', 'header']],
+		['a header after a body row', ['body', 'header']],
+		['a misplaced caption', ['header', 'caption']],
+		['duplicate captions', ['caption', 'caption', 'header']],
+		['a body cell in the header', ['header-with-body-cell']],
+		['a header cell in a body row', ['header', 'body-with-header-cell']],
+	] as const)('T16 rejects %s transactionally', (_name, children) => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const valid = tableDocument(editor.schema, { header: [{ text: 'valid' }], rows: [] })
+			const invalid = malformedTableDocument(editor.schema, children)
+			const model = createHierarchicalMarkdownComparisonModel(valid, invalid)
+
+			expect(model.edits).toHaveLength(1)
+			expect(model.edits[0]).toMatchObject({
+				kind: 'content',
+				primary: {
+					operation: 'replace',
+					coarseReason: 'unsupported-table',
+					context: { before: { code: 'table' }, after: { code: 'table' } },
+				},
+			})
+			expect(model.edits[0]!.descriptors).toHaveLength(1)
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('T17 rejects a 10001-column table before attempting column alignment', () => {
+		const valid = { header: [{ text: 'valid' }], rows: [] }
+		const hugeWidth = {
+			header: Array.from({ length: 10_001 }, (_value, index) => ({ text: `column ${index}` })),
+			rows: [],
+		}
+		const model = compareTableSpecs(valid, hugeWidth)
+
+		expect(model.edits).toHaveLength(1)
+		expect(model.edits[0]!.primary.coarseReason).toBe('unsupported-table')
+		expect(model.edits[0]!.descriptors).toHaveLength(1)
+	})
+
+	it('F09 retains solved table work without partial edits when a later exact-evidence veto coarsens the table', () => {
+		const editor = createComparisonTestEditor('placeholder')
+		try {
+			const columnCount = 100
+			const bodyTextLength = Math.floor(DEFAULT_COMPARISON_TOKEN_LEDGER / (4 * columnCount ** 2)) - 6
+			const body = (suffix: string) => Array.from({ length: columnCount }, (_value, index) => ({
+				text: `${String.fromCodePoint(0x100 + index).repeat(bodyTextLength - 1)}${suffix}`,
+			}))
+			const beforeHeader = Array.from({ length: columnCount }, (_value, index) => ({ text: index === 0 ? 'q' : 'a' }))
+			const afterHeader = Array.from({ length: columnCount }, (_value, index) => ({ text: index === columnCount - 1 ? 'q' : 'b' }))
+			const headerRowProfileLength = 2 * columnCount
+			const bodyRowProfileLength = (bodyTextLength + 2) * columnCount
+			const rowCharge = 2 * (3 * headerRowProfileLength + bodyRowProfileLength)
+			const columnProfileLength = bodyTextLength + 6
+			const columnCharge = 2 * columnCount ** 2 * columnProfileLength
+			const remainingTokens = DEFAULT_COMPARISON_TOKEN_LEDGER - rowCharge - columnCharge
+			const laterProfileLength = Math.floor(remainingTokens / (2 * columnCount ** 2)) + 1
+			const laterTextLength = laterProfileLength - 3
+			const repeatedHeaders = (character: string) => Array.from(
+				{ length: columnCount },
+				() => ({ text: character.repeat(laterTextLength) }),
+			)
+			const anchor = editor.schema.nodes.paragraph!.create(null, editor.schema.text('exact veto boundary anchor'))
+			const before = editor.schema.nodes.doc!.create(null, [
+				tableNode(editor.schema, { header: beforeHeader, rows: [body('x')] }),
+				anchor,
+				tableNode(editor.schema, { header: repeatedHeaders('c'), rows: [] }),
+			])
+			const after = editor.schema.nodes.doc!.create(null, [
+				tableNode(editor.schema, { header: afterHeader, rows: [body('y')] }),
+				anchor,
+				tableNode(editor.schema, { header: repeatedHeaders('d'), rows: [] }),
+			])
+			const model = createHierarchicalMarkdownComparisonModel(before, after)
+
+			expect(2 * columnCount ** 2 * laterProfileLength).toBeGreaterThan(remainingTokens)
+			expect(2 * columnCount ** 2 * laterProfileLength).toBeLessThan(DEFAULT_COMPARISON_TOKEN_LEDGER)
+			expect(model.edits.map(({ primary }) => primary.coarseReason)).toEqual([
+				'table-evidence-conflict',
+				'comparison-limit',
+			])
+			expect(model.edits.every(({ descriptors }) => descriptors.length === 1)).toBe(true)
+		} finally {
+			editor.destroy()
+		}
+	})
+
+	it('T18 shares table token work across consecutive column plans', () => {
+		interface Column {
+			key: string
+			profile: readonly string[]
+		}
+		const before: Column[] = [
+			{ key: 'before-a', profile: ['a', 'same-a'] },
+			{ key: 'before-b', profile: ['b', 'same-b'] },
+		]
+		const after: Column[] = [
+			{ key: 'after-a', profile: ['a', 'same-a'] },
+			{ key: 'after-b', profile: ['b', 'same-b'] },
+		]
+		const work = { remainingCells: 8, remainingTokenComparisons: 20 }
+		const options = {
+			work,
+			fingerprint: ({ key }: Column) => key,
+			profile: ({ profile }: Column) => profile,
+			compatible: () => true,
+		}
+
+		const first = alignComparisonColumns(before, after, options)
+		expect(first.every((region) => !('coarseReason' in region && region.coarseReason === 'comparison-limit'))).toBe(true)
+		expect(work).toEqual({ remainingCells: 4, remainingTokenComparisons: 4 })
+
+		const second = alignComparisonColumns(before, after, options)
+		expect(second).toEqual([{
+			before: { from: 0, to: 2 },
+			after: { from: 0, to: 2 },
+			coarseReason: 'comparison-limit',
+		}])
+		expect(work).toEqual({ remainingCells: 4, remainingTokenComparisons: 4 })
+	})
+})

--- a/src/tests/markdown.spec.js
+++ b/src/tests/markdown.spec.js
@@ -175,6 +175,7 @@ describe('Markdown though editor', () => {
 
 	test('details', ({ markdownThroughEditor }) => {
 		expect(markdownThroughEditor('<details>\n<summary>**summary**</summary>\n* list\n\n</details>\n')).toBe('<details>\n<summary>**summary**</summary>\n* list\n\n</details>\n')
+		expect(markdownThroughEditor('<details open>\n<summary>summary</summary>\ncontent\n\n</details>\n')).toBe('<details open>\n<summary>summary</summary>\ncontent\n\n</details>\n')
 	})
 
 	test('nested details', ({ markdownThroughEditor }) => {

--- a/src/tests/markdownit/details.spec.js
+++ b/src/tests/markdownit/details.spec.js
@@ -11,6 +11,10 @@ describe('Details extension', () => {
 		const rendered = markdownit.render('<details>\n<summary>summary</summary>\ncontent\n</details>')
 		expect(stripIndent(rendered)).toBe('<details><summary>summary</summary><p>content</p></details>')
 	})
+	it('renders the native open state', () => {
+		const rendered = markdownit.render('<details open>\n<summary>summary</summary>\ncontent\n</details>')
+		expect(stripIndent(rendered)).toBe('<details open=""><summary>summary</summary><p>content</p></details>')
+	})
 	it('renders with empty summary', () => {
 		const rendered = markdownit.render('<details>\n<summary></summary>\ncontent\n</details>')
 		expect(stripIndent(rendered)).toBe('<details><summary></summary><p>content</p></details>')

--- a/src/tests/nodes/DetailsViewAccessibility.spec.ts
+++ b/src/tests/nodes/DetailsViewAccessibility.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import DetailsView from '../../nodes/DetailsView.vue'
+
+function mountDetails(attrs: { open: boolean, openDetails: boolean }, updateAttributes = vi.fn()) {
+	return mount(DetailsView, {
+		props: { node: { attrs }, updateAttributes },
+		global: {
+			stubs: {
+				NodeViewWrapper: { template: '<div><slot /></div>' },
+				NodeViewContent: { template: '<div><slot /></div>' },
+				NcButton: {
+					emits: ['click'],
+					template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot name="icon" /></button>',
+				},
+				TriangleSmallDownIcon: true,
+			},
+		},
+	})
+}
+
+describe('DetailsView disclosure control', () => {
+	it('names the button and toggles details from the button', async () => {
+		const wrapper = mountDetails({ open: false, openDetails: false })
+		const button = wrapper.get('button')
+
+		expect(button.attributes('aria-label')).toBe('Expand details')
+		expect(button.attributes('aria-expanded')).toBe('false')
+
+		await button.trigger('click')
+
+		expect(button.attributes('aria-label')).toBe('Collapse details')
+		expect(button.attributes('aria-expanded')).toBe('true')
+	})
+
+	it('opens persisted native details without clearing the stored state', () => {
+		const updateAttributes = vi.fn()
+		const wrapper = mountDetails({ open: true, openDetails: false }, updateAttributes)
+
+		expect(wrapper.get('button').attributes('aria-label')).toBe('Collapse details')
+		expect(wrapper.get('button').attributes('aria-expanded')).toBe('true')
+		expect(updateAttributes).not.toHaveBeenCalled()
+	})
+})

--- a/src/tests/nodes/Image.spec.ts
+++ b/src/tests/nodes/Image.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Plugin } from '@tiptap/pm/state'
+
+import { getExtensionField } from '@tiptap/core'
+import { describe, expect, it } from 'vitest'
+import Image from '../../nodes/Image.ts'
+
+describe('Image plugins', () => {
+	it('omits attachment extraction when attachment events are disabled', () => {
+		const extension = Image.configure({ emitAttachmentEvents: false })
+		const addPlugins = getExtensionField(extension, 'addProseMirrorPlugins', { options: extension.options }) as () => Plugin[]
+
+		expect(addPlugins()).toHaveLength(1)
+	})
+})

--- a/src/tests/nodes/ImageViewAccessibility.spec.ts
+++ b/src/tests/nodes/ImageViewAccessibility.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { shallowRef } from 'vue'
+import ImageView from '../../nodes/ImageView.vue'
+import { ATTACHMENT_RESOLVER } from '../../components/Editor.provider.ts'
+
+type ImageViewProps = InstanceType<typeof ImageView>['$props']
+
+const attachment = {
+	alt: 'Diagram',
+	davPath: '/diagram.png',
+	fullUrl: '/diagram.png',
+	isImage: true,
+	metadata: null,
+	mimetype: 'image/png',
+	name: 'diagram.png',
+	previewUrl: '/preview.png',
+	size: 100,
+}
+
+beforeEach(() => {
+	vi.stubGlobal('ResizeObserver', class {
+		observe() {}
+		disconnect() {}
+	})
+	vi.stubGlobal('IntersectionObserver', class {
+		observe() {}
+		disconnect() {}
+	})
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+async function mountImage(isImage: boolean) {
+	const editor = { isEditable: false, off: vi.fn(), on: vi.fn() }
+	const wrapper = mount(ImageView, {
+		props: {
+			editor,
+			node: { attrs: { alt: 'Diagram', src: 'diagram.png' } },
+			decorations: [],
+			selected: false,
+			extension: { options: { noLazyImages: false } },
+			getPos: () => 0,
+			updateAttributes: vi.fn(),
+			deleteNode: vi.fn(),
+			view: {},
+			innerDecorations: {},
+			HTMLAttributes: {},
+		} as unknown as ImageViewProps,
+		global: {
+			provide: {
+				[ATTACHMENT_RESOLVER as symbol]: shallowRef({ resolve: vi.fn().mockResolvedValue({ ...attachment, isImage }) }),
+			},
+			stubs: {
+				NodeViewWrapper: { template: '<div><slot /></div>' },
+				ShowImageModal: true,
+			},
+		},
+	})
+	await wrapper.setData({ attachment: { ...attachment, isImage }, imageLoaded: true, loaded: true })
+	return wrapper
+}
+
+describe('ImageView read-only actions', () => {
+	it.each([
+		[true, 'Open image Diagram'],
+		[false, 'Open attachment Diagram'],
+	] as const)('AUD-18 renders a named native button when isImage is %s', async (isImage, label) => {
+		const wrapper = await mountImage(isImage)
+		const action = wrapper.find<HTMLButtonElement>('.media-wrapper')
+
+		expect(action.element.tagName).toBe('BUTTON')
+		expect(action.attributes('type')).toBe('button')
+		expect(action.attributes('aria-label')).toBe(label)
+		expect(action.element.tabIndex).toBe(0)
+	})
+
+	it('AUD-18 routes image button activation through the real modal handler', async () => {
+		const wrapper = await mountImage(true)
+		const view = wrapper.vm as unknown as { embeddedImageList: Array<typeof attachment & { src: string }> }
+		vi.spyOn(wrapper.vm, 'updateEmbeddedImageList').mockImplementation(async () => {
+			view.embeddedImageList = [{ ...attachment, src: 'diagram.png' }]
+		})
+
+		await wrapper.find<HTMLButtonElement>('.media-wrapper').trigger('click')
+
+		expect(wrapper.vm.imageIndex).toBe(0)
+		expect(wrapper.vm.showImageModal).toBe(true)
+	})
+
+	it('AUD-18 routes attachment button activation through the real Viewer action', async () => {
+		const open = vi.fn()
+		vi.stubGlobal('OCA', { Viewer: { file: null, mimetypes: ['image/png'], open } })
+		const wrapper = await mountImage(false)
+
+		await wrapper.find<HTMLButtonElement>('.media-wrapper').trigger('click')
+
+		expect(open).toHaveBeenCalledOnce()
+		expect(open).toHaveBeenCalledWith({ path: attachment.davPath })
+	})
+})

--- a/src/tests/playwrightConfig.spec.ts
+++ b/src/tests/playwrightConfig.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const originalComparisonBaseURL = process.env.TEXT_COMPARISON_BASE_URL
+const originalComparisonE2E = process.env.TEXT_COMPARISON_E2E
+const originalBaseURL = process.env.baseURL
+
+afterEach(() => {
+	setEnvironment('TEXT_COMPARISON_BASE_URL', originalComparisonBaseURL)
+	setEnvironment('TEXT_COMPARISON_E2E', originalComparisonE2E)
+	setEnvironment('baseURL', originalBaseURL)
+})
+
+function setEnvironment(name: string, value: string | undefined) {
+	if (value === undefined) {
+		delete process.env[name]
+	} else {
+		process.env[name] = value
+	}
+}
+
+async function loadConfig(comparisonBaseURL: string | undefined, baseURL: string | undefined, comparisonE2E?: string) {
+	setEnvironment('TEXT_COMPARISON_BASE_URL', comparisonBaseURL)
+	setEnvironment('TEXT_COMPARISON_E2E', comparisonE2E)
+	setEnvironment('baseURL', baseURL)
+	vi.resetModules()
+	return (await import('../../playwright.config.ts')).default
+}
+
+describe('Playwright comparison server selection', () => {
+	it.each([
+		{ name: 'unset values', comparisonBaseURL: undefined, baseURL: undefined, expected: 'http://localhost:8089/index.php/', managed: true },
+		{ name: 'empty values', comparisonBaseURL: '', baseURL: '', expected: 'http://localhost:8089/index.php/', managed: true },
+		{ name: 'generic external URL', comparisonBaseURL: '', baseURL: 'https://generic.example/index.php/', expected: 'https://generic.example/index.php/', managed: false },
+		{ name: 'dedicated external URL', comparisonBaseURL: 'https://text.example/index.php/', baseURL: '', expected: 'https://text.example/index.php/', managed: false },
+		{ name: 'dedicated precedence', comparisonBaseURL: 'https://text.example/index.php/', baseURL: 'https://generic.example/index.php/', expected: 'https://text.example/index.php/', managed: false },
+	])('uses the selected URL for $name', async ({ comparisonBaseURL, baseURL, expected, managed }) => {
+		const config = await loadConfig(comparisonBaseURL, baseURL)
+
+		expect(config.use?.baseURL).toBe(expected)
+		expect(config.webServer === undefined).toBe(!managed)
+	})
+
+	it('routes comparison and memory tests to their dedicated projects', async () => {
+		const config = await loadConfig(undefined, undefined, '1')
+		const projects = config.projects ?? []
+		const byName = new Map(projects.map((project) => [project.name, project]))
+		const comparisonNames = [
+			'comparison-chromium',
+			'comparison-webkit',
+			'comparison-chromium-memory',
+		]
+
+		expect(projects.map(({ name }) => name)).toEqual(['chromium', ...comparisonNames])
+		for (const name of comparisonNames) {
+			const match = byName.get(name)?.testMatch
+			expect(match).toBeInstanceOf(RegExp)
+			expect((match as RegExp).test('playwright/comparison/comparison.spec.ts')).toBe(true)
+			expect((match as RegExp).test('playwright/example.spec.ts')).toBe(false)
+		}
+		for (const name of comparisonNames.slice(0, 2)) {
+			expect(byName.get(name)?.grepInvert).toEqual(/@memory/)
+			expect(byName.get(name)?.grep).toBeUndefined()
+		}
+		expect(byName.get('comparison-chromium-memory')?.grep).toEqual(/@memory/)
+		expect(byName.get('comparison-chromium-memory')?.grepInvert).toBeUndefined()
+		const ordinaryIgnore = byName.get('chromium')?.testIgnore
+		expect(ordinaryIgnore).toBeInstanceOf(RegExp)
+		expect((ordinaryIgnore as RegExp).test('playwright/comparison/comparison.spec.ts')).toBe(true)
+		expect((ordinaryIgnore as RegExp).test('playwright/example.spec.ts')).toBe(false)
+	})
+})

--- a/src/tests/services/AttachmentResolver.spec.js
+++ b/src/tests/services/AttachmentResolver.spec.js
@@ -36,11 +36,9 @@ function initAttachmentResolver(args) {
 			previewUrl: `http://nextcloud.local/apps/text/mediaPreview?documentId=${fileId}&sessionId=${sessionId}&sessionToken=${sessionToken}&mediaFileName=${a2name}"`,
 		},
 	]
-	const axiosSpy = vi
-		.spyOn(axios, 'post')
+	vi.spyOn(axios, 'post')
 		.mockReturnValue({ data: attachmentList })
 	const resolver = new AttachmentResolver(args)
-	expect(axiosSpy).toHaveBeenCalled()
 	return resolver
 }
 
@@ -54,6 +52,15 @@ describe('Image resolver', () => {
 		uid: 'user-uid',
 	}
 	const currentDirectory = '/parentDir'
+
+	it('does not request attachment metadata for a direct URL', async () => {
+		const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({ data: [] })
+		const resolver = new AttachmentResolver({ fileId })
+
+		await resolver.resolve('https://example.org/pic.jpg')
+
+		expect(axiosSpy).not.toHaveBeenCalled()
+	})
 
 	it('is a class with one constructor argument', () => {
 		const resolver = initAttachmentResolver({ fileId })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,15 @@ const config = createAppConfig(
 		},
 		config: {
 			base: process.env.BASE,
+			worker: {
+				rollupOptions: {
+					output: {
+						assetFileNames: 'js/[name]-[hash][extname]',
+						chunkFileNames: 'js/[name]-[hash].worker.chunk.mjs',
+						entryFileNames: 'js/[name]-[hash].worker.mjs',
+					},
+				},
+			},
 			resolve: {
 				dedupe: ['vue'],
 			},


### PR DESCRIPTION
Backport of the complete version-comparison stack to stable35: nextcloud/text#9047, #9048, #9049 and #9050 as one combined change, with their implementation unchanged.

This is the Text side of the Collectives page-version comparison feature: a semantic change model, the Changes view with a public factory, highlighted Full documents, and the literal Markdown source comparison with its worker. Feature context lives in https://github.com/nextcloud/collectives/issues/599.

Verification: 1,761 unit tests passed (single worker); 71 browser tests passed; production build and type check passed. Parallel test runs hit timeouts, so the suite was run with one worker. Lint passes with 205 jsdoc warnings that the repository configuration does not fail on.

AI disclosure: developed with OpenAI Codex (gpt-5.6-sol). Codex generated the implementation and tests under my direction; I reviewed, cleaned and verified the code, ran the verification above, and signed the commit personally (DCO).
