### PR TITLE
chore(renovate): don't open PRs for unstable releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
 	"rangeStrategy": "bump",
 	"minimumReleaseAge": "4 days",
 	"rebaseWhen": "conflicted",
-	"ignoreUnstable": false,
 	"baseBranchPatterns": ["main", "stable35", "stable34", "stable33", "stable32"],
 	"enabledManagers": ["npm"],
 	"ignoreDeps": ["node", "npm"],


### PR DESCRIPTION
Should stop renovate from opening PRs for playwright alpha/beta releases.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
